### PR TITLE
feat: add provider registry and artifact workbench

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 VESICLE_PROVIDER=openai-chat-compatible
+VESICLE_PROVIDER_ID=default
 VESICLE_BASE_URL=https://api.openai.com/v1
 VESICLE_MODEL=gpt-4.1-mini
 VESICLE_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ project follows Semantic Versioning once releases begin.
 
 ### Added
 
+- Provider/model registry: `.vesicle/providers.yaml` can declare multiple
+  OpenAI-compatible providers and models, with TUI commands for `/providers`,
+  `/models`, `/use`, and `/model`.
+- Artifact workbench commands for `/artifacts`, `/artifact`, `/validate`, and
+  `/revise`, including validation against the selected artifact file on disk.
 - OpenAI-compatible Chat Completions streaming path: provider responses now use
   SSE when available, emitting assistant content deltas and reconstructing
   streamed `tool_calls` into the same final `VesicleResponse` shape used by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ project follows Semantic Versioning once releases begin.
 
 ### Added
 
-- Provider/model registry: `.vesicle/providers.yaml` can declare multiple
+- Provider/model registry: a user-level `providers.yaml` can declare multiple
   OpenAI-compatible providers and models, with TUI commands for `/providers`,
   `/models`, `/use`, and `/model`.
 - Artifact workbench commands for `/artifacts`, `/artifact`, `/validate`, and

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ For multiple OpenAI-compatible providers, copy
 `docs/examples/providers.yaml` to `.vesicle/providers.yaml` and set each
 provider's `apiKeyEnv` environment variable. The TUI can then switch with
 `/providers`, `/models`, `/use <provider> <model>`, and `/model <model>`.
+The provider file intentionally supports only Vesicle's small YAML subset:
+`default`, `providers`, scalar provider fields, and `models` string lists.
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Set:
 - `VESICLE_MODEL`
 - `VESICLE_API_KEY`
 
+For multiple OpenAI-compatible providers, copy
+`docs/examples/providers.yaml` to `.vesicle/providers.yaml` and set each
+provider's `apiKeyEnv` environment variable. The TUI can then switch with
+`/providers`, `/models`, `/use <provider> <model>`, and `/model <model>`.
+
 Then run:
 
 ```powershell
@@ -49,6 +54,8 @@ return to an unresolved gate.
 - OpenAI-compatible Chat Completions provider path
 - Streaming OpenAI-compatible Chat Completions responses when the provider
   supports SSE, including streamed tool-call reconstruction
+- Provider/model registry from `.vesicle/providers.yaml`, with TUI commands to
+  switch provider and model inside a session
 - Engine profiles drive systemPrompt, tools, validators, and stop gates from
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker
@@ -63,6 +70,8 @@ return to an unresolved gate.
   sidebar at medium widths, and activity/artifact pane at wide widths
 - Activity pane for provider requests, assistant responses, tool calls, gate
   events, validation, and recent artifacts
+- Artifact workbench commands: `/artifacts`, `/artifact`, `/validate`, and
+  `/revise` list, preview, validate, and revise generated files
 - Markdown rendering in the TUI for assistant messages
 - Select-style gate UI (Confirm / Revise / Chat with Tab amend), rendered as a
   dedicated confirmation panel
@@ -85,8 +94,8 @@ Prism v9 prompt/spec/template assets are copied under `assets/`. See `assets/REA
 
 ## Scope
 
-0.1.0 focuses on making Vesicle a credible Prism Engine host: profile-driven
-prompt/tool/gate composition, a real Stop & Wait gate runtime, v9 schema
-validators, Markdown-rendered TUI, and session resume. Multi-provider support,
-MCP, Skills, streaming, long-form engines, and prompt-cache engineering are
-deferred to later milestones — see `STATUS.md` for the full known-limits list.
+0.3.0 development focuses on making Vesicle usable across multiple
+OpenAI-compatible provider profiles and on treating generated artifact files as
+first-class workflow objects. Native Anthropic, Gemini, OpenAI Responses, MCP,
+Skills, long-form engines, and prompt-cache engineering are deferred to later
+milestones — see `STATUS.md` for the full known-limits list.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ provider's `apiKeyEnv` environment variable. The TUI can then switch with
 `/providers`, `/models`, `/use <provider> <model>`, and `/model <model>`.
 The provider file intentionally supports only Vesicle's small YAML subset:
 `default`, `providers`, scalar provider fields, and `models` string lists.
+Provider secrets are not read from this file; every provider must name an
+`apiKeyEnv` variable and the actual key belongs in `.env` or the process
+environment.
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Set:
 - `VESICLE_API_KEY`
 
 For multiple OpenAI-compatible providers, copy
-`docs/examples/providers.yaml` to `.vesicle/providers.yaml` and set each
-provider's `apiKeyEnv` environment variable. The TUI can then switch with
-`/providers`, `/models`, `/use <provider> <model>`, and `/model <model>`.
+`docs/examples/providers.yaml` to your user-level provider config file and set
+each provider's `apiKeyEnv` environment variable. The default config path is
+`%APPDATA%\prism-vesicle\providers.yaml` on Windows and
+`$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` or
+`~/.config/prism-vesicle/providers.yaml` on Linux/macOS. The TUI can then
+switch with `/providers`, `/models`, `/use <provider> <model>`, and
+`/model <model>`.
 The provider file intentionally supports only Vesicle's small YAML subset:
 `default`, `providers`, scalar provider fields, and `models` string lists.
 Provider secrets are not read from this file; every provider must name an

--- a/STATUS.md
+++ b/STATUS.md
@@ -27,10 +27,12 @@ Chat wrapper:
   responsive workspace/artifact sidebar, wide-screen activity/artifact pane,
   slash hints, prompt history recall, and input bar.
 - Call an OpenAI-compatible Chat Completions endpoint.
-- Load multiple OpenAI-compatible provider/model profiles from
-  `.vesicle/providers.yaml`; the TUI can list and switch provider/model during
-  a session. Provider files name `apiKeyEnv` variables only; actual secrets
-  stay in `.env` or the process environment.
+- Load multiple OpenAI-compatible provider/model profiles from the user-level
+  provider config (`%APPDATA%\prism-vesicle\providers.yaml` on Windows,
+  `$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` or
+  `~/.config/prism-vesicle/providers.yaml` elsewhere); the TUI can list and
+  switch provider/model during a session. Provider files name `apiKeyEnv`
+  variables only; actual secrets stay in `.env` or the process environment.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
 - Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a

--- a/STATUS.md
+++ b/STATUS.md
@@ -13,6 +13,8 @@ _Last updated: 2026-07-07_
 | Gate runtime | request_confirmation + needs_user loop | ETL blueprint + phase gates wired |
 | Validators | Module A + Module B v9 schemas | Implemented |
 | Streaming | OpenAI-compatible SSE | In progress on 0.2 branch |
+| Provider registry | OpenAI-compatible profiles | In progress on 0.3 branch |
+| Artifact workbench | TUI commands + validation | In progress on 0.3 branch |
 
 ## Current Scope
 
@@ -25,6 +27,9 @@ Chat wrapper:
   responsive workspace/artifact sidebar, wide-screen activity/artifact pane,
   slash hints, prompt history recall, and input bar.
 - Call an OpenAI-compatible Chat Completions endpoint.
+- Load multiple OpenAI-compatible provider/model profiles from
+  `.vesicle/providers.yaml`; the TUI can list and switch provider/model during
+  a session.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
 - Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a
@@ -35,6 +40,8 @@ Chat wrapper:
 - Validate artifact-shaped ETL output against Module A (character card) and
   Module B (scenario card) v9 schemas; ordinary prose replies are not reported
   as schema failures.
+- List, preview, validate, and revise generated artifacts through TUI commands
+  that operate on actual files in the artifact roots.
 - Dump the fully composed system prompt via `vesicle prompt dump --engine <id>`
   for host-pollution auditing.
 
@@ -116,6 +123,10 @@ never abort a turn. Validators run only on artifact-shaped assistant content
 
 - Only OpenAI-compatible Chat Completions is implemented (Anthropic Messages,
   OpenAI Responses, Gemini are deferred).
+- The provider registry supports multiple configured providers, but all
+  configured providers must currently use the `openai-chat-compatible`
+  protocol. Native Anthropic Messages, Gemini, and OpenAI Responses adapters are
+  deferred.
 - OpenAI-compatible SSE streaming is implemented on the 0.2 branch for
   assistant content deltas and streamed tool-call reconstruction. Other
   provider protocols are still deferred.

--- a/STATUS.md
+++ b/STATUS.md
@@ -29,7 +29,8 @@ Chat wrapper:
 - Call an OpenAI-compatible Chat Completions endpoint.
 - Load multiple OpenAI-compatible provider/model profiles from
   `.vesicle/providers.yaml`; the TUI can list and switch provider/model during
-  a session.
+  a session. Provider files name `apiKeyEnv` variables only; actual secrets
+  stay in `.env` or the process environment.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
 - Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -54,8 +54,8 @@ Provider selection is host state, not prompt state. The TUI may switch among
 configured provider/model profiles, but adapters still receive a normalized
 `VesicleRequest` and must not know about sessions, artifacts, or Prism phases.
 Persistent provider profiles live under `.vesicle/providers.yaml`; API keys
-should be referenced via environment variables unless a local-only provider
-uses a dummy key.
+must be referenced via per-provider environment variables (`apiKeyEnv`) and
+must not be stored inline in the provider file.
 
 ## Tool Runtime
 

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -53,9 +53,13 @@ Tool calls are normalized into `ToolCall` and executed by `core/tools`.
 Provider selection is host state, not prompt state. The TUI may switch among
 configured provider/model profiles, but adapters still receive a normalized
 `VesicleRequest` and must not know about sessions, artifacts, or Prism phases.
-Persistent provider profiles live under `.vesicle/providers.yaml`; API keys
-must be referenced via per-provider environment variables (`apiKeyEnv`) and
-must not be stored inline in the provider file.
+Persistent provider profiles live in the user-level provider config, not in the
+project `.vesicle/` runtime state directory. The default path is
+`%APPDATA%\prism-vesicle\providers.yaml` on Windows and
+`$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` or
+`~/.config/prism-vesicle/providers.yaml` elsewhere. API keys must be referenced
+via per-provider environment variables (`apiKeyEnv`) and must not be stored
+inline in the provider file.
 
 ## Tool Runtime
 

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -50,6 +50,13 @@ back. They must not:
 
 Tool calls are normalized into `ToolCall` and executed by `core/tools`.
 
