### PR TITLE
feat(streaming): add OpenAI-compatible live tool loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ project follows Semantic Versioning once releases begin.
 
 ## [Unreleased]
 
+### Added
+
+- OpenAI-compatible Chat Completions streaming path: provider responses now use
+  SSE when available, emitting assistant content deltas and reconstructing
+  streamed `tool_calls` into the same final `VesicleResponse` shape used by
+  non-streaming calls.
+- Agent-loop streaming events for assistant deltas and streamed tool-call
+  deltas.
+- TUI live assistant draft rendering while a provider response is in flight.
+
+### Fixed
+
+- TUI tool calls/results now render as compact transcript summaries instead of
+  dumping full tool arguments or full file contents into the main chat stream.
+- Streaming now rejects premature SSE EOF, reports malformed chunks with a
+  provider-stream error, retries without OpenAI-specific `stream_options` for
+  stricter compatible providers, and preserves the final assistant turn in the
+  in-memory conversation history.
+
 ## [0.1.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ return to an unresolved gate.
 ## Current Capabilities
 
 - OpenAI-compatible Chat Completions provider path
+- Streaming OpenAI-compatible Chat Completions responses when the provider
+  supports SSE, including streamed tool-call reconstruction
 - Engine profiles drive systemPrompt, tools, validators, and stop gates from
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,6 +12,7 @@ _Last updated: 2026-07-07_
 | TUI | OpenTUI + Solid | Responsive shell + gate/session panels |
 | Gate runtime | request_confirmation + needs_user loop | ETL blueprint + phase gates wired |
 | Validators | Module A + Module B v9 schemas | Implemented |
+| Streaming | OpenAI-compatible SSE | In progress on 0.2 branch |
 
 ## Current Scope
 
@@ -115,10 +116,9 @@ never abort a turn. Validators run only on artifact-shaped assistant content
 
 - Only OpenAI-compatible Chat Completions is implemented (Anthropic Messages,
   OpenAI Responses, Gemini are deferred).
-- Tool calls are non-streaming; assistant text is non-streaming.
-- The agent loop now emits coarse activity events for provider requests, tool
-  calls, gate pauses, and validation, but token-level provider streaming is
-  still deferred.
+- OpenAI-compatible SSE streaming is implemented on the 0.2 branch for
+  assistant content deltas and streamed tool-call reconstruction. Other
+  provider protocols are still deferred.
 - TUI engine switching is hardcoded to ETL (runtime/evaluate profiles exist
   and load, but the TUI does not yet offer a selector).
 - Gate UI is Select-style for ETL blueprint and phase checkpoints, with a

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -114,8 +114,9 @@ Prompts are runtime assets, not hardcoded source literals.
 - Session lists should mark unresolved gates so the user can distinguish a
   normal transcript from a workflow waiting for confirmation.
 - Long-running turns should emit host-visible activity events before and after
-  provider requests, tool calls, gate pauses, and validation. Token-level
-  streaming can build on this event path later.
+  provider requests, tool calls, gate pauses, and validation. Provider
+  streaming should emit assistant deltas as they arrive while still
+  reconstructing a final provider response for session replay.
 
 ## Validation Semantics
 

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "../../config/env";
 import { createProvider } from "../../providers";