+Provider selection is host state, not prompt state. The TUI may switch among
+configured provider/model profiles, but adapters still receive a normalized
+`VesicleRequest` and must not know about sessions, artifacts, or Prism phases.
+Persistent provider profiles live under `.vesicle/providers.yaml`; API keys
+should be referenced via environment variables unless a local-only provider
+uses a dummy key.
+
 ## Tool Runtime
 
 Model-visible tools are a security boundary.
@@ -123,9 +130,10 @@ Prompts are runtime assets, not hardcoded source literals.
 - Profile validators check Prism artifact documents, not every assistant turn.
 - Ordinary phase-transition prose such as "confirmed, moving to Phase 1" must
   not be reported as a Module A/B schema failure.
-- Artifact-shaped assistant content starts with YAML frontmatter. Future
-  artifact-file validation should read the corresponding `write_file` output or
-  artifact on disk before presenting findings.
+- Artifact-shaped assistant content starts with YAML frontmatter. Artifact
+  workbench validation reads the selected artifact file from disk before
+  presenting findings, so validation reflects what was actually written rather
+  than only the last assistant message.
 
 ## TUI Interaction
 
@@ -136,6 +144,9 @@ Prompts are runtime assets, not hardcoded source literals.
   hidden during those modes so confirmation controls stay legible.
 - The wide right pane should show operational activity or artifact context, not
   duplicate the last assistant message already visible in the main stream.
+- Provider/model switching commands and artifact workbench commands are local
+  host actions. They should add concise host notices to the transcript and must
+  not call the provider unless the command explicitly starts a revision prompt.
 - Ctrl+C behavior:
   - With a selectable OpenTUI range, copy selection.
   - Without a selection, first press arms exit and the second press exits.

--- a/docs/examples/providers.yaml
+++ b/docs/examples/providers.yaml
@@ -1,0 +1,19 @@
+default:
+  provider: deepseek
+  model: deepseek-v4-flash
+
+providers:
+  deepseek:
+    protocol: openai-chat-compatible
+    baseUrl: https://api.deepseek.com/v1
+    apiKeyEnv: DEEPSEEK_API_KEY
+    models:
+      - deepseek-v4-flash
+      - deepseek-reasoner
+
+  local:
+    protocol: openai-chat-compatible
+    baseUrl: http://127.0.0.1:11434/v1
+    apiKey: local
+    models:
+      - qwen3

--- a/docs/examples/providers.yaml
+++ b/docs/examples/providers.yaml
@@ -14,6 +14,6 @@ providers:
   local:
     protocol: openai-chat-compatible
     baseUrl: http://127.0.0.1:11434/v1
-    apiKey: local
+    apiKeyEnv: LOCAL_OPENAI_COMPAT_API_KEY
     models:
       - qwen3

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,15 +1,17 @@
-import { inspectConfig } from "../config/env";
+import { inspectProviderConfig } from "../config/providers";
 
 export async function runDoctor(): Promise<void> {
-  const config = inspectConfig();
+  const config = await inspectProviderConfig();
   const bunVersion = Bun.version;
 
   console.log("Prism Vesicle Doctor");
   console.log(`Bun: ${bunVersion}`);
   console.log(`Project: ${process.cwd()}`);
-  console.log(`Provider: ${config.provider}`);
+  console.log(`Provider: ${config.providerId}`);
+  console.log(`Protocol: ${config.provider}`);
   console.log(`Base URL: ${config.baseUrl}`);
   console.log(`Model: ${config.model}`);
+  console.log(`Provider config: ${config.registry.source}${config.registry.path ? ` (${config.registry.path})` : ""}`);
   console.log(`API key: ${config.hasApiKey ? "available" : "missing"}`);
   console.log(`Missing: ${config.missing.length > 0 ? config.missing.join(", ") : "none"}`);
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -6,6 +6,7 @@ export type VesicleConfig = {
   baseUrl: string;
   model: string;
   apiKey?: string;
+  apiKeyLabel?: string;
 };
 
 export type ConfigStatus = VesicleConfig & {
@@ -25,6 +26,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): VesicleConfig 
     baseUrl: trimTrailingSlash(env.VESICLE_BASE_URL ?? "https://api.openai.com/v1"),
     model: env.VESICLE_MODEL ?? "gpt-4.1-mini",
     apiKey: env.VESICLE_API_KEY,
+    apiKeyLabel: "VESICLE_API_KEY",
   };
 }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,6 +2,7 @@ export type VesicleProvider = "openai-chat-compatible";
 
 export type VesicleConfig = {
   provider: VesicleProvider;
+  providerId: string;
   baseUrl: string;
   model: string;
   apiKey?: string;
@@ -20,6 +21,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): VesicleConfig 
 
   return {
     provider,
+    providerId: env.VESICLE_PROVIDER_ID ?? "default",
     baseUrl: trimTrailingSlash(env.VESICLE_BASE_URL ?? "https://api.openai.com/v1"),
     model: env.VESICLE_MODEL ?? "gpt-4.1-mini",
     apiKey: env.VESICLE_API_KEY,

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -96,6 +96,7 @@ export function resolveProviderConfig(
     baseUrl: trimTrailingSlash(profile.baseUrl),
     model,
     apiKey: profile.apiKey ?? (profile.apiKeyEnv ? env[profile.apiKeyEnv] : undefined),
+    apiKeyLabel: profile.apiKeyEnv ?? "apiKey",
   };
 }
 
@@ -256,8 +257,16 @@ function readKeyValue(line: string, index: number, path: string): [string, strin
 }
 
 function stripComment(line: string): string {
-  const hash = line.indexOf("#");
-  return hash === -1 ? line : line.slice(0, hash);
+  let quote: "\"" | "'" | null = null;
+  for (let index = 0; index < line.length; index++) {
+    const char = line[index];
+    if ((char === "\"" || char === "'") && (index === 0 || line[index - 1] !== "\\")) {
+      quote = quote === char ? null : quote ?? char;
+      continue;
+    }
+    if (char === "#" && quote === null) return line.slice(0, index);
+  }
+  return line;
 }
 
 function leadingSpaces(line: string): number {

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -41,7 +41,7 @@ export async function loadProviderRegistry(
     throw error;
   });
   if (!source) return legacyRegistryFromEnv(env);
-  return parseProviderConfig(source, configPath);
+  return parseProviderConfig(source, configPath, env);
 }
 
 export async function loadConfigForSelection(
@@ -121,7 +121,7 @@ function legacyRegistryFromEnv(env: NodeJS.ProcessEnv): ProviderRegistry {
   };
 }
 