-import type { VesicleMessage, VesicleResponse } from "../../providers/shared/types";
+import type { ProviderAdapter, VesicleMessage, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
 import { executeFileTool, fileToolDefinitions } from "../tools";
 import type { ToolCall, ToolDefinition } from "../tools";
 import { composeSystemPrompt, loadPromptBundle } from "../prompt/loader";
@@ -29,8 +29,10 @@ export type RunPromptOptions = {
 
 export type AgentLoopEvent =
   | { type: "provider_request"; iteration: number }
-  | { type: "assistant_response"; content: string; toolCallCount: number }
-  | { type: "tool_call"; name: string; callId: string }
+  | { type: "assistant_delta"; delta: string }
+  | { type: "tool_call_delta"; name?: string; argumentsDelta?: string }
+  | { type: "assistant_response"; content: string; toolCalls: Array<{ id: string; name: string; arguments: string }> }
+  | { type: "tool_call"; name: string; callId: string; arguments: string }
   | { type: "tool_result"; name: string; callId: string; ok: boolean; content: string }
   | { type: "gate_pending"; gate: string }
   | { type: "validation"; ok: boolean };
@@ -187,7 +189,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
 
   for (let iteration = 0; iteration < maxToolIterations; iteration++) {
     onEvent?.({ type: "provider_request", iteration });
-    response = await provider.complete({
+    response = await completeWithStreaming(provider, {
       id: session.sessionId,
       model: {
         provider: config.provider,
@@ -196,10 +198,14 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
       system: [systemPrompt],
       messages,
       tools,
-    });
+    }, onEvent);
 
     const toolCalls = response.toolCalls ?? [];
-    onEvent?.({ type: "assistant_response", content: response.content, toolCallCount: toolCalls.length });
+    onEvent?.({
+      type: "assistant_response",
+      content: response.content,
+      toolCalls: toolCalls.map((call) => ({ id: call.id, name: call.name, arguments: call.arguments })),
+    });
     if (toolCalls.length === 0) {
       break;
     }
@@ -240,7 +246,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
     let anyFailed = false;
 
     for (const call of fileCalls) {
-      onEvent?.({ type: "tool_call", name: call.name, callId: call.id });
+      onEvent?.({ type: "tool_call", name: call.name, callId: call.id, arguments: call.arguments });
       const toolResult = await executeFileTool(rootDir, call);
       const content = JSON.stringify({
         ok: toolResult.ok,
@@ -342,14 +348,18 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
     throw new Error("Provider did not return a response.");
   }
 
-  await session.append({
-    role: "assistant",
-    content: response.content,
-    metadata: {
-      providerResponseId: response.id,
-      usage: response.usage,
-    },
-  });
+  const finalResponseHasToolCalls = (response.toolCalls?.length ?? 0) > 0;
+  if (!finalResponseHasToolCalls) {
+    messages.push({ role: "assistant", content: response.content });
+    await session.append({
+      role: "assistant",
+      content: response.content,
+      metadata: {
+        providerResponseId: response.id,
+        usage: response.usage,
+      },
+    });
+  }
 
   // Run declared validators on the final assistant content. Validators are
   // advisory — failures surface to the TUI and session but never abort the
@@ -380,6 +390,40 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
      */
     messages,
   };
+}
+
+async function completeWithStreaming(
+  provider: ProviderAdapter,
+  request: VesicleRequest,
+  onEvent?: (event: AgentLoopEvent) => void,
+): Promise<VesicleResponse> {
+  if (!provider.stream) {
+    return provider.complete(request);
+  }
+
+  let response: VesicleResponse | undefined;
+  for await (const event of provider.stream(request)) {
+    switch (event.type) {
+      case "content_delta":
+        onEvent?.({ type: "assistant_delta", delta: event.delta });
+        break;
+      case "tool_call_delta":
+        onEvent?.({
+          type: "tool_call_delta",
+          name: event.name,
+          argumentsDelta: event.argumentsDelta,
+        });
+        break;
+      case "complete":
+        response = event.response;
+        break;
+    }
+  }
+
+  if (!response) {
+    throw new Error("Provider stream ended without a final response.");
+  }
+  return response;
 }
 
 function shouldValidateAssistantContent(content: string): boolean {

--- a/src/providers/openai-chat/adapter.ts
+++ b/src/providers/openai-chat/adapter.ts
@@ -1,5 +1,5 @@
 import type { VesicleConfig } from "../../config/env";
-import type { ProviderAdapter, VesicleRequest, VesicleResponse } from "../shared/types";
+import type { ProviderAdapter, ProviderStreamEvent, VesicleRequest, VesicleResponse } from "../shared/types";
 
 type ChatCompletionChoice = {
   finish_reason?: string | null;
@@ -29,6 +29,33 @@ type ChatCompletionResponse = {
   };
 };
 
+type ChatCompletionStreamChunk = {
+  id?: string;
+  choices?: Array<{
+    finish_reason?: string | null;
+    delta?: {
+      content?: string | null;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: {
+    message?: string;
+  };
+};
+
 export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
   readonly id = "openai-chat-compatible";
 
@@ -45,46 +72,7 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
         "Authorization": `Bearer ${this.config.apiKey}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        model: request.model.model,
-        messages: [
-          ...request.system.map((content) => ({ role: "system", content })),
-          ...request.messages.map((message) => {
-            if (message.role === "tool") {
-              return {
-                role: "tool",
-                tool_call_id: message.toolCallId,
-                content: message.content,
-              };
-            }
-
-            if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
-              return {
-                role: "assistant",
-                content: message.content || null,
-                tool_calls: message.toolCalls.map((call) => ({
-                  id: call.id,
-                  type: "function",
-                  function: {
-                    name: call.name,
-                    arguments: call.arguments,
-                  },
-                })),
-              };
-            }
-
-            return {
-              role: message.role,
-              content: message.content,
-            };
-          }),
-        ],
-        tools: request.tools && request.tools.length > 0 ? request.tools : undefined,
-        tool_choice: request.tools && request.tools.length > 0 ? "auto" : undefined,
-        temperature: request.generation?.temperature ?? 0.7,
-        max_tokens: request.generation?.maxTokens,
-        stream: false,
-      }),
+      body: JSON.stringify(toChatCompletionBody(request, false)),
     });
 
     const body = await response.json().catch(() => undefined) as ChatCompletionResponse | undefined;
@@ -93,29 +81,272 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
       throw new Error(`Provider request failed (${response.status}): ${providerMessage}`);
     }
 
-    const choice = body?.choices?.[0];
-    const content = choice?.message?.content ?? "";
-    const toolCalls = choice?.message?.tool_calls?.map((toolCall) => ({
-      id: toolCall.id,
-      name: toolCall.function.name,
-      arguments: toolCall.function.arguments,
-    }));
+    return responseFromChatCompletionBody(body, request.id);
+  }
 
-    if (!content && (!toolCalls || toolCalls.length === 0)) {
-      throw new Error("Provider response did not include assistant content or tool calls.");
+  async *stream(request: VesicleRequest): AsyncIterable<ProviderStreamEvent> {
+    if (!this.config.apiKey) {
+      throw new Error("VESICLE_API_KEY is required before making a provider request.");
     }
 
-    return {
-      id: body?.id ?? request.id,
-      content,
-      toolCalls,
-      finishReason: choice?.finish_reason ?? undefined,
-      raw: body,
-      usage: {
-        inputTokens: body?.usage?.prompt_tokens,
-        outputTokens: body?.usage?.completion_tokens,
-        totalTokens: body?.usage?.total_tokens,
+    const response = await this.fetchChatCompletion(request, true, true);
+    const retryWithoutStreamOptions = !response.ok && isRetryableStreamRequestFailure(response.status);
+    const streamResponse = retryWithoutStreamOptions
+      ? await this.fetchChatCompletion(request, true, false)
+      : response;
+
+    if (!streamResponse.ok && isRetryableStreamRequestFailure(streamResponse.status)) {
+      yield { type: "complete", response: await this.complete(request) };
+      return;
+    }
+
+    if (!streamResponse.ok) {
+      const providerMessage = await readProviderErrorMessage(streamResponse);
+      throw new Error(`Provider request failed (${streamResponse.status}): ${providerMessage}`);
+    }
+    if (!streamResponse.body) {
+      throw new Error("Provider streaming response did not include a body.");
+    }
+    if (streamResponse.headers.get("content-type")?.includes("application/json")) {
+      const body = await streamResponse.json().catch(() => undefined) as ChatCompletionResponse | undefined;
+      yield { type: "complete", response: responseFromChatCompletionBody(body, request.id) };
+      return;
+    }
+
+    const state = createStreamAccumulator(request.id);
+    let sawDone = false;
+    for await (const payload of readSseData(streamResponse.body)) {
+      if (payload === "[DONE]") {
+        sawDone = true;
+        break;
+      }
+      const chunk = parseStreamChunk(payload);
+      if (chunk.error?.message) {
+        throw new Error(`Provider stream failed: ${chunk.error.message}`);
+      }
+      for (const event of absorbStreamChunk(state, chunk)) {
+        yield event;
+      }
+    }
+    if (!sawDone) {
+      throw new Error("Provider stream ended before [DONE].");
+    }
+
+    const final = finalizeStream(state);
+    yield { type: "complete", response: final };
+  }
+
+  private fetchChatCompletion(request: VesicleRequest, stream: boolean, includeUsage: boolean): Promise<Response> {
+    return fetch(`${this.config.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${this.config.apiKey}`,
+        "Content-Type": "application/json",
       },
+      body: JSON.stringify(toChatCompletionBody(request, stream, includeUsage)),
+    });
+  }
+}
+
+function responseFromChatCompletionBody(body: ChatCompletionResponse | undefined, fallbackId: string): VesicleResponse {
+  const choice = body?.choices?.[0];
+  const content = choice?.message?.content ?? "";
+  const toolCalls = choice?.message?.tool_calls?.map((toolCall) => ({
+    id: toolCall.id,
+    name: toolCall.function.name,
+    arguments: toolCall.function.arguments,
+  }));
+
+  if (!content && (!toolCalls || toolCalls.length === 0)) {
+    throw new Error("Provider response did not include assistant content or tool calls.");
+  }
+
+  return {
+    id: body?.id ?? fallbackId,
+    content,
+    toolCalls,
+    finishReason: choice?.finish_reason ?? undefined,
+    raw: body,
+    usage: {
+      inputTokens: body?.usage?.prompt_tokens,
+      outputTokens: body?.usage?.completion_tokens,
+      totalTokens: body?.usage?.total_tokens,
+    },
+  };
+}
+
+async function readProviderErrorMessage(response: Response): Promise<string> {
+  const body = await response.json().catch(() => undefined) as ChatCompletionResponse | undefined;
+  return body?.error?.message ?? response.statusText;
+}
+
+function isRetryableStreamRequestFailure(status: number): boolean {
+  return status === 400 || status === 404 || status === 422;
+}
+
+function toChatCompletionBody(request: VesicleRequest, stream: boolean, includeUsage = false): Record<string, unknown> {
+  return {
+    model: request.model.model,
+    messages: [
+      ...request.system.map((content) => ({ role: "system", content })),
+      ...request.messages.map((message) => {
+        if (message.role === "tool") {
+          return {
+            role: "tool",
+            tool_call_id: message.toolCallId,
+            content: message.content,
+          };
+        }
+
+        if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
+          return {
+            role: "assistant",
+            content: message.content || null,
+            tool_calls: message.toolCalls.map((call) => ({
+              id: call.id,
+              type: "function",
+              function: {
+                name: call.name,
+                arguments: call.arguments,
+              },
+            })),
+          };
+        }
+
+        return {
+          role: message.role,
+          content: message.content,
+        };
+      }),
+    ],
+    tools: request.tools && request.tools.length > 0 ? request.tools : undefined,
+    tool_choice: request.tools && request.tools.length > 0 ? "auto" : undefined,
+    temperature: request.generation?.temperature ?? 0.7,
+    max_tokens: request.generation?.maxTokens,
+    stream,
+    stream_options: stream && includeUsage ? { include_usage: true } : undefined,
+  };
+}
+
+type StreamAccumulator = {
+  id: string;
+  content: string;
+  finishReason?: string;
+  toolCalls: Map<number, { index: number; id?: string; name?: string; arguments: string }>;
+  usage?: VesicleResponse["usage"];
+};
+
+function createStreamAccumulator(fallbackId: string): StreamAccumulator {
+  return {
+    id: fallbackId,
+    content: "",
+    toolCalls: new Map(),
+  };
+}
+
+function absorbStreamChunk(state: StreamAccumulator, chunk: ChatCompletionStreamChunk): ProviderStreamEvent[] {
+  const events: ProviderStreamEvent[] = [];
+  if (chunk.id) state.id = chunk.id;
+  if (chunk.usage) {
+    state.usage = {
+      inputTokens: chunk.usage.prompt_tokens,
+      outputTokens: chunk.usage.completion_tokens,
+      totalTokens: chunk.usage.total_tokens,
     };
   }
+
+  const choice = chunk.choices?.[0];
+  if (!choice) return events;
+  if (choice.finish_reason) state.finishReason = choice.finish_reason;
+
+  const contentDelta = choice.delta?.content ?? "";
+  if (contentDelta) {
+    state.content += contentDelta;
+    events.push({ type: "content_delta", delta: contentDelta });
+  }
+
+  for (const delta of choice.delta?.tool_calls ?? []) {
+    const current = state.toolCalls.get(delta.index) ?? { index: delta.index, arguments: "" };
+    if (delta.id) current.id = delta.id;
+    if (delta.function?.name) current.name = `${current.name ?? ""}${delta.function.name}`;
+    if (delta.function?.arguments) current.arguments += delta.function.arguments;
+    state.toolCalls.set(delta.index, current);
+    events.push({
+      type: "tool_call_delta",
+      index: delta.index,
+      id: delta.id,
+      name: delta.function?.name,
+      argumentsDelta: delta.function?.arguments,
+    });
+  }
+
+  return events;
+}
+
+function finalizeStream(state: StreamAccumulator): VesicleResponse {
+  const toolCalls = [...state.toolCalls.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, call]) => ({
+      id: call.id ?? `call_${call.index}`,
+      name: call.name ?? "",
+      arguments: call.arguments,
+    }))
+    .filter((call) => call.name);
+
+  if (!state.content && toolCalls.length === 0) {
+    throw new Error("Provider response did not include assistant content or tool calls.");
+  }
+
+  return {
+    id: state.id,
+    content: state.content,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    finishReason: state.finishReason,
+    usage: state.usage,
+  };
+}
+
+async function* readSseData(body: ReadableStream<Uint8Array>): AsyncIterable<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split(/\r?\n\r?\n/);
+      buffer = parts.pop() ?? "";
+      for (const part of parts) {
+        const data = parseSseDataBlock(part);
+        if (data) yield data;
+      }
+    }
+
+    buffer += decoder.decode();
+    const trailing = parseSseDataBlock(buffer);
+    if (trailing) yield trailing;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseStreamChunk(payload: string): ChatCompletionStreamChunk {
+  try {
+    return JSON.parse(payload) as ChatCompletionStreamChunk;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Provider stream delivered unparseable data: ${detail}`);
+  }
+}
+
+function parseSseDataBlock(block: string): string | undefined {
+  const lines = block.split(/\r?\n/);
+  const dataLines = lines
+    .map((line) => line.trimEnd())
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart());
+  if (dataLines.length === 0) return undefined;
+  return dataLines.join("\n");
 }

--- a/src/providers/shared/types.ts
+++ b/src/providers/shared/types.ts
@@ -38,7 +38,13 @@ export type VesicleResponse = {
   };
 };
 
+export type ProviderStreamEvent =
+  | { type: "content_delta"; delta: string }
+  | { type: "tool_call_delta"; index: number; id?: string; name?: string; argumentsDelta?: string }
+  | { type: "complete"; response: VesicleResponse };
+
 export interface ProviderAdapter {
   id: string;
   complete(request: VesicleRequest): Promise<VesicleResponse>;
+  stream?(request: VesicleRequest): AsyncIterable<ProviderStreamEvent>;
 }

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -16,6 +16,12 @@ import { listSessions, loadSessionSnapshot } from "../core/session/store";
 import type { SessionSummary } from "../core/session/store";
 import { resolveTuiLayout } from "./layout";
 import { SessionPicker } from "./SessionPicker";
+import {
+  renderAssistantToolTurn,
+  renderResumedToolResultSummary,
+  renderToolCallSummary,
+  renderToolResultSummary,
+} from "./tool-summary";
 
 type Role = "user" | "assistant" | "system" | "tool";
 
@@ -68,6 +74,8 @@ export function App() {
   const [activity, setActivity] = createSignal<ActivityEntry[]>([
     { kind: "system", text: "Activity will show provider requests, tool calls, gates, and validation." },
   ]);
+  const [streamingAssistant, setStreamingAssistant] = createSignal("");
+  const [lastDisplayedToolAssistantContent, setLastDisplayedToolAssistantContent] = createSignal<string | null>(null);
   const [promptHistory, setPromptHistory] = createSignal<string[]>([]);
   const [historyIndex, setHistoryIndex] = createSignal<number | null>(null);
 
@@ -235,6 +243,7 @@ export function App() {
     setPromptHistory((prev) => [...prev.filter((entry) => entry !== prompt), prompt].slice(-50));
     setHistoryIndex(null);
     setSessionPicker(null);
+    setLastDisplayedToolAssistantContent(null);
     setBusy(true);
     setStatus("sending request");
     recordActivity({ kind: "provider", text: "sending provider request" });
@@ -309,9 +318,10 @@ export function App() {
       setGateFeedbackMode(null);
       setGateFeedback("");
       setOutput(result.assistantContent);
+      const alreadyDisplayed = lastDisplayedToolAssistantContent() === result.assistantContent;
       setMessages((prev) => [
         ...prev,
-        { role: "assistant", content: result.assistantContent },
+        ...(alreadyDisplayed ? [] : [{ role: "assistant" as const, content: result.assistantContent }]),
         { role: "system", content: `Stop gate pending: ${result.gate.gate}. Use ↑/↓ + Enter, or type into the amend box (Tab).` },
       ]);
       setStatus(`gate pending: ${result.gate.gate}`);
@@ -321,6 +331,7 @@ export function App() {
     setPendingGate(null);
     setGateFeedbackMode(null);
     setGateFeedback("");
+    setLastDisplayedToolAssistantContent(null);
 
     const profileValidation = result.validation;
     const ok = profileValidation ? profileValidation.ok : true;
@@ -335,7 +346,10 @@ export function App() {
     setOutput(result.response.content);
     void refreshArtifacts();
 
-    const appended: Message[] = [{ role: "assistant", content: result.response.content }];
+    const appended: Message[] = [];
+    if (!result.response.toolCalls?.length && result.response.content.trim()) {
+      appended.push({ role: "assistant", content: result.response.content });
+    }
     if (profileValidation) {
       appended.push({ role: "system", content: renderValidationNotice(profileValidation) });
     }
@@ -347,6 +361,7 @@ export function App() {
     const message = error instanceof Error ? error.message : String(error);
     setStatus("error");
     setOutput(message);
+    setStreamingAssistant("");
     recordActivity({ kind: "system", text: `error: ${message}` });
     setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${message}` }]);
   }
@@ -354,20 +369,37 @@ export function App() {
   function handleAgentEvent(event: AgentLoopEvent) {
     switch (event.type) {
       case "provider_request":
+        setStreamingAssistant("");
         recordActivity({ kind: "provider", text: `provider request #${event.iteration + 1}` });
         return;
+      case "assistant_delta":
+        setStreamingAssistant((prev) => `${prev}${event.delta}`);
+        return;
+      case "tool_call_delta":
+        if (event.name) {
+          recordActivity({ kind: "tool", text: `tool call forming: ${event.name}` });
+        }
+        return;
       case "assistant_response":
+        setStreamingAssistant("");
+        if (event.toolCalls.length > 0) {
+          const content = renderAssistantToolTurn(event.content, event.toolCalls);
+          setMessages((prev) => [...prev, { role: "assistant", content }]);
+          setLastDisplayedToolAssistantContent(event.content);
+        }
         recordActivity({
           kind: "assistant",
-          text: event.toolCallCount > 0
-            ? `assistant response with ${event.toolCallCount} tool call${event.toolCallCount > 1 ? "s" : ""}`
+          text: event.toolCalls.length > 0
+            ? `assistant response with ${event.toolCalls.length} tool call${event.toolCalls.length > 1 ? "s" : ""}`
             : "assistant response complete",
         });
         return;
       case "tool_call":
+        setMessages((prev) => [...prev, { role: "tool", content: renderToolCallSummary(event.name, event.arguments) }]);
         recordActivity({ kind: "tool", text: `calling ${event.name}` });
         return;
       case "tool_result":
+        setMessages((prev) => [...prev, { role: "tool", content: renderToolResultSummary(event.name, event.ok, event.content) }]);
         recordActivity({ kind: "tool", text: `${event.ok ? "ok" : "failed"} ${event.name}: ${event.content}` });
         return;
       case "gate_pending":
@@ -527,18 +559,20 @@ export function App() {
     // visually distinct from rendered model output.
     if (message.role === "assistant" && message.content.trim()) {
       return (
-        <box flexDirection="column" border borderColor={palette.assistant} paddingX={1}>
-          <text content="assistant" fg={palette.assistant} attributes={1} />
+        <box flexDirection="column">
+          <text content="━━━━━━━━ assistant" fg={palette.assistant} attributes={1} />
           <markdown content={message.content} syntaxStyle={sharedSyntaxStyle} conceal={true} />
+          <text content=" " fg={palette.textDim} />
         </box>
       );
     }
 
     if (message.role === "user") {
       return (
-        <box flexDirection="column" border borderColor={palette.user} paddingX={1}>
-          <text content="you" fg={palette.user} attributes={1} />
+        <box flexDirection="column">
+          <text content="━━━━━━━━ you" fg={palette.user} attributes={1} />
           <text content={message.content} fg={palette.textPrimary} />
+          <text content=" " fg={palette.textDim} />
         </box>
       );
     }
@@ -587,6 +621,12 @@ export function App() {
           <scrollbox width="100%" height="100%" stickyScroll stickyStart="bottom">
             <box flexDirection="column">
               {messages().map((message) => renderMessage(message))}
+              <Show when={streamingAssistant().trim().length > 0} fallback={<box height={0} />}>
+                <box flexDirection="column">
+                  <text content="━━━━━━━━ assistant streaming" fg={palette.assistant} attributes={1} />
+                  <markdown content={streamingAssistant()} syntaxStyle={sharedSyntaxStyle} conceal={true} />
+                </box>
+              </Show>
             </box>
           </scrollbox>
         </box>
@@ -697,7 +737,16 @@ function activityColor(kind: ActivityEntry["kind"]): string {
 }
 
 function displayMessageFromResumed(message: VesicleMessage): Message {
-  if (message.role === "user" || message.role === "assistant" || message.role === "tool") {
+  if (message.role === "assistant") {
+    const content = message.toolCalls && message.toolCalls.length > 0
+      ? renderAssistantToolTurn(message.content, message.toolCalls)
+      : message.content;
+    return { role: "assistant", content };
+  }
+  if (message.role === "tool") {
+    return { role: "tool", content: renderResumedToolResultSummary(message.content) };
+  }
+  if (message.role === "user") {
     return { role: message.role, content: message.content };
   }
   return { role: "system", content: message.content };

--- a/src/tui/tool-summary.ts
+++ b/src/tui/tool-summary.ts
@@ -1,0 +1,71 @@
+export type ToolCallSummary = {
+  name: string;
+  arguments?: string;
+};
+
+export function renderAssistantToolTurn(content: string, toolCalls: ToolCallSummary[]): string {
+  const lines: string[] = [];
+  if (content.trim()) lines.push(content.trim());
+  if (toolCalls.length > 0) {
+    lines.push("");
+    lines.push("Tool calls:");
+    for (const call of toolCalls) lines.push(`- ${toolCallLabel(call.name, call.arguments)}`);
+  }
+  return lines.join("\n");
+}
+
+export function renderToolCallSummary(name: string, argumentsJson: string): string {
+  return `-> ${toolCallLabel(name, argumentsJson)}`;
+}
+
+export function renderToolResultSummary(name: string, ok: boolean, content: string): string {
+  return `${ok ? "ok" : "failed"} ${name}: ${summarizeToolContent(content)}`;
+}
+
+export function renderResumedToolResultSummary(content: string): string {
+  const parsed = parseJsonObject(content);
+  const ok = typeof parsed?.ok === "boolean" ? parsed.ok : undefined;
+  const result = typeof parsed?.result === "string" ? parsed.result : content;
+  const status = ok === undefined ? "tool result" : ok ? "ok tool" : "failed tool";
+  return `${status}: ${summarizeToolContent(result)}`;
+}
+
+function toolCallLabel(name: string, argumentsJson?: string): string {
+  const parsed = parseJsonObject(argumentsJson);
+  const parts = [name];
+  if (typeof parsed?.path === "string" && parsed.path.length > 0) {
+    parts.push(parsed.path);
+  } else if (typeof parsed?.gate === "string" && parsed.gate.length > 0) {
+    parts.push(`gate=${parsed.gate}`);
+  }
+  if (typeof parsed?.recursive === "boolean" && parsed.recursive) {
+    parts.push("(recursive)");
+  }
+  if (typeof parsed?.content === "string") {
+    parts.push(`(${parsed.content.length} chars)`);
+  }
+  return parts.join(" ");
+}
+
+function summarizeToolContent(content: string): string {
+  const singleLine = content.replace(/\s+/g, " ").trim();
+  if (!singleLine) return "(empty)";
+  return truncateLine(singleLine, 120);
+}
+
+function parseJsonObject(value: string | undefined): Record<string, unknown> | null {
+  if (!value) return null;
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function truncateLine(value: string, width: number): string {
+  const limit = Math.max(8, width);
+  if (value.length <= limit) return value;
+  return `${value.slice(0, limit - 3)}...`;
+}

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -47,10 +47,11 @@ describe("agent loop sessions", () => {
     });
     if (first.kind !== "complete") throw new Error("expected complete");
     const firstReply = first.response.content;
+    expect(first.messages.map((message) => message.role)).toEqual(["user", "assistant"]);
+    expect(first.messages.at(-1)?.content).toBe(firstReply);
 
     const secondMessages = [
-      ...firstMessages,
-      { role: "assistant" as const, content: firstReply },
+      ...first.messages,
       { role: "user" as const, content: "second" },
     ];
     const second = await runPrompt({

--- a/tests/provider-stream.test.ts
+++ b/tests/provider-stream.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { OpenAIChatCompatibleAdapter } from "../src/providers/openai-chat/adapter";
+import type { ProviderStreamEvent, VesicleRequest } from "../src/providers/shared/types";
+
+const originalFetch = globalThis.fetch;
+
+describe("OpenAI-compatible streaming adapter", () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("streams assistant content deltas and returns a final response", async () => {
+    const bodies: unknown[] = [];
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return new Response(sse([
+        { id: "chatcmpl-stream", choices: [{ delta: { content: "hel" } }] },
+        { id: "chatcmpl-stream", choices: [{ delta: { content: "lo" }, finish_reason: "stop" }] },
+      ]));
+    }) as unknown as typeof fetch;
+
+    const events = await collect(streamAdapter().stream!(request()));
+
+    expect((bodies[0] as { stream: boolean }).stream).toBe(true);
+    expect(events).toContainEqual({ type: "content_delta", delta: "hel" });
+    expect(events).toContainEqual({ type: "content_delta", delta: "lo" });
+    expect(events.at(-1)).toEqual({
+      type: "complete",
+      response: {
+        id: "chatcmpl-stream",
+        content: "hello",
+        finishReason: "stop",
+        toolCalls: undefined,
+        usage: undefined,
+      },
+    });
+  });
+
+  test("streams and reconstructs tool call argument deltas", async () => {
+    globalThis.fetch = (async () => new Response(sse([
+      {
+        id: "chatcmpl-tools",
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              id: "call-write",
+              type: "function",
+              function: { name: "write_file", arguments: "{\"path\":\"workspace/a.md\"," },
+            }],
+          },
+        }],
+      },
+      {
+        id: "chatcmpl-tools",
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 0,
+              function: { arguments: "\"content\":\"hi\"}" },
+            }],
+          },
+          finish_reason: "tool_calls",
+        }],
+      },
+    ]))) as unknown as typeof fetch;
+
+    const events = await collect(streamAdapter().stream!(request()));
+    const final = events.at(-1);
+
+    expect(events.some((event) => event.type === "tool_call_delta" && event.name === "write_file")).toBe(true);
+    expect(final).toEqual({
+      type: "complete",
+      response: {
+        id: "chatcmpl-tools",
+        content: "",
+        finishReason: "tool_calls",
+        toolCalls: [{
+          id: "call-write",
+          name: "write_file",
+          arguments: "{\"path\":\"workspace/a.md\",\"content\":\"hi\"}",
+        }],
+        usage: undefined,
+      },
+    });
+  });
+
+  test("rejects a stream that ends before the [DONE] marker", async () => {
+    globalThis.fetch = (async () => new Response(sse([
+      { id: "chatcmpl-cut", choices: [{ delta: { content: "partial" } }] },
+    ], { done: false }))) as unknown as typeof fetch;
+
+    await expect(collect(streamAdapter().stream!(request()))).rejects.toThrow("Provider stream ended before [DONE].");
+  });
+
+  test("reports malformed SSE payloads with a provider-stream error", async () => {
+    globalThis.fetch = (async () => new Response(rawSse([
+      "data: {not-json}\n\n",
+      "data: [DONE]\n\n",
+    ]))) as unknown as typeof fetch;
+
+    await expect(collect(streamAdapter().stream!(request()))).rejects.toThrow("Provider stream delivered unparseable data");
+  });
+
+  test("retries streaming without stream_options when an OpenAI-compatible provider rejects them", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      bodies.push(body);
+      if (bodies.length === 1) {
+        return Response.json({ error: { message: "unknown field: stream_options" } }, { status: 400 });
+      }
+      return new Response(sse([
+        { id: "chatcmpl-retry", choices: [{ delta: { content: "ok" }, finish_reason: "stop" }] },
+      ]));
+    }) as unknown as typeof fetch;
+
+    const events = await collect(streamAdapter().stream!(request()));
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0].stream_options).toEqual({ include_usage: true });
+    expect(bodies[1].stream_options).toBeUndefined();
+    expect(events.at(-1)).toMatchObject({
+      type: "complete",
+      response: { id: "chatcmpl-retry", content: "ok", finishReason: "stop" },
+    });
+  });
+
+  test("uses the provider delta index for fallback streamed tool-call ids", async () => {
+    globalThis.fetch = (async () => new Response(sse([
+      {
+        id: "chatcmpl-indexed",
+        choices: [{
+          delta: {
+            tool_calls: [{
+              index: 3,
+              type: "function",
+              function: { name: "read_file", arguments: "{\"path\":\"workspace/a.md\"}" },
+            }],
+          },
+          finish_reason: "tool_calls",
+        }],
+      },
+    ]))) as unknown as typeof fetch;
+
+    const events = await collect(streamAdapter().stream!(request()));
+
+    expect(events.at(-1)).toMatchObject({
+      type: "complete",
+      response: {
+        toolCalls: [{ id: "call_3", name: "read_file", arguments: "{\"path\":\"workspace/a.md\"}" }],
+      },
+    });
+  });
+});
+
+function streamAdapter() {
+  return new OpenAIChatCompatibleAdapter({
+    provider: "openai-chat-compatible",
+    baseUrl: "https://provider.test/v1",
+    model: "test-model",
+    apiKey: "test-key",
+  });
+}
+
+function request(): VesicleRequest {
+  return {
+    id: "session-test",
+    model: { provider: "openai-chat-compatible", model: "test-model" },
+    system: ["system"],
+    messages: [{ role: "user", content: "hello" }],
+  };
+}
+
+async function collect(events: AsyncIterable<ProviderStreamEvent>): Promise<ProviderStreamEvent[]> {
+  const result: ProviderStreamEvent[] = [];
+  for await (const event of events) result.push(event);
+  return result;
+}
+
+function sse(chunks: unknown[], options: { done?: boolean } = {}): ReadableStream<Uint8Array> {
+  const lines = chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`);
+  if (options.done !== false) lines.push("data: [DONE]\n\n");
+  return rawSse(lines);
+}
+
+function rawSse(lines: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) controller.enqueue(encoder.encode(line));
+      controller.close();
+    },
+  });
+}

--- a/tests/tui-tool-summary.test.ts
+++ b/tests/tui-tool-summary.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import {
+  renderAssistantToolTurn,
+  renderResumedToolResultSummary,
+  renderToolCallSummary,
+  renderToolResultSummary,
+} from "../src/tui/tool-summary";
+
+describe("TUI tool summaries", () => {
+  test("summarizes tool-call arguments without rendering full input", () => {
+    const longContent = "secret draft ".repeat(40);
+    const argumentsJson = JSON.stringify({
+      path: "workspace/阿橘.md",
+      content: longContent,
+    });
+
+    const summary = renderToolCallSummary("write_file", argumentsJson);
+    const assistantTurn = renderAssistantToolTurn("writing file", [
+      { name: "write_file", arguments: argumentsJson },
+    ]);
+
+    expect(summary).toContain("write_file workspace/阿橘.md");
+    expect(summary).toContain(`(${longContent.length} chars)`);
+    expect(summary).not.toContain(longContent);
+    expect(assistantTurn).not.toContain(longContent);
+  });
+
+  test("summarizes live and resumed tool results without dumping full output", () => {
+    const longResult = "line one\n" + "very long file content ".repeat(40);
+    const live = renderToolResultSummary("read_file", true, longResult);
+    const resumed = renderResumedToolResultSummary(JSON.stringify({ ok: true, result: longResult }));
+
+    expect(live).toContain("ok read_file:");
+    expect(resumed).toContain("ok tool:");
+    expect(live.length).toBeLessThan(150);
+    expect(resumed.length).toBeLessThan(150);
+    expect(live).not.toContain(longResult);
+    expect(resumed).not.toContain(longResult);
+  });
+});


### PR DESCRIPTION
## Summary

- Add OpenAI-compatible SSE streaming support and live assistant draft rendering in the TUI.
- Stream and reconstruct tool-call deltas while preserving the final provider response shape for session replay.
- Render tool calls and tool results inline in the transcript as compact summaries, including resumed sessions, without dumping full tool payloads into the main chat.

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run doctor`

## Notes

- Base branch: `develop`
- This is the proposed 0.2.0 streaming/tool-loop feature branch.