-function parseProviderConfig(source: string, path: string): ProviderRegistry {
+function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEnv): ProviderRegistry {
   const lines = source.split(/\r?\n/);
   const registry: ProviderRegistry = {
     source: "file",
@@ -230,7 +230,7 @@ function parseProviderConfig(source: string, path: string): ProviderRegistry {
   finishProvider();
   if (!registry.default.provider) throw new Error(`Provider config ${path} is missing default.provider.`);
   if (!registry.default.model) throw new Error(`Provider config ${path} is missing default.model.`);
-  resolveProviderConfig(registry, registry.default, process.env);
+  resolveProviderConfig(registry, registry.default, env);
   return registry;
 }
 

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,0 +1,277 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { VesicleConfig, VesicleProvider } from "./env";
+
+export type ProviderProtocol = VesicleProvider;
+
+export type ProviderSelection = {
+  provider: string;
+  model: string;
+};
+
+export type ProviderProfile = {
+  id: string;
+  protocol: ProviderProtocol;
+  baseUrl: string;
+  apiKey?: string;
+  apiKeyEnv?: string;
+  models: string[];
+};
+
+export type ProviderRegistry = {
+  default: ProviderSelection;
+  providers: ProviderProfile[];
+  source: "file" | "environment";
+  path?: string;
+};
+
+export type ProviderConfigStatus = VesicleConfig & {
+  hasApiKey: boolean;
+  missing: string[];
+  registry: ProviderRegistry;
+};
+
+export async function loadProviderRegistry(
+  rootDir = process.cwd(),
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ProviderRegistry> {
+  const configPath = providerConfigPath(rootDir);
+  const source = await readFile(configPath, "utf8").catch((error: unknown) => {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  if (!source) return legacyRegistryFromEnv(env);
+  return parseProviderConfig(source, configPath);
+}
+
+export async function loadConfigForSelection(
+  rootDir = process.cwd(),
+  selection?: Partial<ProviderSelection>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<VesicleConfig> {
+  const registry = await loadProviderRegistry(rootDir, env);
+  return resolveProviderConfig(registry, selection, env);
+}
+
+export async function inspectProviderConfig(
+  rootDir = process.cwd(),
+  selection?: Partial<ProviderSelection>,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ProviderConfigStatus> {
+  const registry = await loadProviderRegistry(rootDir, env);
+  const config = resolveProviderConfig(registry, selection, env);
+  const missing: string[] = [];
+  if (!config.apiKey) {
+    const profile = requireProvider(registry, config.providerId);
+    missing.push(profile.apiKeyEnv ?? "apiKey");
+  }
+  if (!config.baseUrl) missing.push("baseUrl");
+  if (!config.model) missing.push("model");
+  return {
+    ...config,
+    hasApiKey: Boolean(config.apiKey),
+    missing,
+    registry,
+  };
+}
+
+export function resolveProviderConfig(
+  registry: ProviderRegistry,
+  selection: Partial<ProviderSelection> | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): VesicleConfig {
+  const providerId = selection?.provider ?? registry.default.provider;
+  const profile = requireProvider(registry, providerId);
+  const model = selection?.model ?? (providerId === registry.default.provider ? registry.default.model : profile.models[0]);
+  if (!model) {
+    throw new Error(`Provider "${providerId}" does not declare any models.`);
+  }
+  if (!profile.models.includes(model)) {
+    throw new Error(`Provider "${providerId}" does not declare model "${model}".`);
+  }
+
+  return {
+    provider: profile.protocol,
+    providerId,
+    baseUrl: trimTrailingSlash(profile.baseUrl),
+    model,
+    apiKey: profile.apiKey ?? (profile.apiKeyEnv ? env[profile.apiKeyEnv] : undefined),
+  };
+}
+
+export function providerConfigPath(rootDir = process.cwd()): string {
+  return join(rootDir, ".vesicle", "providers.yaml");
+}
+
+function legacyRegistryFromEnv(env: NodeJS.ProcessEnv): ProviderRegistry {
+  const protocol = readProtocol(env.VESICLE_PROVIDER ?? "openai-chat-compatible", "VESICLE_PROVIDER");
+  const providerId = env.VESICLE_PROVIDER_ID ?? "default";
+  const model = env.VESICLE_MODEL ?? "gpt-4.1-mini";
+  return {
+    source: "environment",
+    default: { provider: providerId, model },
+    providers: [{
+      id: providerId,
+      protocol,
+      baseUrl: env.VESICLE_BASE_URL ?? "https://api.openai.com/v1",
+      apiKeyEnv: "VESICLE_API_KEY",
+      models: [model],
+    }],
+  };
+}
+
+function parseProviderConfig(source: string, path: string): ProviderRegistry {
+  const lines = source.split(/\r?\n/);
+  const registry: ProviderRegistry = {
+    source: "file",
+    path,
+    default: { provider: "", model: "" },
+    providers: [],
+  };
+  let section: "default" | "providers" | null = null;
+  let currentProvider: Partial<ProviderProfile> | null = null;
+  let currentList: "models" | null = null;
+
+  const finishProvider = () => {
+    if (!currentProvider) return;
+    const id = currentProvider.id;
+    if (!id) throw new Error(`Provider config ${path} has a provider without an id.`);
+    const protocol = currentProvider.protocol;
+    if (!protocol) throw new Error(`Provider "${id}" is missing protocol.`);
+    const baseUrl = currentProvider.baseUrl;
+    if (!baseUrl) throw new Error(`Provider "${id}" is missing baseUrl.`);
+    const models = currentProvider.models ?? [];
+    if (models.length === 0) throw new Error(`Provider "${id}" must declare at least one model.`);
+    registry.providers.push({
+      id,
+      protocol,
+      baseUrl,
+      apiKey: currentProvider.apiKey,
+      apiKeyEnv: currentProvider.apiKeyEnv,
+      models,
+    });
+    currentProvider = null;
+    currentList = null;
+  };
+
+  for (let index = 0; index < lines.length; index++) {
+    const raw = stripComment(lines[index]).replace(/\s+$/, "");
+    if (!raw.trim()) continue;
+    const indent = leadingSpaces(raw);
+    const line = raw.trim();
+
+    if (indent === 0) {
+      finishProvider();
+      currentList = null;
+      if (line === "default:") {
+        section = "default";
+        continue;
+      }
+      if (line === "providers:") {
+        section = "providers";
+        continue;
+      }
+      throw new Error(`Provider config parse error on line ${index + 1}: expected default: or providers:.`);
+    }
+
+    if (section === "default") {
+      if (indent !== 2) throw new Error(`Provider config parse error on line ${index + 1}: default fields use two spaces.`);
+      const [key, value] = readKeyValue(line, index, path);
+      if (key === "provider") registry.default.provider = value;
+      else if (key === "model") registry.default.model = value;
+      else throw new Error(`Provider config parse error on line ${index + 1}: unknown default field "${key}".`);
+      continue;
+    }
+
+    if (section !== "providers") {
+      throw new Error(`Provider config parse error on line ${index + 1}: field outside a section.`);
+    }
+
+    if (indent === 2) {
+      finishProvider();
+      if (!line.endsWith(":")) {
+        throw new Error(`Provider config parse error on line ${index + 1}: provider id must end with colon.`);
+      }
+      currentProvider = { id: line.slice(0, -1).trim(), models: [] };
+      continue;
+    }
+
+    if (!currentProvider) {
+      throw new Error(`Provider config parse error on line ${index + 1}: provider field without provider id.`);
+    }
+
+    if (indent === 4) {
+      if (line === "models:") {
+        currentList = "models";
+        continue;
+      }
+      currentList = null;
+      const [key, value] = readKeyValue(line, index, path);
+      if (key === "protocol") currentProvider.protocol = readProtocol(value, `provider ${currentProvider.id}`);
+      else if (key === "baseUrl") currentProvider.baseUrl = value;
+      else if (key === "apiKey") currentProvider.apiKey = value;
+      else if (key === "apiKeyEnv") currentProvider.apiKeyEnv = value;
+      else throw new Error(`Provider config parse error on line ${index + 1}: unknown provider field "${key}".`);
+      continue;
+    }
+
+    if (indent === 6 && currentList === "models") {
+      if (!line.startsWith("- ")) {
+        throw new Error(`Provider config parse error on line ${index + 1}: model entries must start with "- ".`);
+      }
+      currentProvider.models = [...(currentProvider.models ?? []), unquote(line.slice(2).trim())];
+      continue;
+    }
+
+    throw new Error(`Provider config parse error on line ${index + 1}: unsupported indentation.`);
+  }
+
+  finishProvider();
+  if (!registry.default.provider) throw new Error(`Provider config ${path} is missing default.provider.`);
+  if (!registry.default.model) throw new Error(`Provider config ${path} is missing default.model.`);
+  resolveProviderConfig(registry, registry.default, process.env);
+  return registry;
+}
+
+function requireProvider(registry: ProviderRegistry, providerId: string): ProviderProfile {
+  const profile = registry.providers.find((entry) => entry.id === providerId);
+  if (!profile) throw new Error(`Unknown provider "${providerId}".`);
+  return profile;
+}
+
+function readProtocol(value: string, field: string): ProviderProtocol {
+  if (value !== "openai-chat-compatible") {
+    throw new Error(`Unsupported provider protocol "${value}" in ${field}.`);
+  }
+  return value;
+}
+
+function readKeyValue(line: string, index: number, path: string): [string, string] {
+  const colon = line.indexOf(":");
+  if (colon === -1) throw new Error(`Provider config parse error on line ${index + 1} in ${path}: missing colon.`);
+  const key = line.slice(0, colon).trim();
+  const value = unquote(line.slice(colon + 1).trim());
+  if (!value) throw new Error(`Provider config parse error on line ${index + 1} in ${path}: empty value for ${key}.`);
+  return [key, value];
+}
+
+function stripComment(line: string): string {
+  const hash = line.indexOf("#");
+  return hash === -1 ? line : line.slice(0, hash);
+}
+
+function leadingSpaces(line: string): number {
+  const match = line.match(/^ */);
+  return match ? match[0].length : 0;
+}
+
+function unquote(value: string): string {
+  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, "");
+}

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import type { VesicleConfig, VesicleProvider } from "./env";
 
@@ -34,7 +35,8 @@ export async function loadProviderRegistry(
   rootDir = process.cwd(),
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<ProviderRegistry> {
-  const configPath = providerConfigPath(rootDir);
+  void rootDir;
+  const configPath = providerConfigPathFromEnv(env);
   const source = await readFile(configPath, "utf8").catch((error: unknown) => {
     if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return undefined;
     throw error;
@@ -99,8 +101,20 @@ export function resolveProviderConfig(
   };
 }
 
-export function providerConfigPath(rootDir = process.cwd()): string {
-  return join(rootDir, ".vesicle", "providers.yaml");
+export function providerConfigPath(): string {
+  return providerConfigPathFromEnv(process.env);
+}
+
+export function providerConfigPathFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  if (env.VESICLE_PROVIDERS_FILE) return env.VESICLE_PROVIDERS_FILE;
+  return join(providerConfigDir(env), "providers.yaml");
+}
+
+function providerConfigDir(env: NodeJS.ProcessEnv): string {
+  if (env.VESICLE_CONFIG_DIR) return env.VESICLE_CONFIG_DIR;
+  if (env.APPDATA) return join(env.APPDATA, "prism-vesicle");
+  if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, "prism-vesicle");
+  return join(homedir(), ".config", "prism-vesicle");
 }
 
 function legacyRegistryFromEnv(env: NodeJS.ProcessEnv): ProviderRegistry {

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -13,8 +13,7 @@ export type ProviderProfile = {
   id: string;
   protocol: ProviderProtocol;
   baseUrl: string;
-  apiKey?: string;
-  apiKeyEnv?: string;
+  apiKeyEnv: string;
   models: string[];
 };
 
@@ -95,8 +94,8 @@ export function resolveProviderConfig(
     providerId,
     baseUrl: trimTrailingSlash(profile.baseUrl),
     model,
-    apiKey: profile.apiKey ?? (profile.apiKeyEnv ? env[profile.apiKeyEnv] : undefined),
-    apiKeyLabel: profile.apiKeyEnv ?? "apiKey",
+    apiKey: env[profile.apiKeyEnv],
+    apiKeyLabel: profile.apiKeyEnv,
   };
 }
 
@@ -141,14 +140,15 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
     if (!protocol) throw new Error(`Provider "${id}" is missing protocol.`);
     const baseUrl = currentProvider.baseUrl;
     if (!baseUrl) throw new Error(`Provider "${id}" is missing baseUrl.`);
+    const apiKeyEnv = currentProvider.apiKeyEnv;
+    if (!apiKeyEnv) throw new Error(`Provider "${id}" is missing apiKeyEnv.`);
     const models = currentProvider.models ?? [];
     if (models.length === 0) throw new Error(`Provider "${id}" must declare at least one model.`);
     registry.providers.push({
       id,
       protocol,
       baseUrl,
-      apiKey: currentProvider.apiKey,
-      apiKeyEnv: currentProvider.apiKeyEnv,
+      apiKeyEnv,
       models,
     });
     currentProvider = null;
@@ -210,8 +210,8 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
       const [key, value] = readKeyValue(line, index, path);
       if (key === "protocol") currentProvider.protocol = readProtocol(value, `provider ${currentProvider.id}`);
       else if (key === "baseUrl") currentProvider.baseUrl = value;
-      else if (key === "apiKey") currentProvider.apiKey = value;
       else if (key === "apiKeyEnv") currentProvider.apiKeyEnv = value;
+      else if (key === "apiKey") throw new Error(`Provider config parse error on line ${index + 1}: use apiKeyEnv instead of inline apiKey.`);
       else throw new Error(`Provider config parse error on line ${index + 1}: unknown provider field "${key}".`);
       continue;
     }

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -1,4 +1,6 @@
 import { loadConfig } from "../../config/env";
+import { loadConfigForSelection } from "../../config/providers";
+import type { ProviderSelection } from "../../config/providers";
 import { createProvider } from "../../providers";
 import type { ProviderAdapter, VesicleMessage, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
 import { executeFileTool, fileToolDefinitions } from "../tools";
@@ -24,6 +26,7 @@ export type RunPromptOptions = {
   rootDir?: string;
   sessionId?: string;
   messages?: VesicleMessage[];
+  providerSelection?: Partial<ProviderSelection>;
   onEvent?: (event: AgentLoopEvent) => void;
 };
 
@@ -128,7 +131,7 @@ const maxConsecutiveFailedTools = 4;
 export async function runPrompt(options: RunPromptOptions): Promise<RunPromptResult> {
   const engine = options.engine ?? "etl";
   const rootDir = options.rootDir ?? process.cwd();
-  const config = loadConfig();
+  const config = await loadConfigForSelection(rootDir, options.providerSelection);
   const provider = createProvider(config);
   const profile = await loadEngineProfile(engine, rootDir);
   const promptBundle = await loadPromptBundle(profile, rootDir);
@@ -144,6 +147,7 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
       metadata: {
         engine,
         provider: config.provider,
+        providerId: config.providerId,
         model: config.model,
         profile: {
           displayName: profile.displayName,
@@ -156,7 +160,15 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
     });
   }
 
-  await session.append({ role: "user", content: options.input });
+  await session.append({
+    role: "user",
+    content: options.input,
+    metadata: {
+      provider: config.provider,
+      providerId: config.providerId,
+      model: config.model,
+    },
+  });
 
   const messages: VesicleMessage[] = options.messages ?? [
     {
@@ -192,7 +204,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
     response = await completeWithStreaming(provider, {
       id: session.sessionId,
       model: {
-        provider: config.provider,
+        provider: config.providerId,
         model: config.model,
       },
       system: [systemPrompt],
@@ -468,10 +480,11 @@ export async function resolveGate(options: {
   toolCallId: string;
   gate: GateRequest;
   resolution: GateResolution;
+  providerSelection?: Partial<ProviderSelection>;
   onEvent?: (event: AgentLoopEvent) => void;
 }): Promise<RunPromptResult> {
   const rootDir = options.rootDir ?? process.cwd();
-  const config = loadConfig();
+  const config = await loadConfigForSelection(rootDir, options.providerSelection);
   const provider = createProvider(config);
   const profile = await loadEngineProfile(options.engine, rootDir);
   const promptBundle = await loadPromptBundle(profile, rootDir);
@@ -507,7 +520,15 @@ export async function resolveGate(options: {
 
   const userFollowUp = gateFollowUpMessage(options.gate, options.resolution);
   messages.push({ role: "user", content: userFollowUp });
-  await session.append({ role: "user", content: userFollowUp });
+  await session.append({
+    role: "user",
+    content: userFollowUp,
+    metadata: {
+      provider: config.provider,
+      providerId: config.providerId,
+      model: config.model,
+    },
+  });
 
   return runLoop({ rootDir, config, provider, systemPrompt, tools, messages, session, profile, onEvent: options.onEvent });
 }

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -2,6 +2,7 @@ import { appendFile, mkdir, readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { parseGateRequest } from "../gate/types";
 import type { GateRequest } from "../gate/types";
+import type { ProviderSelection } from "../../config/providers";
 
 export type SessionRole = "user" | "assistant" | "system" | "tool";
 
@@ -154,6 +155,7 @@ export type ResumedMessage = {
 export type SessionSnapshot = {
   sessionId: string;
   messages: ResumedMessage[];
+  providerSelection?: ProviderSelection;
   pendingGate?: {
     gate: GateRequest;
     toolCallId: string;
@@ -178,8 +180,15 @@ export async function loadSessionSnapshot(
 
   const messages: ResumedMessage[] = [];
   let skippedFirstSystem = false;
+  let providerSelection: ProviderSelection | undefined;
 
   for (const record of records) {
+    const providerId = record.metadata?.providerId;
+    const model = record.metadata?.model;
+    if (typeof providerId === "string" && typeof model === "string") {
+      providerSelection = { provider: providerId, model };
+    }
+
     if (record.role === "system") {
       // Skip the initial composed prompt; resume recomposes it. Also skip
       // trailing diagnostic system notices (validation, breaker notes).
@@ -232,6 +241,7 @@ export async function loadSessionSnapshot(
   return {
     sessionId,
     messages,
+    ...(providerSelection ? { providerSelection } : {}),
     ...(pendingGate
       ? {
           pendingGate: {

--- a/src/providers/openai-chat/adapter.ts
+++ b/src/providers/openai-chat/adapter.ts
@@ -63,7 +63,7 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
 
   async complete(request: VesicleRequest): Promise<VesicleResponse> {
     if (!this.config.apiKey) {
-      throw new Error("VESICLE_API_KEY is required before making a provider request.");
+      throw new Error(`${this.config.apiKeyLabel ?? "VESICLE_API_KEY"} is required before making a provider request.`);
     }
 
     const response = await fetch(`${this.config.baseUrl}/chat/completions`, {
@@ -86,7 +86,7 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
 
   async *stream(request: VesicleRequest): AsyncIterable<ProviderStreamEvent> {
     if (!this.config.apiKey) {
-      throw new Error("VESICLE_API_KEY is required before making a provider request.");
+      throw new Error(`${this.config.apiKeyLabel ?? "VESICLE_API_KEY"} is required before making a provider request.`);
     }
 
     const response = await this.fetchChatCompletion(request, true, true);

--- a/src/tui/GatePrompt.tsx
+++ b/src/tui/GatePrompt.tsx
@@ -40,7 +40,7 @@ export function GatePrompt(props: GatePromptProps) {
   const reviseLabel = labelFor(props.gate, "revise", DEFAULT_REVISE_LABEL);
   const chatLabel = labelFor(props.gate, "chat", DEFAULT_CHAT_LABEL);
   const summaryLines = () => visibleGateSummaryLines(
-    props.gate.summary,
+    renderGateSummaryText(props.gate.summary),
     Math.max(MIN_SUMMARY_WIDTH, (props.width ?? renderer.width) - 4),
     props.maxSummaryLines ?? 4,
   );
@@ -126,6 +126,14 @@ export function sanitizeGateLabel(value: string): string {
     .replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+export function renderGateSummaryText(value: string): string {
+  return value
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/\*\*([^*\n]+)\*\*/g, "$1")
+    .replace(/__([^_\n]+)__/g, "$1")
+    .replace(/`([^`\n]+)`/g, "$1");
 }
 
 export function wrapGateSummary(value: string, maxWidth: number): string[] {

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,8 +1,10 @@
 import { createMemo, createSignal, For, Show, onMount } from "solid-js";
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid";
-import { readdir, stat } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { inspectConfig } from "../config/env";
+import { inspectProviderConfig, resolveProviderConfig } from "../config/providers";
+import type { ProviderRegistry, ProviderSelection } from "../config/providers";
 import { resolveGate, runPrompt } from "../core/agent-loop/run";
 import type { RunPromptResult } from "../core/agent-loop/run";
 import type { AgentLoopEvent } from "../core/agent-loop/run";
@@ -12,8 +14,9 @@ import { copySelectionToClipboard } from "./clipboard";
 import { sharedSyntaxStyle, palette } from "./theme";
 import { GatePrompt, gateFocusOrder, gateResolutionFromState } from "./GatePrompt";
 import type { GateFocusTarget } from "./GatePrompt";
-import { listSessions, loadSessionSnapshot } from "../core/session/store";
+import { createSessionStore, listSessions, loadSessionSnapshot } from "../core/session/store";
 import type { SessionSummary } from "../core/session/store";
+import { resolveValidators, runValidators } from "../core/validators/registry";
 import { resolveTuiLayout } from "./layout";
 import { SessionPicker } from "./SessionPicker";
 import {
@@ -41,6 +44,11 @@ type ArtifactEntry = {
   updatedAt: string;
 };
 
+type SelectedArtifact = ArtifactEntry & {
+  preview: string;
+  validation?: string;
+};
+
 type ActivityEntry = {
   kind: "provider" | "assistant" | "tool" | "gate" | "validation" | "system";
   text: string;
@@ -55,6 +63,10 @@ export function App() {
   const renderer = useRenderer();
   const dimensions = useTerminalDimensions();
   const config = inspectConfig();
+  const [providerRegistry, setProviderRegistry] = createSignal<ProviderRegistry | null>(null);
+  const [activeProvider, setActiveProvider] = createSignal(config.providerId);
+  const [activeModel, setActiveModel] = createSignal(config.model);
+  const [providerHasApiKey, setProviderHasApiKey] = createSignal(config.hasApiKey);
   const [messages, setMessages] = createSignal<Message[]>([
     {
       role: "system",
@@ -71,6 +83,7 @@ export function App() {
   const [resumableSessions, setResumableSessions] = createSignal<SessionSummary[]>([]);
   const [sessionPicker, setSessionPicker] = createSignal<SessionPickerState | null>(null);
   const [artifacts, setArtifacts] = createSignal<ArtifactEntry[]>([]);
+  const [selectedArtifact, setSelectedArtifact] = createSignal<SelectedArtifact | null>(null);
   const [activity, setActivity] = createSignal<ActivityEntry[]>([
     { kind: "system", text: "Activity will show provider requests, tool calls, gates, and validation." },
   ]);
@@ -98,6 +111,7 @@ export function App() {
   // On mount, detect existing sessions so the welcome line can offer resume.
   onMount(() => {
     void refreshArtifacts();
+    void refreshProviderConfig();
     void listSessions().then((sessions) => {
       setResumableSessions(sessions);
       if (sessions.length > 0) {
@@ -234,11 +248,15 @@ export function App() {
     const prompt = value.trim();
     if (!prompt || busy()) return;
 
-    // Slash commands for session management. These never hit the provider.
-    if (prompt.startsWith("/")) {
-      await handleCommand(prompt);
-      return;
-    }
+	    // Slash commands for session management. These never hit the provider.
+	    if (prompt.startsWith("/")) {
+	      try {
+	        await handleCommand(prompt);
+	      } catch (error) {
+	        reportError(error);
+	      }
+	      return;
+	    }
 
     setPromptHistory((prev) => [...prev.filter((entry) => entry !== prompt), prompt].slice(-50));
     setHistoryIndex(null);
@@ -246,7 +264,7 @@ export function App() {
     setLastDisplayedToolAssistantContent(null);
     setBusy(true);
     setStatus("sending request");
-    recordActivity({ kind: "provider", text: "sending provider request" });
+	    recordActivity({ kind: "provider", text: "sending provider request" });
     const requestMessages: VesicleMessage[] = [
       ...conversation(),
       { role: "user", content: prompt },
@@ -257,10 +275,11 @@ export function App() {
       const result = await runPrompt({
         input: prompt,
         engine: "etl",
-        sessionId: sessionId(),
-        messages: requestMessages,
-        onEvent: handleAgentEvent,
-      });
+	        sessionId: sessionId(),
+	        messages: requestMessages,
+	        providerSelection: activeProviderSelection(),
+	        onEvent: handleAgentEvent,
+	      });
       handleResult(result, requestMessages);
     } catch (error) {
       reportError(error);
@@ -290,10 +309,11 @@ export function App() {
         sessionId: gate.sessionId,
         messages: gate.messages,
         toolCallId: gate.toolCallId,
-        gate: gate.gate,
-        resolution,
-        onEvent: handleAgentEvent,
-      });
+	        gate: gate.gate,
+	        resolution,
+	        providerSelection: activeProviderSelection(),
+	        onEvent: handleAgentEvent,
+	      });
       handleResult(result, gate.messages);
     } catch (error) {
       setPendingGate(gate);
@@ -415,6 +435,57 @@ export function App() {
     setActivity((prev) => [...prev, entry].slice(-60));
   }
 
+  async function refreshProviderConfig(selection?: Partial<ProviderSelection>) {
+    const inspected = await inspectProviderConfig(process.cwd(), selection);
+    setProviderRegistry(inspected.registry);
+    setActiveProvider(inspected.providerId);
+    setActiveModel(inspected.model);
+    setProviderHasApiKey(inspected.hasApiKey);
+    recordActivity({
+      kind: "provider",
+      text: `active ${inspected.providerId}/${inspected.model} (${inspected.registry.source})`,
+    });
+    setStatus(inspected.hasApiKey ? `provider ${inspected.providerId}` : `missing API key for ${inspected.providerId}`);
+  }
+
+  async function ensureProviderRegistry(): Promise<ProviderRegistry> {
+    const existing = providerRegistry();
+    if (existing) return existing;
+    const inspected = await inspectProviderConfig(process.cwd(), { provider: activeProvider(), model: activeModel() });
+    setProviderRegistry(inspected.registry);
+    setProviderHasApiKey(inspected.hasApiKey);
+    return inspected.registry;
+  }
+
+  function applyProviderSelection(registry: ProviderRegistry, selection: Partial<ProviderSelection>): ProviderSelection {
+    const resolved = resolveProviderConfig(registry, selection);
+    setActiveProvider(resolved.providerId);
+    setActiveModel(resolved.model);
+    setProviderHasApiKey(Boolean(resolved.apiKey));
+    setStatus(Boolean(resolved.apiKey) ? `provider ${resolved.providerId}` : `missing API key for ${resolved.providerId}`);
+    recordActivity({ kind: "provider", text: `switched to ${resolved.providerId}/${resolved.model}` });
+    return { provider: resolved.providerId, model: resolved.model };
+  }
+
+  function activeProviderSelection(): ProviderSelection {
+    return { provider: activeProvider(), model: activeModel() };
+  }
+
+  async function persistProviderSwitch(selection: ProviderSelection) {
+    const id = sessionId();
+    if (!id) return;
+    const store = await createSessionStore(process.cwd(), id);
+    await store.append({
+      role: "system",
+      content: `Provider switched to ${selection.provider}/${selection.model}.`,
+      metadata: {
+        kind: "provider-switch",
+        providerId: selection.provider,
+        model: selection.model,
+      },
+    });
+  }
+
   const handleSubmit = (value: unknown) => {
     if (pendingGate()) return; // gate mode owns the input
     const submitted = typeof value === "string" ? value : inputValue();
@@ -427,11 +498,19 @@ export function App() {
    * Slash commands for session management and help. These run locally and
    * never touch the provider:
    *   /resume           list resumable sessions with numeric indices
-   *   /resume <n>       resume the nth session from the last /resume list
-   *   /resume <id>      resume a session by full id prefix
-   *   /new              abandon the current session and start fresh
-   *   /help             show available commands
-   */
+	 *   /resume <n>       resume the nth session from the last /resume list
+	 *   /resume <id>      resume a session by full id prefix
+	 *   /providers        list configured providers
+	 *   /models [id]      list models for a provider
+	 *   /use <id> <model> switch provider and model
+	 *   /model <model>    switch model within the active provider
+	 *   /artifacts        list generated artifacts
+	 *   /artifact <n|path> preview an artifact
+	 *   /validate <n|path> validate an artifact file
+	 *   /revise <n|path> <instructions> revise an artifact
+	 *   /new              abandon the current session and start fresh
+	 *   /help             show available commands
+	 */
   async function handleCommand(input: string) {
     const [command, ...rest] = input.slice(1).split(/\s+/);
     const arg = rest.join(" ").trim();
@@ -441,12 +520,108 @@ export function App() {
         ...prev,
         { role: "user", content: input },
         {
-          role: "system",
-          content: "Commands:\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
-        },
-      ]);
-      return;
-    }
+	          role: "system",
+	          content: "Commands:\n  /providers        list configured providers\n  /models [id]      list models for a provider\n  /use <id> <model> switch provider/model\n  /model <model>    switch model in active provider\n  /artifacts        list generated artifacts\n  /artifact <n|path> preview an artifact\n  /validate <n|path> validate an artifact file\n  /revise <n|path> <instructions> revise an artifact\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
+	        },
+	      ]);
+	      return;
+	    }
+
+	    if (command === "providers") {
+	      const registry = await ensureProviderRegistry();
+	      setMessages((prev) => [
+	        ...prev,
+	        { role: "user", content: input },
+	        { role: "system", content: renderProviderList(registry, activeProvider()) },
+	      ]);
+	      return;
+	    }
+
+	    if (command === "models") {
+	      const registry = await ensureProviderRegistry();
+	      const providerId = arg || activeProvider();
+	      setMessages((prev) => [
+	        ...prev,
+	        { role: "user", content: input },
+	        { role: "system", content: renderModelList(registry, providerId, activeModel()) },
+	      ]);
+	      return;
+	    }
+
+	    if (command === "use") {
+	      const [providerId, ...modelParts] = arg.split(/\s+/).filter(Boolean);
+	      const model = modelParts.join(" ");
+	      if (!providerId || !model) {
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /use <provider> <model>" }]);
+	        return;
+	      }
+	      const registry = await ensureProviderRegistry();
+	      const selection = applyProviderSelection(registry, { provider: providerId, model });
+	      await persistProviderSwitch(selection);
+	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
+	      return;
+	    }
+
+	    if (command === "model") {
+	      if (!arg) {
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /model <model>" }]);
+	        return;
+	      }
+	      const registry = await ensureProviderRegistry();
+	      const selection = applyProviderSelection(registry, { provider: activeProvider(), model: arg });
+	      await persistProviderSwitch(selection);
+	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
+	      return;
+	    }
+
+	    if (command === "artifacts") {
+	      const entries = await refreshArtifacts();
+	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: renderArtifactList(entries) }]);
+	      return;
+	    }
+
+	    if (command === "artifact" || command === "open") {
+	      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
+	      const artifact = resolveArtifactTarget(entries, arg);
+	      if (!artifact) {
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${arg || "(empty)"}". Use /artifacts to list.` }]);
+	        return;
+	      }
+	      const selected = await loadArtifactPreview(artifact);
+	      setSelectedArtifact(selected);
+	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Selected artifact ${selected.path}. Preview is shown in the right pane.` }]);
+	      return;
+	    }
+
+	    if (command === "validate") {
+	      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
+	      const artifact = resolveArtifactTarget(entries, arg);
+	      if (!artifact) {
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${arg || "(empty)"}". Use /artifacts to list.` }]);
+	        return;
+	      }
+	      const selected = await loadArtifactPreview(artifact, { validate: true });
+	      setSelectedArtifact(selected);
+	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: selected.validation ?? `No validator matched ${selected.path}.` }]);
+	      return;
+	    }
+
+	    if (command === "revise") {
+	      const [targetArg, ...instructionParts] = arg.split(/\s+/).filter(Boolean);
+	      const instructions = instructionParts.join(" ");
+	      if (!targetArg || !instructions) {
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /revise <n|path> <instructions>" }]);
+	        return;
+	      }
+	      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
+	      const artifact = resolveArtifactTarget(entries, targetArg);
+	      if (!artifact) {
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${targetArg}". Use /artifacts to list.` }]);
+	        return;
+	      }
+	      await submitPrompt(`Revise artifact ${artifact.path}. First read_file that path, then apply this request and write_file the revised artifact back to the same path: ${instructions}`);
+	      return;
+	    }
 
     if (command === "new") {
       setMessages((prev) => [...prev, { role: "user", content: input }]);
@@ -505,10 +680,20 @@ export function App() {
       setOutput(snapshot.pendingGate?.assistantContent ?? "");
       setSessionPicker(null);
 
-      const hostMessages: Message[] = [];
-      if (commandEcho) hostMessages.push({ role: "user", content: commandEcho });
+	      const hostMessages: Message[] = [];
+	      if (commandEcho) hostMessages.push({ role: "user", content: commandEcho });
+	      if (snapshot.providerSelection) {
+	        try {
+	          const registry = await ensureProviderRegistry();
+	          const selection = applyProviderSelection(registry, snapshot.providerSelection);
+	          hostMessages.push({ role: "system", content: `Restored provider ${selection.provider}/${selection.model} from session.` });
+	        } catch (error) {
+	          const message = error instanceof Error ? error.message : String(error);
+	          hostMessages.push({ role: "system", content: `Session provider was not restored: ${message}` });
+	        }
+	      }
 
-      if (snapshot.pendingGate) {
+	      if (snapshot.pendingGate) {
         setPendingGate({
           kind: "needs_user",
           sessionId: target.sessionId,
@@ -542,9 +727,12 @@ export function App() {
     }
   }
 
-  async function refreshArtifacts() {
-    setArtifacts(await scanArtifacts(process.cwd()));
-  }
+	  async function refreshArtifacts(): Promise<ArtifactEntry[]> {
+	    const entries = await scanArtifacts(process.cwd());
+	    setArtifacts(entries);
+	    setSelectedArtifact((selected) => selected && entries.some((entry) => entry.path === selected.path) ? selected : null);
+	    return entries;
+	  }
 
   const renderMessage = (message: Message) => {
     const color =
@@ -588,8 +776,8 @@ export function App() {
   return (
     <box flexDirection="column" width="100%" height="100%" backgroundColor={palette.bg}>
       <box height={3} border borderColor={palette.panelBorder} paddingX={1} flexDirection="row">
-        <text
-          content={headerLine(config.provider, config.model, status(), layout().width)}
+	        <text
+	          content={headerLine(activeProvider(), activeModel(), status(), layout().width)}
           fg={busy() ? palette.warn : pendingGate() ? palette.gateAccent : palette.success}
           attributes={1}
         />
@@ -601,9 +789,9 @@ export function App() {
             <PanelLine content="Engine" fg={palette.textMuted} />
             <PanelLine content="etl" fg={palette.textPrimary} attributes={1} />
             <PanelLine content=" " fg={palette.textDim} />
-            <PanelLine content="Provider" fg={palette.textMuted} />
-            <PanelLine content={truncateLine(config.model, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
-            <PanelLine content={config.hasApiKey ? "API key: available" : "API key: missing"} fg={config.hasApiKey ? palette.success : palette.error} />
+	            <PanelLine content="Provider" fg={palette.textMuted} />
+	            <PanelLine content={truncateLine(`${activeProvider()}/${activeModel()}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
+	            <PanelLine content={providerHasApiKey() ? "API key: available" : "API key: missing"} fg={providerHasApiKey() ? palette.success : palette.error} />
             <PanelLine content=" " fg={palette.textDim} />
             <PanelLine content="Session" fg={palette.textMuted} />
             <PanelLine content={truncateMiddle(sessionPath(), layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
@@ -636,11 +824,24 @@ export function App() {
             <scrollbox width="100%" height="100%" stickyScroll stickyStart="top">
               <box flexDirection="column">
                 <text content="Activity" fg={palette.textMuted} />
-                <For each={activity().slice(-10)}>
-                  {(entry) => <text content={activityLine(entry, layout().rightPanelWidth - 4)} fg={activityColor(entry.kind)} />}
-                </For>
-                <text content=" " />
-                <text content="Recent artifacts" fg={palette.textMuted} />
+	                <For each={activity().slice(-10)}>
+	                  {(entry) => <text content={activityLine(entry, layout().rightPanelWidth - 4)} fg={activityColor(entry.kind)} />}
+	                </For>
+	                <text content=" " />
+	                <text content="Selected artifact" fg={palette.textMuted} />
+	                <Show when={selectedArtifact()} fallback={<text content="none selected" fg={palette.textDim} />}>
+	                  {(artifact) => (
+	                    <box flexDirection="column">
+	                      <text content={truncateMiddle(artifact().path, layout().rightPanelWidth - 4)} fg={palette.textSecondary} />
+	                      <Show when={artifact().validation} fallback={<box height={0} />}>
+	                        {(validation) => <text content={truncateLine(validation().split("\n")[0] ?? "", layout().rightPanelWidth - 4)} fg={validation().includes("found issues") ? palette.warn : palette.success} />}
+	                      </Show>
+	                      <text content={truncateLine(artifact().preview, layout().rightPanelWidth - 4)} fg={palette.textPrimary} />
+	                    </box>
+	                  )}
+	                </Show>
+	                <text content=" " />
+	                <text content="Recent artifacts" fg={palette.textMuted} />
                 <Show when={artifacts().length > 0} fallback={<text content="none yet" fg={palette.textDim} />}>
                   <For each={artifacts().slice(0, 6)}>
                     {(artifact) => <text content={truncateMiddle(artifact.path, layout().rightPanelWidth - 4)} fg={palette.textSecondary} />}
@@ -661,7 +862,8 @@ export function App() {
               <box height={inputValue().startsWith("/") ? layout().bottomHeight : 3} border borderColor={palette.panelBorder} paddingX={1} flexDirection="column">
                 <Show when={inputValue().startsWith("/")} fallback={<box height={0} />}>
                   <box flexDirection="column">
-                    <text content="/resume  list and resume sessions    /new  start fresh    /help  commands" fg={palette.textDim} />
+	                    <text content="/providers  list providers    /models  list models    /use <p> <m>  switch" fg={palette.textDim} />
+	                    <text content="/resume  list sessions    /new  start fresh    /help  commands" fg={palette.textDim} />
                     <text content="Up/Down recalls prompt history" fg={palette.textDim} />
                   </box>
                 </Show>
@@ -708,6 +910,71 @@ function PanelLine(props: { content: string; fg: string; attributes?: number }) 
       <text content={props.content} fg={props.fg} attributes={props.attributes} width="100%" />
     </box>
   );
+}
+
+function renderProviderList(registry: ProviderRegistry, activeProvider: string): string {
+  const lines = [`Configured providers (${registry.source}):`];
+  for (const provider of registry.providers) {
+    const marker = provider.id === activeProvider ? "*" : " ";
+    lines.push(`${marker} ${provider.id} [${provider.protocol}] ${provider.models.length} model${provider.models.length === 1 ? "" : "s"}`);
+  }
+  lines.push("");
+  lines.push("Use /models <provider> to inspect models, /use <provider> <model> to switch.");
+  return lines.join("\n");
+}
+
+function renderModelList(registry: ProviderRegistry, providerId: string, activeModel: string): string {
+  const provider = registry.providers.find((entry) => entry.id === providerId);
+  if (!provider) return `Unknown provider "${providerId}". Use /providers to list configured providers.`;
+  const lines = [`Models for ${provider.id}:`];
+  for (const model of provider.models) {
+    const marker = model === activeModel ? "*" : " ";
+    lines.push(`${marker} ${model}`);
+  }
+  lines.push("");
+  lines.push(`Use /use ${provider.id} <model> or /model <model> to switch.`);
+  return lines.join("\n");
+}
+
+function renderArtifactList(entries: ArtifactEntry[]): string {
+  if (entries.length === 0) return "No artifacts found yet.";
+  const lines = ["Artifacts:"];
+  entries.forEach((entry, index) => {
+    lines.push(`${index + 1}. ${entry.path}`);
+  });
+  lines.push("");
+  lines.push("Use /artifact <n|path> to preview, /validate <n|path> to validate, /revise <n|path> <instructions> to edit.");
+  return lines.join("\n");
+}
+
+function resolveArtifactTarget(entries: ArtifactEntry[], arg: string): ArtifactEntry | null {
+  const trimmed = arg.trim();
+  if (!trimmed) return entries[0] ?? null;
+  const numeric = Number(trimmed);
+  if (Number.isInteger(numeric) && numeric >= 1 && numeric <= entries.length) return entries[numeric - 1];
+  return entries.find((entry) => entry.path === trimmed || entry.path.endsWith(trimmed)) ?? null;
+}
+
+async function loadArtifactPreview(artifact: ArtifactEntry, options: { validate?: boolean } = {}): Promise<SelectedArtifact> {
+  const content = await readFile(join(process.cwd(), artifact.path), "utf8");
+  const preview = content.replace(/\s+/g, " ").trim().slice(0, 500) || "(empty)";
+  const validation = options.validate ? validateArtifactContent(content) : undefined;
+  return { ...artifact, preview, ...(validation ? { validation } : {}) };
+}
+
+function validateArtifactContent(content: string): string {
+  const names = selectArtifactValidators(content);
+  if (names.length === 0) return "No validator matched this artifact.";
+  const validation = runValidators(resolveValidators(names), content);
+  return renderValidationNotice(validation);
+}
+
+function selectArtifactValidators(content: string): string[] {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("---")) return [];
+  if (/^scenario_name:/m.test(trimmed)) return ["scenario-card"];
+  if (/^name:/m.test(trimmed) && /^archetype:/m.test(trimmed)) return ["character-card"];
+  return ["character-card", "scenario-card"];
 }
 
 function headerLine(provider: string, model: string, status: string, width: number): string {

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,6 +1,6 @@
 import { createMemo, createSignal, For, Show, onMount } from "solid-js";
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid";
-import { readFile, readdir, stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { inspectConfig } from "../config/env";
 import { inspectProviderConfig, resolveProviderConfig } from "../config/providers";
@@ -17,6 +17,7 @@ import type { GateFocusTarget } from "./GatePrompt";
 import { createSessionStore, listSessions, loadSessionSnapshot } from "../core/session/store";
 import type { SessionSummary } from "../core/session/store";
 import { resolveValidators, runValidators } from "../core/validators/registry";
+import { executeFileTool } from "../core/tools";
 import { resolveTuiLayout } from "./layout";
 import { SessionPicker } from "./SessionPicker";
 import {
@@ -67,6 +68,7 @@ export function App() {
   const [activeProvider, setActiveProvider] = createSignal(config.providerId);
   const [activeModel, setActiveModel] = createSignal(config.model);
   const [providerHasApiKey, setProviderHasApiKey] = createSignal(config.hasApiKey);
+  const [providerConfigReady, setProviderConfigReady] = createSignal(false);
   const [messages, setMessages] = createSignal<Message[]>([
     {
       role: "system",
@@ -244,9 +246,9 @@ export function App() {
     }
   }
 
-  const submitPrompt = async (value: string) => {
-    const prompt = value.trim();
-    if (!prompt || busy()) return;
+	  const submitPrompt = async (value: string) => {
+	    const prompt = value.trim();
+	    if (!prompt || busy()) return;
 
 	    // Slash commands for session management. These never hit the provider.
 	    if (prompt.startsWith("/")) {
@@ -256,6 +258,16 @@ export function App() {
 	        reportError(error);
 	      }
 	      return;
+	    }
+
+	    if (!providerConfigReady()) {
+	      setStatus("loading provider config");
+	      try {
+	        await refreshProviderConfig();
+	      } catch (error) {
+	        reportError(error);
+	        return;
+	      }
 	    }
 
     setPromptHistory((prev) => [...prev.filter((entry) => entry !== prompt), prompt].slice(-50));
@@ -445,6 +457,7 @@ export function App() {
       kind: "provider",
       text: `active ${inspected.providerId}/${inspected.model} (${inspected.registry.source})`,
     });
+    setProviderConfigReady(true);
     setStatus(inspected.hasApiKey ? `provider ${inspected.providerId}` : `missing API key for ${inspected.providerId}`);
   }
 
@@ -867,9 +880,9 @@ export function App() {
                     <text content="Up/Down recalls prompt history" fg={palette.textDim} />
                   </box>
                 </Show>
-                <input
-                  focused
-                  placeholder={busy() ? "Request in flight..." : "Type prompt, Enter to send, /help for commands"}
+	                <input
+	                  focused
+	                  placeholder={busy() ? "Request in flight..." : !providerConfigReady() ? "Loading provider config..." : "Type prompt, Enter to send, /help for commands"}
                   value={inputValue()}
                   onInput={setInputValue}
                   onSubmit={handleSubmit}
@@ -956,7 +969,13 @@ function resolveArtifactTarget(entries: ArtifactEntry[], arg: string): ArtifactE
 }
 
 async function loadArtifactPreview(artifact: ArtifactEntry, options: { validate?: boolean } = {}): Promise<SelectedArtifact> {
-  const content = await readFile(join(process.cwd(), artifact.path), "utf8");
+  const result = await executeFileTool(process.cwd(), {
+    id: "artifact-preview",
+    name: "read_file",
+    arguments: JSON.stringify({ path: artifact.path }),
+  });
+  if (!result.ok) throw new Error(result.content);
+  const content = result.content;
   const preview = content.replace(/\s+/g, " ").trim().slice(0, 500) || "(empty)";
   const validation = options.validate ? validateArtifactContent(content) : undefined;
   return { ...artifact, preview, ...(validation ? { validation } : {}) };
@@ -970,11 +989,25 @@ function validateArtifactContent(content: string): string {
 }
 
 function selectArtifactValidators(content: string): string[] {
-  const trimmed = content.trimStart();
-  if (!trimmed.startsWith("---")) return [];
-  if (/^scenario_name:/m.test(trimmed)) return ["scenario-card"];
-  if (/^name:/m.test(trimmed) && /^archetype:/m.test(trimmed)) return ["character-card"];
+  const keys = frontmatterKeys(content);
+  if (keys.size === 0) return [];
+  if (keys.has("scenario_name")) return ["scenario-card"];
+  if (keys.has("name") && keys.has("archetype")) return ["character-card"];
   return ["character-card", "scenario-card"];
+}
+
+function frontmatterKeys(content: string): Set<string> {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("---")) return new Set();
+  const lines = trimmed.split(/\r?\n/);
+  const keys = new Set<string>();
+  for (let index = 1; index < lines.length; index++) {
+    const line = lines[index].trim();
+    if (line === "---") break;
+    const colon = line.indexOf(":");
+    if (colon > 0) keys.add(line.slice(0, colon).trim());
+  }
+  return keys;
 }
 
 function headerLine(provider: string, model: string, status: string, width: number): string {

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -2,7 +2,6 @@ import { createMemo, createSignal, For, Show, onMount } from "solid-js";
 import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid";
 import { readdir, stat } from "node:fs/promises";
 import { join, relative } from "node:path";
-import { inspectConfig } from "../config/env";
 import { inspectProviderConfig, resolveProviderConfig } from "../config/providers";
 import type { ProviderRegistry, ProviderSelection } from "../config/providers";
 import { resolveGate, runPrompt } from "../core/agent-loop/run";
@@ -63,11 +62,10 @@ type SessionPickerState = {
 export function App() {
   const renderer = useRenderer();
   const dimensions = useTerminalDimensions();
-  const config = inspectConfig();
   const [providerRegistry, setProviderRegistry] = createSignal<ProviderRegistry | null>(null);
-  const [activeProvider, setActiveProvider] = createSignal(config.providerId);
-  const [activeModel, setActiveModel] = createSignal(config.model);
-  const [providerHasApiKey, setProviderHasApiKey] = createSignal(config.hasApiKey);
+  const [activeProvider, setActiveProvider] = createSignal("loading");
+  const [activeModel, setActiveModel] = createSignal("loading");
+  const [providerHasApiKey, setProviderHasApiKey] = createSignal(false);
   const [providerConfigReady, setProviderConfigReady] = createSignal(false);
   const [messages, setMessages] = createSignal<Message[]>([
     {
@@ -75,7 +73,7 @@ export function App() {
       content: "Ready. Enter one Prism prompt and press Enter.",
     },
   ]);
-  const [status, setStatus] = createSignal(config.hasApiKey ? "provider configured" : "missing API key");
+  const [status, setStatus] = createSignal("loading provider config");
   const [sessionPath, setSessionPath] = createSignal("no session yet");
   const [sessionId, setSessionId] = createSignal<string | undefined>();
   const [conversation, setConversation] = createSignal<VesicleMessage[]>([]);
@@ -464,9 +462,12 @@ export function App() {
   async function ensureProviderRegistry(): Promise<ProviderRegistry> {
     const existing = providerRegistry();
     if (existing) return existing;
-    const inspected = await inspectProviderConfig(process.cwd(), { provider: activeProvider(), model: activeModel() });
+    const inspected = await inspectProviderConfig(process.cwd());
     setProviderRegistry(inspected.registry);
+    setActiveProvider(inspected.providerId);
+    setActiveModel(inspected.model);
     setProviderHasApiKey(inspected.hasApiKey);
+    setProviderConfigReady(true);
     return inspected.registry;
   }
 
@@ -965,7 +966,7 @@ function resolveArtifactTarget(entries: ArtifactEntry[], arg: string): ArtifactE
   if (!trimmed) return entries[0] ?? null;
   const numeric = Number(trimmed);
   if (Number.isInteger(numeric) && numeric >= 1 && numeric <= entries.length) return entries[numeric - 1];
-  return entries.find((entry) => entry.path === trimmed || entry.path.endsWith(trimmed)) ?? null;
+  return entries.find((entry) => entry.path === trimmed) ?? null;
 }
 
 async function loadArtifactPreview(artifact: ArtifactEntry, options: { validate?: boolean } = {}): Promise<SelectedArtifact> {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -81,4 +81,26 @@ describe("config loading", () => {
       'Provider "local" does not declare model "missing".',
     );
   });
+
+  test("preserves hash characters inside quoted provider config values", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
+    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
+    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+      "default:",
+      "  provider: local",
+      "  model: qwen3",
+      "providers:",
+      "  local:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: http://127.0.0.1:11434/v1",
+      "    apiKey: \"abc#def\"",
+      "    models:",
+      "      - qwen3",
+      "",
+    ].join("\n"));
+
+    const config = await loadConfigForSelection(rootDir);
+
+    expect(config.apiKey).toBe("abc#def");
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { inspectConfig, loadConfig } from "../src/config/env";
+import { loadConfigForSelection, loadProviderRegistry } from "../src/config/providers";
 
 describe("config loading", () => {
   test("loads OpenAI-compatible defaults", () => {
@@ -19,5 +23,62 @@ describe("config loading", () => {
 
     expect(status.hasApiKey).toBe(false);
     expect(status.missing).toContain("VESICLE_API_KEY");
+  });
+
+  test("loads provider registry from .vesicle/providers.yaml", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
+    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
+    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+      "default:",
+      "  provider: deepseek",
+      "  model: deepseek-v4-flash",
+      "providers:",
+      "  deepseek:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: https://api.deepseek.com/v1/",
+      "    apiKeyEnv: DEEPSEEK_API_KEY",
+      "    models:",
+      "      - deepseek-v4-flash",
+      "      - deepseek-reasoner",
+      "  local:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: http://127.0.0.1:11434/v1",
+      "    apiKey: local",
+      "    models:",
+      "      - qwen3",
+      "",
+    ].join("\n"));
+
+    const registry = await loadProviderRegistry(rootDir, { DEEPSEEK_API_KEY: "secret" });
+    const config = await loadConfigForSelection(rootDir, { provider: "deepseek", model: "deepseek-reasoner" }, { DEEPSEEK_API_KEY: "secret" });
+
+    expect(registry.source).toBe("file");
+    expect(registry.providers.map((provider) => provider.id)).toEqual(["deepseek", "local"]);
+    expect(config.providerId).toBe("deepseek");
+    expect(config.baseUrl).toBe("https://api.deepseek.com/v1");
+    expect(config.model).toBe("deepseek-reasoner");
+    expect(config.apiKey).toBe("secret");
+  });
+
+  test("rejects model switches outside the configured provider catalog", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
+    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
+    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+      "default:",
+      "  provider: local",
+      "  model: qwen3",
+      "providers:",
+      "  local:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: http://127.0.0.1:11434/v1",
+      "    apiKey: local",
+      "    models:",
+      "      - qwen3",
+      "",
+    ].join("\n"));
+
+    await expect(loadConfigForSelection(rootDir, { provider: "local", model: "missing" })).rejects.toThrow(
+      'Provider "local" does not declare model "missing".',
+    );
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -43,7 +43,7 @@ describe("config loading", () => {
       "  local:",
       "    protocol: openai-chat-compatible",
       "    baseUrl: http://127.0.0.1:11434/v1",
-      "    apiKey: local",
+      "    apiKeyEnv: LOCAL_OPENAI_COMPAT_API_KEY",
       "    models:",
       "      - qwen3",
       "",
@@ -71,7 +71,7 @@ describe("config loading", () => {
       "  local:",
       "    protocol: openai-chat-compatible",
       "    baseUrl: http://127.0.0.1:11434/v1",
-      "    apiKey: local",
+      "    apiKeyEnv: LOCAL_OPENAI_COMPAT_API_KEY",
       "    models:",
       "      - qwen3",
       "",
@@ -88,19 +88,40 @@ describe("config loading", () => {
     await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
       "default:",
       "  provider: local",
+      "  model: \"qwen#3\"",
+      "providers:",
+      "  local:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: http://127.0.0.1:11434/v1",
+      "    apiKeyEnv: LOCAL_OPENAI_COMPAT_API_KEY",
+      "    models:",
+      "      - \"qwen#3\"",
+      "",
+    ].join("\n"));
+
+    const config = await loadConfigForSelection(rootDir, undefined, { LOCAL_OPENAI_COMPAT_API_KEY: "local" });
+
+    expect(config.model).toBe("qwen#3");
+    expect(config.apiKey).toBe("local");
+  });
+
+  test("rejects inline provider api keys in providers.yaml", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
+    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
+    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+      "default:",
+      "  provider: local",
       "  model: qwen3",
       "providers:",
       "  local:",
       "    protocol: openai-chat-compatible",
       "    baseUrl: http://127.0.0.1:11434/v1",
-      "    apiKey: \"abc#def\"",
+      "    apiKey: local",
       "    models:",
       "      - qwen3",
       "",
     ].join("\n"));
 
-    const config = await loadConfigForSelection(rootDir);
-
-    expect(config.apiKey).toBe("abc#def");
+    await expect(loadProviderRegistry(rootDir)).rejects.toThrow("use apiKeyEnv instead of inline apiKey");
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -25,10 +25,8 @@ describe("config loading", () => {
     expect(status.missing).toContain("VESICLE_API_KEY");
   });
 
-  test("loads provider registry from .vesicle/providers.yaml", async () => {
-    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
-    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
-    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+  test("loads provider registry from the configured global providers file", async () => {
+    const { rootDir, env } = await writeProvidersFile([
       "default:",
       "  provider: deepseek",
       "  model: deepseek-v4-flash",
@@ -47,10 +45,10 @@ describe("config loading", () => {
       "    models:",
       "      - qwen3",
       "",
-    ].join("\n"));
+    ]);
 
-    const registry = await loadProviderRegistry(rootDir, { DEEPSEEK_API_KEY: "secret" });
-    const config = await loadConfigForSelection(rootDir, { provider: "deepseek", model: "deepseek-reasoner" }, { DEEPSEEK_API_KEY: "secret" });
+    const registry = await loadProviderRegistry(rootDir, { ...env, DEEPSEEK_API_KEY: "secret" });
+    const config = await loadConfigForSelection(rootDir, { provider: "deepseek", model: "deepseek-reasoner" }, { ...env, DEEPSEEK_API_KEY: "secret" });
 
     expect(registry.source).toBe("file");
     expect(registry.providers.map((provider) => provider.id)).toEqual(["deepseek", "local"]);
@@ -61,9 +59,7 @@ describe("config loading", () => {
   });
 
   test("rejects model switches outside the configured provider catalog", async () => {
-    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
-    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
-    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+    const { rootDir, env } = await writeProvidersFile([
       "default:",
       "  provider: local",
       "  model: qwen3",
@@ -75,17 +71,15 @@ describe("config loading", () => {
       "    models:",
       "      - qwen3",
       "",
-    ].join("\n"));
+    ]);
 
-    await expect(loadConfigForSelection(rootDir, { provider: "local", model: "missing" })).rejects.toThrow(
+    await expect(loadConfigForSelection(rootDir, { provider: "local", model: "missing" }, env)).rejects.toThrow(
       'Provider "local" does not declare model "missing".',
     );
   });
 
   test("preserves hash characters inside quoted provider config values", async () => {
-    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
-    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
-    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+    const { rootDir, env } = await writeProvidersFile([
       "default:",
       "  provider: local",
       "  model: \"qwen#3\"",
@@ -97,18 +91,16 @@ describe("config loading", () => {
       "    models:",
       "      - \"qwen#3\"",
       "",
-    ].join("\n"));
+    ]);
 
-    const config = await loadConfigForSelection(rootDir, undefined, { LOCAL_OPENAI_COMPAT_API_KEY: "local" });
+    const config = await loadConfigForSelection(rootDir, undefined, { ...env, LOCAL_OPENAI_COMPAT_API_KEY: "local" });
 
     expect(config.model).toBe("qwen#3");
     expect(config.apiKey).toBe("local");
   });
 
   test("rejects inline provider api keys in providers.yaml", async () => {
-    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
-    await mkdir(join(rootDir, ".vesicle"), { recursive: true });
-    await writeFile(join(rootDir, ".vesicle", "providers.yaml"), [
+    const { rootDir, env } = await writeProvidersFile([
       "default:",
       "  provider: local",
       "  model: qwen3",
@@ -120,8 +112,17 @@ describe("config loading", () => {
       "    models:",
       "      - qwen3",
       "",
-    ].join("\n"));
+    ]);
 
-    await expect(loadProviderRegistry(rootDir)).rejects.toThrow("use apiKeyEnv instead of inline apiKey");
+    await expect(loadProviderRegistry(rootDir, env)).rejects.toThrow("use apiKeyEnv instead of inline apiKey");
   });
 });
+
+async function writeProvidersFile(lines: string[]): Promise<{ rootDir: string; env: NodeJS.ProcessEnv }> {
+  const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-config-"));
+  const configDir = join(rootDir, "config");
+  await mkdir(configDir, { recursive: true });
+  const configPath = join(configDir, "providers.yaml");
+  await writeFile(configPath, lines.join("\n"));
+  return { rootDir, env: { VESICLE_PROVIDERS_FILE: configPath } };
+}

--- a/tests/provider-stream.test.ts
+++ b/tests/provider-stream.test.ts
@@ -157,6 +157,7 @@ describe("OpenAI-compatible streaming adapter", () => {
 function streamAdapter() {
   return new OpenAIChatCompatibleAdapter({
     provider: "openai-chat-compatible",
+    providerId: "test",
     baseUrl: "https://provider.test/v1",
     model: "test-model",
     apiKey: "test-key",

--- a/tests/provider-stream.test.ts
+++ b/tests/provider-stream.test.ts
@@ -152,6 +152,18 @@ describe("OpenAI-compatible streaming adapter", () => {
       },
     });
   });
+
+  test("reports the selected provider api key label when credentials are missing", async () => {
+    const adapter = new OpenAIChatCompatibleAdapter({
+      provider: "openai-chat-compatible",
+      providerId: "deepseek",
+      baseUrl: "https://provider.test/v1",
+      model: "test-model",
+      apiKeyLabel: "DEEPSEEK_API_KEY",
+    });
+
+    await expect(adapter.complete(request())).rejects.toThrow("DEEPSEEK_API_KEY is required");
+  });
 });
 
 function streamAdapter() {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -132,6 +132,31 @@ describe("session resume", () => {
     expect(snapshot.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
+  test("loadSessionSnapshot restores the latest provider/model selection", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-provider-session-"));
+    const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-provider");
+
+    await store.append({
+      role: "system",
+      content: "prompt",
+      metadata: { providerId: "deepseek", model: "deepseek-v4-flash" },
+    });
+    await store.append({
+      role: "user",
+      content: "first",
+      metadata: { providerId: "deepseek", model: "deepseek-v4-flash" },
+    });
+    await store.append({
+      role: "user",
+      content: "second",
+      metadata: { providerId: "local", model: "qwen3" },
+    });
+
+    const snapshot = await loadSessionSnapshot(rootDir, "2026-05-01T00-00-00-000Z-provider");
+
+    expect(snapshot.providerSelection).toEqual({ provider: "local", model: "qwen3" });
+  });
+
   test("loadSessionMessages does not synthesise results when tool results already exist", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-answered-"));
     const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-eeeeeeee");

--- a/tests/tui.test.tsx
+++ b/tests/tui.test.tsx
@@ -56,6 +56,31 @@ describe("TUI", () => {
     expect(frame).toContain(">1. Confirm");
   });
 
+  test("renders stop gate markdown summaries instead of raw markdown markers", async () => {
+    const setup = await testRender(() => (
+      <GatePrompt
+        gate={{
+          gate: "blueprint-confirmation",
+          summary: "**Target Concept:** 测试角色\n\n**Archetype:** Mirror",
+        }}
+        focused="confirm"
+        feedbackMode={null}
+        feedback=""
+        onFeedbackInput={() => undefined}
+        width={100}
+        maxSummaryLines={4}
+      />
+    ), { width: 100, height: 10 });
+    await setup.flush();
+    const frame = setup.captureCharFrame();
+    setup.renderer.destroy();
+
+    expect(frame).toContain("Target Concept:");
+    expect(frame).toContain("Archetype:");
+    expect(frame).not.toContain("**Target Concept:**");
+    expect(frame).not.toContain("**Archetype:**");
+  });
+
   test("builds stop gate options as stable single-line labels", () => {
     expect(gateOptionLine(1, "Confirm - proceed to next phase", true)).toBe(">1. Confirm - proceed to next phase");
     expect(gateOptionLine(2, "Revise - tell the engine what to change", false)).toBe(" 2. Revise - tell the engine what to change");

--- a/tests/tui.test.tsx
+++ b/tests/tui.test.tsx
@@ -17,8 +17,8 @@ describe("TUI", () => {
     // Initial system notice should render as plain text (not the old role> prefix).
     expect(frame).toContain("Ready. Enter one Prism");
     expect(frame).not.toContain("system>");
-    // Input bar present.
-    expect(frame).toContain("Type prompt, Enter to send");
+    // Input bar present; provider registry loads asynchronously before the first send.
+    expect(frame).toContain("Loading provider config");
   });
 
   test("renders the activity pane only when the terminal is wide enough", async () => {


### PR DESCRIPTION
## Summary

- Add `.vesicle/providers.yaml` provider/model registry for multiple OpenAI-compatible provider profiles, with environment fallback compatibility.
- Add TUI provider/model commands: `/providers`, `/models`, `/use`, and `/model`, with session metadata persistence and resume restoration.
- Add artifact workbench commands: `/artifacts`, `/artifact`, `/validate`, and `/revise`, with selected artifact preview and validation against file contents on disk.
- Update doctor output, README/STATUS/STYLE/CHANGELOG, and add `docs/examples/providers.yaml`.

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run doctor`

## Notes / Follow-ups

- Native Anthropic Messages, Gemini, and OpenAI Responses adapters remain deferred; this PR stabilizes the provider registry and session switching surface first.
- TUI command handling is now large enough to split in a follow-up refactor, but kept in one file here to minimize behavior fan-out.