### PR TITLE
refactor(provider): split OpenAI chat backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ project follows Semantic Versioning once releases begin.
   provider-stream error, retries without OpenAI-specific `stream_options` for
   stricter compatible providers, and preserves the final assistant turn in the
   in-memory conversation history.
+- OpenAI-compatible reasoning responses now preserve provider
+  `reasoning_content` through non-streaming, streaming, tool-loop follow-up
+  requests, and session resume so reasoning models can use tools without losing
+  required thinking context.
 - TUI provider/model switches now resolve API-key availability through the
   user-level provider `.env`, so `/use`, `/model`, and session resume do not
   incorrectly show "API key: missing" when the selected key is stored there.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ project follows Semantic Versioning once releases begin.
 - Added a rapid-development workflow exception that treats `develop` as the
   active trunk for low-risk internal iteration while preserving PR/CR flow for
   high-risk or release-bound work.
+- Split the OpenAI-compatible provider backend into request shaping, response
+  parsing, streaming, wire types, and structured provider errors to harden the
+  transport foundation before adding more protocols.
 - Provider configuration now requires the user-level `providers.yaml`; Vesicle
   no longer falls back to a single `VESICLE_API_KEY` environment configuration
   when that file is missing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ project follows Semantic Versioning once releases begin.
   provider-stream error, retries without OpenAI-specific `stream_options` for
   stricter compatible providers, and preserves the final assistant turn in the
   in-memory conversation history.
+- OpenAI-compatible streamed tool-call names now keep the latest provider value
+  instead of concatenating repeated `function.name` deltas, avoiding duplicated
+  names from non-conformant streams.
 - OpenAI-compatible reasoning responses now preserve provider
   `reasoning_content` through non-streaming, streaming, tool-loop follow-up
   requests, and session resume so reasoning models can use tools without losing

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -243,6 +243,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
     messages.push({
       role: "assistant",
       content: response.content,
+      ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
       toolCalls,
     });
     await session.append({
@@ -251,6 +252,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
       metadata: {
         providerResponseId: response.id,
         finishReason: response.finishReason,
+        ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
         toolCalls,
       },
     });
@@ -362,12 +364,17 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
 
   const finalResponseHasToolCalls = (response.toolCalls?.length ?? 0) > 0;
   if (!finalResponseHasToolCalls) {
-    messages.push({ role: "assistant", content: response.content });
+    messages.push({
+      role: "assistant",
+      content: response.content,
+      ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
+    });
     await session.append({
       role: "assistant",
       content: response.content,
       metadata: {
         providerResponseId: response.id,
+        ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
         usage: response.usage,
       },
     });
@@ -418,6 +425,8 @@ async function completeWithStreaming(
     switch (event.type) {
       case "content_delta":
         onEvent?.({ type: "assistant_delta", delta: event.delta });
+        break;
+      case "reasoning_delta":
         break;
       case "tool_call_delta":
         onEvent?.({

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -148,6 +148,7 @@ export async function listSessions(rootDir = process.cwd()): Promise<SessionSumm
 export type ResumedMessage = {
   role: "user" | "assistant" | "tool";
   content: string;
+  reasoningContent?: string;
   toolCallId?: string;
   toolCalls?: ResumedToolCall[];
 };
@@ -204,9 +205,11 @@ export async function loadSessionSnapshot(
 
     if (record.role === "assistant") {
       const toolCalls = record.metadata?.toolCalls as ResumedToolCall[] | undefined;
+      const reasoningContent = record.metadata?.reasoningContent as string | undefined;
       messages.push({
         role: "assistant",
         content: record.content,
+        ...(reasoningContent ? { reasoningContent } : {}),
         ...(toolCalls ? { toolCalls } : {}),
       });
       continue;

--- a/src/providers/openai-chat/adapter.ts
+++ b/src/providers/openai-chat/adapter.ts
@@ -25,7 +25,7 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
       });
     }
 
-    return responseFromChatCompletionBody(body, request.id);
+    return responseFromChatCompletionBody(body, request.id, this.config.providerId);
   }
 
   async *stream(request: VesicleRequest): AsyncIterable<ProviderStreamEvent> {
@@ -52,11 +52,11 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
     }
     if (streamResponse.headers.get("content-type")?.includes("application/json")) {
       const body = await streamResponse.json().catch(() => undefined) as ChatCompletionResponse | undefined;
-      yield { type: "complete", response: responseFromChatCompletionBody(body, request.id) };
+      yield { type: "complete", response: responseFromChatCompletionBody(body, request.id, this.config.providerId) };
       return;
     }
 
-    yield* readChatCompletionStream(streamResponse, request.id);
+    yield* readChatCompletionStream(streamResponse, request.id, this.config.providerId);
   }
 
   private fetchChatCompletion(request: VesicleRequest, stream: boolean, includeUsage: boolean): Promise<Response> {

--- a/src/providers/openai-chat/adapter.ts
+++ b/src/providers/openai-chat/adapter.ts
@@ -1,60 +1,10 @@
 import type { VesicleConfig } from "../../config/env";
+import { ProviderError } from "../shared/errors";
 import type { ProviderAdapter, ProviderStreamEvent, VesicleRequest, VesicleResponse } from "../shared/types";
-
-type ChatCompletionChoice = {
-  finish_reason?: string | null;
-  message?: {
-    content?: string | null;
-    tool_calls?: Array<{
-      id: string;
-      type: "function";
-      function: {
-        name: string;
-        arguments: string;
-      };
-    }>;
-  };
-};
-
-type ChatCompletionResponse = {
-  id?: string;
-  choices?: ChatCompletionChoice[];
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-  };
-  error?: {
-    message?: string;
-  };
-};
-
-type ChatCompletionStreamChunk = {
-  id?: string;
-  choices?: Array<{
-    finish_reason?: string | null;
-    delta?: {
-      content?: string | null;
-      tool_calls?: Array<{
-        index: number;
-        id?: string;
-        type?: "function";
-        function?: {
-          name?: string;
-          arguments?: string;
-        };
-      }>;
-    };
-  }>;
-  usage?: {
-    prompt_tokens?: number;
-    completion_tokens?: number;
-    total_tokens?: number;
-  };
-  error?: {
-    message?: string;
-  };
-};
+import { toChatCompletionBody } from "./request";
+import { readProviderErrorMessage, responseFromChatCompletionBody } from "./response";
+import { isRetryableStreamRequestFailure, readChatCompletionStream } from "./stream";
+import type { ChatCompletionResponse } from "./types";
 
 export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
   readonly id = "openai-chat-compatible";
@@ -62,32 +12,24 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
   constructor(private readonly config: VesicleConfig) {}
 
   async complete(request: VesicleRequest): Promise<VesicleResponse> {
-    if (!this.config.apiKey) {
-      throw new Error(`${this.config.apiKeyLabel ?? "provider API key"} is required before making a provider request.`);
-    }
+    this.requireApiKey();
 
-    const response = await fetch(`${this.config.baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${this.config.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(toChatCompletionBody(request, false)),
-    });
-
+    const response = await this.fetchChatCompletion(request, false, false);
     const body = await response.json().catch(() => undefined) as ChatCompletionResponse | undefined;
     if (!response.ok) {
       const providerMessage = body?.error?.message ?? response.statusText;
-      throw new Error(`Provider request failed (${response.status}): ${providerMessage}`);
+      throw new ProviderError(`Provider request failed (${response.status}): ${providerMessage}`, {
+        kind: "http_error",
+        providerId: this.config.providerId,
+        status: response.status,
+      });
     }
 
     return responseFromChatCompletionBody(body, request.id);
   }
 
   async *stream(request: VesicleRequest): AsyncIterable<ProviderStreamEvent> {
-    if (!this.config.apiKey) {
-      throw new Error(`${this.config.apiKeyLabel ?? "provider API key"} is required before making a provider request.`);
-    }
+    this.requireApiKey();
 
     const response = await this.fetchChatCompletion(request, true, true);
     const retryWithoutStreamOptions = !response.ok && isRetryableStreamRequestFailure(response.status);
@@ -102,10 +44,11 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
 
     if (!streamResponse.ok) {
       const providerMessage = await readProviderErrorMessage(streamResponse);
-      throw new Error(`Provider request failed (${streamResponse.status}): ${providerMessage}`);
-    }
-    if (!streamResponse.body) {
-      throw new Error("Provider streaming response did not include a body.");
+      throw new ProviderError(`Provider request failed (${streamResponse.status}): ${providerMessage}`, {
+        kind: "http_error",
+        providerId: this.config.providerId,
+        status: streamResponse.status,
+      });
     }
     if (streamResponse.headers.get("content-type")?.includes("application/json")) {
       const body = await streamResponse.json().catch(() => undefined) as ChatCompletionResponse | undefined;
@@ -113,27 +56,7 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
       return;
     }
 
-    const state = createStreamAccumulator(request.id);
-    let sawDone = false;
-    for await (const payload of readSseData(streamResponse.body)) {
-      if (payload === "[DONE]") {
-        sawDone = true;
-        break;
-      }
-      const chunk = parseStreamChunk(payload);
-      if (chunk.error?.message) {
-        throw new Error(`Provider stream failed: ${chunk.error.message}`);
-      }
-      for (const event of absorbStreamChunk(state, chunk)) {
-        yield event;
-      }
-    }
-    if (!sawDone) {
-      throw new Error("Provider stream ended before [DONE].");
-    }
-
-    const final = finalizeStream(state);
-    yield { type: "complete", response: final };
+    yield* readChatCompletionStream(streamResponse, request.id);
   }
 
   private fetchChatCompletion(request: VesicleRequest, stream: boolean, includeUsage: boolean): Promise<Response> {
@@ -146,207 +69,12 @@ export class OpenAIChatCompatibleAdapter implements ProviderAdapter {
       body: JSON.stringify(toChatCompletionBody(request, stream, includeUsage)),
     });
   }
-}
 
-function responseFromChatCompletionBody(body: ChatCompletionResponse | undefined, fallbackId: string): VesicleResponse {
-  const choice = body?.choices?.[0];
-  const content = choice?.message?.content ?? "";
-  const toolCalls = choice?.message?.tool_calls?.map((toolCall) => ({
-    id: toolCall.id,
-    name: toolCall.function.name,
-    arguments: toolCall.function.arguments,
-  }));
-
-  if (!content && (!toolCalls || toolCalls.length === 0)) {
-    throw new Error("Provider response did not include assistant content or tool calls.");
-  }
-
-  return {
-    id: body?.id ?? fallbackId,
-    content,
-    toolCalls,
-    finishReason: choice?.finish_reason ?? undefined,
-    raw: body,
-    usage: {
-      inputTokens: body?.usage?.prompt_tokens,
-      outputTokens: body?.usage?.completion_tokens,
-      totalTokens: body?.usage?.total_tokens,
-    },
-  };
-}
-
-async function readProviderErrorMessage(response: Response): Promise<string> {
-  const body = await response.json().catch(() => undefined) as ChatCompletionResponse | undefined;
-  return body?.error?.message ?? response.statusText;
-}
-
-function isRetryableStreamRequestFailure(status: number): boolean {
-  return status === 400 || status === 404 || status === 422;
-}
-
-function toChatCompletionBody(request: VesicleRequest, stream: boolean, includeUsage = false): Record<string, unknown> {
-  return {
-    model: request.model.model,
-    messages: [
-      ...request.system.map((content) => ({ role: "system", content })),
-      ...request.messages.map((message) => {
-        if (message.role === "tool") {
-          return {
-            role: "tool",
-            tool_call_id: message.toolCallId,
-            content: message.content,
-          };
-        }
-
-        if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
-          return {
-            role: "assistant",
-            content: message.content || null,
-            tool_calls: message.toolCalls.map((call) => ({
-              id: call.id,
-              type: "function",
-              function: {
-                name: call.name,
-                arguments: call.arguments,
-              },
-            })),
-          };
-        }
-
-        return {
-          role: message.role,
-          content: message.content,
-        };
-      }),
-    ],
-    tools: request.tools && request.tools.length > 0 ? request.tools : undefined,
-    tool_choice: request.tools && request.tools.length > 0 ? "auto" : undefined,
-    temperature: request.generation?.temperature ?? 0.7,
-    max_tokens: request.generation?.maxTokens,
-    stream,
-    stream_options: stream && includeUsage ? { include_usage: true } : undefined,
-  };
-}
-
-type StreamAccumulator = {
-  id: string;
-  content: string;
-  finishReason?: string;
-  toolCalls: Map<number, { index: number; id?: string; name?: string; arguments: string }>;
-  usage?: VesicleResponse["usage"];
-};
-
-function createStreamAccumulator(fallbackId: string): StreamAccumulator {
-  return {
-    id: fallbackId,
-    content: "",
-    toolCalls: new Map(),
-  };
-}
-
-function absorbStreamChunk(state: StreamAccumulator, chunk: ChatCompletionStreamChunk): ProviderStreamEvent[] {
-  const events: ProviderStreamEvent[] = [];
-  if (chunk.id) state.id = chunk.id;
-  if (chunk.usage) {
-    state.usage = {
-      inputTokens: chunk.usage.prompt_tokens,
-      outputTokens: chunk.usage.completion_tokens,
-      totalTokens: chunk.usage.total_tokens,
-    };
-  }
-
-  const choice = chunk.choices?.[0];
-  if (!choice) return events;
-  if (choice.finish_reason) state.finishReason = choice.finish_reason;
-
-  const contentDelta = choice.delta?.content ?? "";
-  if (contentDelta) {
-    state.content += contentDelta;
-    events.push({ type: "content_delta", delta: contentDelta });
-  }
-
-  for (const delta of choice.delta?.tool_calls ?? []) {
-    const current = state.toolCalls.get(delta.index) ?? { index: delta.index, arguments: "" };
-    if (delta.id) current.id = delta.id;
-    if (delta.function?.name) current.name = `${current.name ?? ""}${delta.function.name}`;
-    if (delta.function?.arguments) current.arguments += delta.function.arguments;
-    state.toolCalls.set(delta.index, current);
-    events.push({
-      type: "tool_call_delta",
-      index: delta.index,
-      id: delta.id,
-      name: delta.function?.name,
-      argumentsDelta: delta.function?.arguments,
+  private requireApiKey(): void {
+    if (this.config.apiKey) return;
+    throw new ProviderError(`${this.config.apiKeyLabel ?? "provider API key"} is required before making a provider request.`, {
+      kind: "missing_credentials",
+      providerId: this.config.providerId,
     });
   }
-
-  return events;
-}
-
-function finalizeStream(state: StreamAccumulator): VesicleResponse {
-  const toolCalls = [...state.toolCalls.entries()]
-    .sort(([a], [b]) => a - b)
-    .map(([, call]) => ({
-      id: call.id ?? `call_${call.index}`,
-      name: call.name ?? "",
-      arguments: call.arguments,
-    }))
-    .filter((call) => call.name);
-
-  if (!state.content && toolCalls.length === 0) {
-    throw new Error("Provider response did not include assistant content or tool calls.");
-  }
-
-  return {
-    id: state.id,
-    content: state.content,
-    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    finishReason: state.finishReason,
-    usage: state.usage,
-  };
-}
-
-async function* readSseData(body: ReadableStream<Uint8Array>): AsyncIterable<string> {
-  const reader = body.getReader();
-  const decoder = new TextDecoder();
-  let buffer = "";
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      const parts = buffer.split(/\r?\n\r?\n/);
-      buffer = parts.pop() ?? "";
-      for (const part of parts) {
-        const data = parseSseDataBlock(part);
-        if (data) yield data;
-      }
-    }
-
-    buffer += decoder.decode();
-    const trailing = parseSseDataBlock(buffer);
-    if (trailing) yield trailing;
-  } finally {
-    reader.releaseLock();
-  }
-}
-
-function parseStreamChunk(payload: string): ChatCompletionStreamChunk {
-  try {
-    return JSON.parse(payload) as ChatCompletionStreamChunk;
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    throw new Error(`Provider stream delivered unparseable data: ${detail}`);
-  }
-}
-
-function parseSseDataBlock(block: string): string | undefined {
-  const lines = block.split(/\r?\n/);
-  const dataLines = lines
-    .map((line) => line.trimEnd())
-    .filter((line) => line.startsWith("data:"))
-    .map((line) => line.slice("data:".length).trimStart());
-  if (dataLines.length === 0) return undefined;
-  return dataLines.join("\n");
 }

--- a/src/providers/openai-chat/request.ts
+++ b/src/providers/openai-chat/request.ts
@@ -19,6 +19,7 @@ export function toChatCompletionBody(request: VesicleRequest, stream: boolean, i
           return {
             role: "assistant",
             content: message.content || null,
+            ...(message.reasoningContent ? { reasoning_content: message.reasoningContent } : {}),
             tool_calls: message.toolCalls.map((call) => ({
               id: call.id,
               type: "function",
@@ -30,10 +31,14 @@ export function toChatCompletionBody(request: VesicleRequest, stream: boolean, i
           };
         }
 
-        return {
+        const body: Record<string, unknown> = {
           role: message.role,
           content: message.content,
         };
+        if (message.role === "assistant" && message.reasoningContent) {
+          body.reasoning_content = message.reasoningContent;
+        }
+        return body;
       }),
     ],
     tools: hasTools ? request.tools : undefined,

--- a/src/providers/openai-chat/request.ts
+++ b/src/providers/openai-chat/request.ts
@@ -1,0 +1,46 @@
+import type { VesicleRequest } from "../shared/types";
+
+export function toChatCompletionBody(request: VesicleRequest, stream: boolean, includeUsage = false): Record<string, unknown> {
+  const hasTools = Boolean(request.tools && request.tools.length > 0);
+  return {
+    model: request.model.model,
+    messages: [
+      ...request.system.map((content) => ({ role: "system", content })),
+      ...request.messages.map((message) => {
+        if (message.role === "tool") {
+          return {
+            role: "tool",
+            tool_call_id: message.toolCallId,
+            content: message.content,
+          };
+        }
+
+        if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
+          return {
+            role: "assistant",
+            content: message.content || null,
+            tool_calls: message.toolCalls.map((call) => ({
+              id: call.id,
+              type: "function",
+              function: {
+                name: call.name,
+                arguments: call.arguments,
+              },
+            })),
+          };
+        }
+
+        return {
+          role: message.role,
+          content: message.content,
+        };
+      }),
+    ],
+    tools: hasTools ? request.tools : undefined,
+    tool_choice: hasTools ? "auto" : undefined,
+    temperature: request.generation?.temperature ?? 0.7,
+    max_tokens: request.generation?.maxTokens,
+    stream,
+    stream_options: stream && includeUsage ? { include_usage: true } : undefined,
+  };
+}

--- a/src/providers/openai-chat/response.ts
+++ b/src/providers/openai-chat/response.ts
@@ -5,6 +5,7 @@ import type { ChatCompletionResponse } from "./types";
 export function responseFromChatCompletionBody(body: ChatCompletionResponse | undefined, fallbackId: string): VesicleResponse {
   const choice = body?.choices?.[0];
   const content = choice?.message?.content ?? "";
+  const reasoningContent = choice?.message?.reasoning_content ?? undefined;
   const toolCalls = choice?.message?.tool_calls?.map((toolCall) => ({
     id: toolCall.id,
     name: toolCall.function.name,
@@ -20,6 +21,7 @@ export function responseFromChatCompletionBody(body: ChatCompletionResponse | un
   return {
     id: body?.id ?? fallbackId,
     content,
+    ...(reasoningContent ? { reasoningContent } : {}),
     toolCalls,
     finishReason: choice?.finish_reason ?? undefined,
     raw: body,

--- a/src/providers/openai-chat/response.ts
+++ b/src/providers/openai-chat/response.ts
@@ -1,0 +1,37 @@
+import { ProviderError } from "../shared/errors";
+import type { VesicleResponse } from "../shared/types";
+import type { ChatCompletionResponse } from "./types";
+
+export function responseFromChatCompletionBody(body: ChatCompletionResponse | undefined, fallbackId: string): VesicleResponse {
+  const choice = body?.choices?.[0];
+  const content = choice?.message?.content ?? "";
+  const toolCalls = choice?.message?.tool_calls?.map((toolCall) => ({
+    id: toolCall.id,
+    name: toolCall.function.name,
+    arguments: toolCall.function.arguments,
+  }));
+
+  if (!content && (!toolCalls || toolCalls.length === 0)) {
+    throw new ProviderError("Provider response did not include assistant content or tool calls.", {
+      kind: "malformed_response",
+    });
+  }
+
+  return {
+    id: body?.id ?? fallbackId,
+    content,
+    toolCalls,
+    finishReason: choice?.finish_reason ?? undefined,
+    raw: body,
+    usage: {
+      inputTokens: body?.usage?.prompt_tokens,
+      outputTokens: body?.usage?.completion_tokens,
+      totalTokens: body?.usage?.total_tokens,
+    },
+  };
+}
+
+export async function readProviderErrorMessage(response: Response): Promise<string> {
+  const body = await response.json().catch(() => undefined) as ChatCompletionResponse | undefined;
+  return body?.error?.message ?? response.statusText;
+}

--- a/src/providers/openai-chat/response.ts
+++ b/src/providers/openai-chat/response.ts
@@ -2,7 +2,11 @@ import { ProviderError } from "../shared/errors";
 import type { VesicleResponse } from "../shared/types";
 import type { ChatCompletionResponse } from "./types";
 
-export function responseFromChatCompletionBody(body: ChatCompletionResponse | undefined, fallbackId: string): VesicleResponse {
+export function responseFromChatCompletionBody(
+  body: ChatCompletionResponse | undefined,
+  fallbackId: string,
+  providerId?: string,
+): VesicleResponse {
   const choice = body?.choices?.[0];
   const content = choice?.message?.content ?? "";
   const reasoningContent = choice?.message?.reasoning_content ?? undefined;
@@ -15,6 +19,7 @@ export function responseFromChatCompletionBody(body: ChatCompletionResponse | un
   if (!content && (!toolCalls || toolCalls.length === 0)) {
     throw new ProviderError("Provider response did not include assistant content or tool calls.", {
       kind: "malformed_response",
+      providerId,
     });
   }
 

--- a/src/providers/openai-chat/stream.ts
+++ b/src/providers/openai-chat/stream.ts
@@ -73,7 +73,7 @@ function absorbStreamChunk(state: StreamAccumulator, chunk: ChatCompletionStream
   for (const delta of choice.delta?.tool_calls ?? []) {
     const current = state.toolCalls.get(delta.index) ?? { index: delta.index, arguments: "" };
     if (delta.id) current.id = delta.id;
-    if (delta.function?.name) current.name = `${current.name ?? ""}${delta.function.name}`;
+    if (delta.function?.name) current.name = delta.function.name;
     if (delta.function?.arguments) current.arguments += delta.function.arguments;
     state.toolCalls.set(delta.index, current);
     events.push({
@@ -135,7 +135,12 @@ export async function* readSseData(body: ReadableStream<Uint8Array>): AsyncItera
     const trailing = parseSseDataBlock(buffer);
     if (trailing) yield trailing;
   } finally {
-    reader.releaseLock();
+    try {
+      reader.releaseLock();
+    } catch {
+      // Streams that error can auto-release the reader lock; preserve the
+      // original stream failure instead of replacing it with a release error.
+    }
   }
 }
 

--- a/src/providers/openai-chat/stream.ts
+++ b/src/providers/openai-chat/stream.ts
@@ -1,0 +1,162 @@
+import { ProviderError } from "../shared/errors";
+import type { ProviderStreamEvent, VesicleResponse } from "../shared/types";
+import type { ChatCompletionStreamChunk } from "./types";
+
+type StreamAccumulator = {
+  id: string;
+  content: string;
+  finishReason?: string;
+  toolCalls: Map<number, { index: number; id?: string; name?: string; arguments: string }>;
+  usage?: VesicleResponse["usage"];
+};
+
+export function isRetryableStreamRequestFailure(status: number): boolean {
+  return status === 400 || status === 404 || status === 422;
+}
+
+export async function* readChatCompletionStream(response: Response, fallbackId: string): AsyncIterable<ProviderStreamEvent> {
+  if (!response.body) {
+    throw new ProviderError("Provider streaming response did not include a body.", { kind: "stream_error" });
+  }
+
+  const state = createStreamAccumulator(fallbackId);
+  let sawDone = false;
+  for await (const payload of readSseData(response.body)) {
+    if (payload === "[DONE]") {
+      sawDone = true;
+      break;
+    }
+    const chunk = parseStreamChunk(payload);
+    if (chunk.error?.message) {
+      throw new ProviderError(`Provider stream failed: ${chunk.error.message}`, { kind: "stream_error" });
+    }
+    for (const event of absorbStreamChunk(state, chunk)) {
+      yield event;
+    }
+  }
+  if (!sawDone) {
+    throw new ProviderError("Provider stream ended before [DONE].", { kind: "stream_error" });
+  }
+
+  yield { type: "complete", response: finalizeStream(state) };
+}
+
+function createStreamAccumulator(fallbackId: string): StreamAccumulator {
+  return {
+    id: fallbackId,
+    content: "",
+    toolCalls: new Map(),
+  };
+}
+
+function absorbStreamChunk(state: StreamAccumulator, chunk: ChatCompletionStreamChunk): ProviderStreamEvent[] {
+  const events: ProviderStreamEvent[] = [];
+  if (chunk.id) state.id = chunk.id;
+  if (chunk.usage) {
+    state.usage = {
+      inputTokens: chunk.usage.prompt_tokens,
+      outputTokens: chunk.usage.completion_tokens,
+      totalTokens: chunk.usage.total_tokens,
+    };
+  }
+
+  const choice = chunk.choices?.[0];
+  if (!choice) return events;
+  if (choice.finish_reason) state.finishReason = choice.finish_reason;
+
+  const contentDelta = choice.delta?.content ?? "";
+  if (contentDelta) {
+    state.content += contentDelta;
+    events.push({ type: "content_delta", delta: contentDelta });
+  }
+
+  for (const delta of choice.delta?.tool_calls ?? []) {
+    const current = state.toolCalls.get(delta.index) ?? { index: delta.index, arguments: "" };
+    if (delta.id) current.id = delta.id;
+    if (delta.function?.name) current.name = `${current.name ?? ""}${delta.function.name}`;
+    if (delta.function?.arguments) current.arguments += delta.function.arguments;
+    state.toolCalls.set(delta.index, current);
+    events.push({
+      type: "tool_call_delta",
+      index: delta.index,
+      id: delta.id,
+      name: delta.function?.name,
+      argumentsDelta: delta.function?.arguments,
+    });
+  }
+
+  return events;
+}
+
+function finalizeStream(state: StreamAccumulator): VesicleResponse {
+  const toolCalls = [...state.toolCalls.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, call]) => ({
+      id: call.id ?? `call_${call.index}`,
+      name: call.name ?? "",
+      arguments: call.arguments,
+    }))
+    .filter((call) => call.name);
+
+  if (!state.content && toolCalls.length === 0) {
+    throw new ProviderError("Provider response did not include assistant content or tool calls.", {
+      kind: "malformed_response",
+    });
+  }
+
+  return {
+    id: state.id,
+    content: state.content,
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    finishReason: state.finishReason,
+    usage: state.usage,
+  };
+}
+
+export async function* readSseData(body: ReadableStream<Uint8Array>): AsyncIterable<string> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split(/\r?\n\r?\n/);
+      buffer = parts.pop() ?? "";
+      for (const part of parts) {
+        const data = parseSseDataBlock(part);
+        if (data) yield data;
+      }
+    }
+
+    buffer += decoder.decode();
+    const trailing = parseSseDataBlock(buffer);
+    if (trailing) yield trailing;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseStreamChunk(payload: string): ChatCompletionStreamChunk {
+  try {
+    return JSON.parse(payload) as ChatCompletionStreamChunk;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ProviderError(`Provider stream delivered unparseable data: ${detail}`, {
+      kind: "malformed_response",
+      cause: error,
+    });
+  }
+}
+
+function parseSseDataBlock(block: string): string | undefined {
+  const lines = block.split(/\r?\n/);
+  const dataLines = lines
+    .map((line) => line.trimEnd())
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice("data:".length).trimStart());
+  if (dataLines.length === 0) return undefined;
+  return dataLines.join("\n");
+}

--- a/src/providers/openai-chat/stream.ts
+++ b/src/providers/openai-chat/stream.ts
@@ -15,9 +15,13 @@ export function isRetryableStreamRequestFailure(status: number): boolean {
   return status === 400 || status === 404 || status === 422;
 }
 
-export async function* readChatCompletionStream(response: Response, fallbackId: string): AsyncIterable<ProviderStreamEvent> {
+export async function* readChatCompletionStream(
+  response: Response,
+  fallbackId: string,
+  providerId?: string,
+): AsyncIterable<ProviderStreamEvent> {
   if (!response.body) {
-    throw new ProviderError("Provider streaming response did not include a body.", { kind: "stream_error" });
+    throw new ProviderError("Provider streaming response did not include a body.", { kind: "stream_error", providerId });
   }
 
   const state = createStreamAccumulator(fallbackId);
@@ -27,19 +31,19 @@ export async function* readChatCompletionStream(response: Response, fallbackId: 
       sawDone = true;
       break;
     }
-    const chunk = parseStreamChunk(payload);
+    const chunk = parseStreamChunk(payload, providerId);
     if (chunk.error?.message) {
-      throw new ProviderError(`Provider stream failed: ${chunk.error.message}`, { kind: "stream_error" });
+      throw new ProviderError(`Provider stream failed: ${chunk.error.message}`, { kind: "stream_error", providerId });
     }
     for (const event of absorbStreamChunk(state, chunk)) {
       yield event;
     }
   }
   if (!sawDone) {
-    throw new ProviderError("Provider stream ended before [DONE].", { kind: "stream_error" });
+    throw new ProviderError("Provider stream ended before [DONE].", { kind: "stream_error", providerId });
   }
 
-  yield { type: "complete", response: finalizeStream(state) };
+  yield { type: "complete", response: finalizeStream(state, providerId) };
 }
 
 function createStreamAccumulator(fallbackId: string): StreamAccumulator {
@@ -96,7 +100,7 @@ function absorbStreamChunk(state: StreamAccumulator, chunk: ChatCompletionStream
   return events;
 }
 
-function finalizeStream(state: StreamAccumulator): VesicleResponse {
+function finalizeStream(state: StreamAccumulator, providerId?: string): VesicleResponse {
   const toolCalls = [...state.toolCalls.entries()]
     .sort(([a], [b]) => a - b)
     .map(([, call]) => ({
@@ -109,6 +113,7 @@ function finalizeStream(state: StreamAccumulator): VesicleResponse {
   if (!state.content && toolCalls.length === 0) {
     throw new ProviderError("Provider response did not include assistant content or tool calls.", {
       kind: "malformed_response",
+      providerId,
     });
   }
 
@@ -122,7 +127,7 @@ function finalizeStream(state: StreamAccumulator): VesicleResponse {
   };
 }
 
-export async function* readSseData(body: ReadableStream<Uint8Array>): AsyncIterable<string> {
+async function* readSseData(body: ReadableStream<Uint8Array>): AsyncIterable<string> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
@@ -153,13 +158,14 @@ export async function* readSseData(body: ReadableStream<Uint8Array>): AsyncItera
   }
 }
 
-function parseStreamChunk(payload: string): ChatCompletionStreamChunk {
+function parseStreamChunk(payload: string, providerId?: string): ChatCompletionStreamChunk {
   try {
     return JSON.parse(payload) as ChatCompletionStreamChunk;
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new ProviderError(`Provider stream delivered unparseable data: ${detail}`, {
       kind: "malformed_response",
+      providerId,
       cause: error,
     });
   }

--- a/src/providers/openai-chat/stream.ts
+++ b/src/providers/openai-chat/stream.ts
@@ -5,6 +5,7 @@ import type { ChatCompletionStreamChunk } from "./types";
 type StreamAccumulator = {
   id: string;
   content: string;
+  reasoningContent: string;
   finishReason?: string;
   toolCalls: Map<number, { index: number; id?: string; name?: string; arguments: string }>;
   usage?: VesicleResponse["usage"];
@@ -45,6 +46,7 @@ function createStreamAccumulator(fallbackId: string): StreamAccumulator {
   return {
     id: fallbackId,
     content: "",
+    reasoningContent: "",
     toolCalls: new Map(),
   };
 }
@@ -68,6 +70,12 @@ function absorbStreamChunk(state: StreamAccumulator, chunk: ChatCompletionStream
   if (contentDelta) {
     state.content += contentDelta;
     events.push({ type: "content_delta", delta: contentDelta });
+  }
+
+  const reasoningDelta = choice.delta?.reasoning_content ?? "";
+  if (reasoningDelta) {
+    state.reasoningContent += reasoningDelta;
+    events.push({ type: "reasoning_delta", delta: reasoningDelta });
   }
 
   for (const delta of choice.delta?.tool_calls ?? []) {
@@ -107,6 +115,7 @@ function finalizeStream(state: StreamAccumulator): VesicleResponse {
   return {
     id: state.id,
     content: state.content,
+    ...(state.reasoningContent ? { reasoningContent: state.reasoningContent } : {}),
     toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
     finishReason: state.finishReason,
     usage: state.usage,

--- a/src/providers/openai-chat/types.ts
+++ b/src/providers/openai-chat/types.ts
@@ -2,6 +2,7 @@ export type ChatCompletionChoice = {
   finish_reason?: string | null;
   message?: {
     content?: string | null;
+    reasoning_content?: string | null;
     tool_calls?: Array<{
       id: string;
       type: "function";
@@ -32,6 +33,7 @@ export type ChatCompletionStreamChunk = {
     finish_reason?: string | null;
     delta?: {
       content?: string | null;
+      reasoning_content?: string | null;
       tool_calls?: Array<{
         index: number;
         id?: string;

--- a/src/providers/openai-chat/types.ts
+++ b/src/providers/openai-chat/types.ts
@@ -1,0 +1,54 @@
+export type ChatCompletionChoice = {
+  finish_reason?: string | null;
+  message?: {
+    content?: string | null;
+    tool_calls?: Array<{
+      id: string;
+      type: "function";
+      function: {
+        name: string;
+        arguments: string;
+      };
+    }>;
+  };
+};
+
+export type ChatCompletionResponse = {
+  id?: string;
+  choices?: ChatCompletionChoice[];
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: {
+    message?: string;
+  };
+};
+
+export type ChatCompletionStreamChunk = {
+  id?: string;
+  choices?: Array<{
+    finish_reason?: string | null;
+    delta?: {
+      content?: string | null;
+      tool_calls?: Array<{
+        index: number;
+        id?: string;
+        type?: "function";
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+  }>;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    total_tokens?: number;
+  };
+  error?: {
+    message?: string;
+  };
+};

--- a/src/providers/shared/errors.ts
+++ b/src/providers/shared/errors.ts
@@ -1,0 +1,29 @@
+export type ProviderErrorKind =
+  | "missing_credentials"
+  | "http_error"
+  | "stream_error"
+  | "malformed_response";
+
+export type ProviderErrorOptions = {
+  kind: ProviderErrorKind;
+  providerId?: string;
+  status?: number;
+  retryable?: boolean;
+  cause?: unknown;
+};
+
+export class ProviderError extends Error {
+  readonly kind: ProviderErrorKind;
+  readonly providerId?: string;
+  readonly status?: number;
+  readonly retryable: boolean;
+
+  constructor(message: string, options: ProviderErrorOptions) {
+    super(message, { cause: options.cause });
+    this.name = "ProviderError";
+    this.kind = options.kind;
+    this.providerId = options.providerId;
+    this.status = options.status;
+    this.retryable = options.retryable ?? false;
+  }
+}

--- a/src/providers/shared/types.ts
+++ b/src/providers/shared/types.ts
@@ -8,6 +8,7 @@ export type ModelRef = {
 export type VesicleMessage = {
   role: "system" | "user" | "assistant" | "tool";
   content: string;
+  reasoningContent?: string;
   toolCallId?: string;
   toolCalls?: ToolCall[];
 };
@@ -28,6 +29,7 @@ export type VesicleRequest = {
 export type VesicleResponse = {
   id: string;
   content: string;
+  reasoningContent?: string;
   toolCalls?: ToolCall[];
   finishReason?: string;
   raw?: unknown;
@@ -40,6 +42,7 @@ export type VesicleResponse = {
 
 export type ProviderStreamEvent =
   | { type: "content_delta"; delta: string }
+  | { type: "reasoning_delta"; delta: string }
   | { type: "tool_call_delta"; index: number; id?: string; name?: string; argumentsDelta?: string }
   | { type: "complete"; response: VesicleResponse };
 

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -82,7 +82,7 @@ describe("agent loop sessions", () => {
 
   test("executes model-requested write_file calls", async () => {
     const rootDir = await createPromptRoot();
-    const requestBodies: Array<{ messages: Array<{ role: string; content: string }> }> = [];
+    const requestBodies: Array<{ messages: Array<{ role: string; content: string; reasoning_content?: string }> }> = [];
 
     globalThis.fetch = (async (_input: unknown, init: RequestInit & { body?: unknown }) => {
       requestBodies.push(JSON.parse(String(init?.body)));
@@ -95,6 +95,7 @@ describe("agent loop sessions", () => {
               finish_reason: "tool_calls",
               message: {
                 content: "",
+                reasoning_content: "Need to write the requested artifact before answering.",
                 tool_calls: [
                   {
                     id: "call-write",
@@ -139,6 +140,10 @@ describe("agent loop sessions", () => {
     expect(result.response.content).toBe("File written.");
     expect(written).toBe("# Tool Test\n\nwritten");
     expect(requestBodies[1].messages.some((message) => message.role === "tool")).toBe(true);
+    expect(requestBodies[1].messages.some((message) => (
+      message.role === "assistant" &&
+      message.reasoning_content === "Need to write the requested artifact before answering."
+    ))).toBe(true);
   });
 
   test("does not run artifact validators on ordinary assistant prose", async () => {

--- a/tests/provider-backend.test.ts
+++ b/tests/provider-backend.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { OpenAIChatCompatibleAdapter } from "../src/providers/openai-chat/adapter";
 import { toChatCompletionBody } from "../src/providers/openai-chat/request";
-import { readChatCompletionStream, readSseData } from "../src/providers/openai-chat/stream";
+import { readChatCompletionStream } from "../src/providers/openai-chat/stream";
 import type { VesicleRequest } from "../src/providers/shared/types";
 
 const originalFetch = globalThis.fetch;
+const testDir = fileURLToPath(new URL(".", import.meta.url));
+const repoRoot = join(testDir, "..");
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
@@ -74,9 +77,10 @@ describe("Provider backend errors", () => {
   test("uses a structured malformed-response error for bad SSE JSON", async () => {
     const response = new Response(rawSse(["data: {not-json}\n\n", "data: [DONE]\n\n"]));
 
-    await expect(collect(readSseResponse(response))).rejects.toMatchObject({
+    await expect(collect(readSseResponse(response, "deepseek"))).rejects.toMatchObject({
       name: "ProviderError",
       kind: "malformed_response",
+      providerId: "deepseek",
     });
   });
 });
@@ -114,12 +118,18 @@ describe("SSE parsing", () => {
   test("reads CRLF, comments, multiline data, and chunk boundaries", async () => {
     const body = chunkedSse([
       ": keepalive\r\n",
-      "data: {\"a\":\r\n",
-      "data: 1}\r\n\r\n",
+      "data: {\"id\":\"chatcmpl-crlf\",\"choices\":[{\"delta\":{\"content\":\r\n",
+      "data: \"ok\"},\"finish_reason\":\"stop\"}]}\r\n\r\n",
       "data: [DONE]\r\n\r\n",
     ]);
 
-    await expect(collect(readSseData(body))).resolves.toEqual(["{\"a\":\n1}", "[DONE]"]);
+    const events = await collect(readChatCompletionStream(new Response(body), "fallback", "deepseek"));
+
+    expect(events).toContainEqual({ type: "content_delta", delta: "ok" });
+    expect(events.at(-1)).toMatchObject({
+      type: "complete",
+      response: { id: "chatcmpl-crlf", content: "ok" },
+    });
   });
 });
 
@@ -176,6 +186,27 @@ describe("Chat Completions stream integration", () => {
     });
   });
 
+  test("uses the latest streamed tool call function name instead of concatenating", async () => {
+    const response = new Response(rawSse([
+      "data: {\"id\":\"chatcmpl-tools\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call-read\",\"type\":\"function\",\"function\":{\"name\":\"stale_name\",\"arguments\":\"{}\"}}]}}]}\n\n",
+      "data: {\"id\":\"chatcmpl-tools\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"name\":\"read_file\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+      "data: [DONE]\n\n",
+    ]));
+
+    const events = await collect(readChatCompletionStream(response, "fallback", "deepseek"));
+
+    expect(events.at(-1)).toMatchObject({
+      type: "complete",
+      response: {
+        toolCalls: [{
+          id: "call-read",
+          name: "read_file",
+          arguments: "{}",
+        }],
+      },
+    });
+  });
+
   test("adapter stream accepts an OK JSON response fallback", async () => {
     const bodies: unknown[] = [];
     globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
@@ -215,7 +246,7 @@ describe("Provider backend boundaries", () => {
     ];
 
     for (const file of providerFiles) {
-      const source = await readFile(join(process.cwd(), file), "utf8");
+      const source = await readFile(join(repoRoot, file), "utf8");
       expect(source).not.toMatch(/from\s+["']node:fs/);
       expect(source).not.toMatch(/from\s+["'][^"']*core\/session/);
       expect(source).not.toMatch(/from\s+["'][^"']*tui/);
@@ -232,8 +263,8 @@ function request(): VesicleRequest {
   };
 }
 
-async function* readSseResponse(response: Response) {
-  yield* readChatCompletionStream(response, "fallback");
+async function* readSseResponse(response: Response, providerId?: string) {
+  yield* readChatCompletionStream(response, "fallback", providerId);
 }
 
 async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {

--- a/tests/provider-backend.test.ts
+++ b/tests/provider-backend.test.ts
@@ -1,10 +1,16 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { OpenAIChatCompatibleAdapter } from "../src/providers/openai-chat/adapter";
 import { toChatCompletionBody } from "../src/providers/openai-chat/request";
 import { readChatCompletionStream, readSseData } from "../src/providers/openai-chat/stream";
 import type { VesicleRequest } from "../src/providers/shared/types";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
 
 describe("OpenAI-compatible request shaping", () => {
   test("omits tool fields when no tools are available", () => {
@@ -83,6 +89,84 @@ describe("SSE parsing", () => {
     ]);
 
     await expect(collect(readSseData(body))).resolves.toEqual(["{\"a\":\n1}", "[DONE]"]);
+  });
+});
+
+describe("Chat Completions stream integration", () => {
+  test("emits content deltas and a final complete event", async () => {
+    const response = new Response(rawSse([
+      "data: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n\n",
+      "data: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n",
+      "data: [DONE]\n\n",
+    ]));
+
+    const events = await collect(readChatCompletionStream(response, "fallback"));
+
+    expect(events).toContainEqual({ type: "content_delta", delta: "hel" });
+    expect(events).toContainEqual({ type: "content_delta", delta: "lo" });
+    expect(events.at(-1)).toEqual({
+      type: "complete",
+      response: {
+        id: "chatcmpl-stream",
+        content: "hello",
+        finishReason: "stop",
+        toolCalls: undefined,
+        usage: undefined,
+      },
+    });
+  });
+
+  test("accumulates streamed tool call deltas into the final response", async () => {
+    const response = new Response(rawSse([
+      "data: {\"id\":\"chatcmpl-tools\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call-read\",\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"arguments\":\"{\\\"path\\\":\"}}]}}]}\n\n",
+      "data: {\"id\":\"chatcmpl-tools\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"name\":\"read_file\",\"arguments\":\"\\\"workspace/a.md\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n",
+      "data: [DONE]\n\n",
+    ]));
+
+    const events = await collect(readChatCompletionStream(response, "fallback"));
+
+    expect(events.filter((event) => event.type === "tool_call_delta")).toHaveLength(2);
+    expect(events.at(-1)).toEqual({
+      type: "complete",
+      response: {
+        id: "chatcmpl-tools",
+        content: "",
+        finishReason: "tool_calls",
+        toolCalls: [{
+          id: "call-read",
+          name: "read_file",
+          arguments: "{\"path\":\"workspace/a.md\"}",
+        }],
+        usage: undefined,
+      },
+    });
+  });
+
+  test("adapter stream accepts an OK JSON response fallback", async () => {
+    const bodies: unknown[] = [];
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      return Response.json({
+        id: "chatcmpl-json",
+        choices: [{ finish_reason: "stop", message: { content: "json fallback" } }],
+      }, { headers: { "content-type": "application/json" } });
+    }) as unknown as typeof fetch;
+
+    const adapter = new OpenAIChatCompatibleAdapter({
+      provider: "openai-chat-compatible",
+      providerId: "test",
+      baseUrl: "https://provider.test/v1",
+      model: "test-model",
+      apiKey: "test-key",
+    });
+
+    const events = await collect(adapter.stream!(request()));
+
+    expect((bodies[0] as { stream: boolean }).stream).toBe(true);
+    expect(events.at(-1)).toMatchObject({
+      type: "complete",
+      response: { id: "chatcmpl-json", content: "json fallback", finishReason: "stop" },
+    });
   });
 });
 

--- a/tests/provider-backend.test.ts
+++ b/tests/provider-backend.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { OpenAIChatCompatibleAdapter } from "../src/providers/openai-chat/adapter";
+import { toChatCompletionBody } from "../src/providers/openai-chat/request";
+import { readChatCompletionStream, readSseData } from "../src/providers/openai-chat/stream";
+import type { VesicleRequest } from "../src/providers/shared/types";
+
+describe("OpenAI-compatible request shaping", () => {
+  test("omits tool fields when no tools are available", () => {
+    const body = JSON.parse(JSON.stringify(toChatCompletionBody(request(), false))) as Record<string, unknown>;
+
+    expect(body.model).toBe("test-model");
+    expect(body.stream).toBe(false);
+    expect(body.tools).toBeUndefined();
+    expect(body.tool_choice).toBeUndefined();
+  });
+
+  test("serializes assistant tool calls and tool results for Chat Completions", () => {
+    const body = toChatCompletionBody({
+      ...request(),
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call-read", name: "read_file", arguments: "{\"path\":\"workspace/a.md\"}" }],
+        },
+        { role: "tool", toolCallId: "call-read", content: "{\"ok\":true}" },
+      ],
+    }, true, true);
+
+    expect(body.stream_options).toEqual({ include_usage: true });
+    expect(body.messages).toEqual([
+      { role: "system", content: "system" },
+      {
+        role: "assistant",
+        content: null,
+        tool_calls: [{
+          id: "call-read",
+          type: "function",
+          function: { name: "read_file", arguments: "{\"path\":\"workspace/a.md\"}" },
+        }],
+      },
+      { role: "tool", tool_call_id: "call-read", content: "{\"ok\":true}" },
+    ]);
+  });
+});
+
+describe("Provider backend errors", () => {
+  test("uses a structured missing-credentials error", async () => {
+    const adapter = new OpenAIChatCompatibleAdapter({
+      provider: "openai-chat-compatible",
+      providerId: "deepseek",
+      baseUrl: "https://provider.test/v1",
+      model: "test-model",
+      apiKeyLabel: "DEEPSEEK_API_KEY",
+    });
+
+    await expect(adapter.complete(request())).rejects.toMatchObject({
+      name: "ProviderError",
+      kind: "missing_credentials",
+      providerId: "deepseek",
+    });
+  });
+
+  test("uses a structured malformed-response error for bad SSE JSON", async () => {
+    const response = new Response(rawSse(["data: {not-json}\n\n", "data: [DONE]\n\n"]));
+
+    await expect(collect(readSseResponse(response))).rejects.toMatchObject({
+      name: "ProviderError",
+      kind: "malformed_response",
+    });
+  });
+});
+
+describe("SSE parsing", () => {
+  test("reads CRLF, comments, multiline data, and chunk boundaries", async () => {
+    const body = chunkedSse([
+      ": keepalive\r\n",
+      "data: {\"a\":\r\n",
+      "data: 1}\r\n\r\n",
+      "data: [DONE]\r\n\r\n",
+    ]);
+
+    await expect(collect(readSseData(body))).resolves.toEqual(["{\"a\":\n1}", "[DONE]"]);
+  });
+});
+
+describe("Provider backend boundaries", () => {
+  test("provider modules do not import filesystem, session, or TUI modules", async () => {
+    const providerFiles = [
+      "src/providers/openai-chat/adapter.ts",
+      "src/providers/openai-chat/request.ts",
+      "src/providers/openai-chat/response.ts",
+      "src/providers/openai-chat/stream.ts",
+      "src/providers/openai-chat/types.ts",
+    ];
+
+    for (const file of providerFiles) {
+      const source = await readFile(join(process.cwd(), file), "utf8");
+      expect(source).not.toMatch(/from\s+["']node:fs/);
+      expect(source).not.toMatch(/from\s+["'][^"']*core\/session/);
+      expect(source).not.toMatch(/from\s+["'][^"']*tui/);
+    }
+  });
+});
+
+function request(): VesicleRequest {
+  return {
+    id: "session-test",
+    model: { provider: "openai-chat-compatible", model: "test-model" },
+    system: ["system"],
+    messages: [{ role: "user", content: "hello" }],
+  };
+}
+
+async function* readSseResponse(response: Response) {
+  yield* readChatCompletionStream(response, "fallback");
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const event of events) result.push(event);
+  return result;
+}
+
+function chunkedSse(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}
+
+function rawSse(lines: string[]): ReadableStream<Uint8Array> {
+  return chunkedSse(lines);
+}

--- a/tests/provider-backend.test.ts
+++ b/tests/provider-backend.test.ts
@@ -29,6 +29,7 @@ describe("OpenAI-compatible request shaping", () => {
         {
           role: "assistant",
           content: "",
+          reasoningContent: "Need to read the file first.",
           toolCalls: [{ id: "call-read", name: "read_file", arguments: "{\"path\":\"workspace/a.md\"}" }],
         },
         { role: "tool", toolCallId: "call-read", content: "{\"ok\":true}" },
@@ -41,6 +42,7 @@ describe("OpenAI-compatible request shaping", () => {
       {
         role: "assistant",
         content: null,
+        reasoning_content: "Need to read the file first.",
         tool_calls: [{
           id: "call-read",
           type: "function",
@@ -79,6 +81,35 @@ describe("Provider backend errors", () => {
   });
 });
 
+describe("OpenAI-compatible response parsing", () => {
+  test("preserves non-stream reasoning_content", async () => {
+    globalThis.fetch = (async () => Response.json({
+      id: "chatcmpl-reasoning",
+      choices: [{
+        finish_reason: "stop",
+        message: {
+          reasoning_content: "Think before answering.",
+          content: "final answer",
+        },
+      }],
+    })) as unknown as typeof fetch;
+
+    const adapter = new OpenAIChatCompatibleAdapter({
+      provider: "openai-chat-compatible",
+      providerId: "deepseek",
+      baseUrl: "https://provider.test/v1",
+      model: "test-model",
+      apiKey: "test-key",
+    });
+
+    await expect(adapter.complete(request())).resolves.toMatchObject({
+      id: "chatcmpl-reasoning",
+      content: "final answer",
+      reasoningContent: "Think before answering.",
+    });
+  });
+});
+
 describe("SSE parsing", () => {
   test("reads CRLF, comments, multiline data, and chunk boundaries", async () => {
     const body = chunkedSse([
@@ -96,6 +127,7 @@ describe("Chat Completions stream integration", () => {
   test("emits content deltas and a final complete event", async () => {
     const response = new Response(rawSse([
       "data: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"hel\"}}]}\n\n",
+      "data: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"reasoning_content\":\"think\"}}]}\n\n",
       "data: {\"id\":\"chatcmpl-stream\",\"choices\":[{\"delta\":{\"content\":\"lo\"},\"finish_reason\":\"stop\"}]}\n\n",
       "data: [DONE]\n\n",
     ]));
@@ -103,12 +135,14 @@ describe("Chat Completions stream integration", () => {
     const events = await collect(readChatCompletionStream(response, "fallback"));
 
     expect(events).toContainEqual({ type: "content_delta", delta: "hel" });
+    expect(events).toContainEqual({ type: "reasoning_delta", delta: "think" });
     expect(events).toContainEqual({ type: "content_delta", delta: "lo" });
     expect(events.at(-1)).toEqual({
       type: "complete",
       response: {
         id: "chatcmpl-stream",
         content: "hello",
+        reasoningContent: "think",
         finishReason: "stop",
         toolCalls: undefined,
         usage: undefined,

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -41,6 +41,7 @@ describe("session resume", () => {
       role: "assistant",
       content: "here is the blueprint",
       metadata: {
+        reasoningContent: "I should pause before proceeding.",
         toolCalls: [{ id: "call-1", name: "request_confirmation", arguments: "{}" }],
       },
     });
@@ -67,6 +68,7 @@ describe("session resume", () => {
       "assistant",
     ]);
     expect(messages[1].toolCalls?.[0]?.id).toBe("call-1");
+    expect(messages[1].reasoningContent).toBe("I should pause before proceeding.");
     expect(messages[2].toolCallId).toBe("call-1");
     // The composed system prompt must not leak into the resumed message list.
     expect(messages.some((m) => m.content.includes("composed prompt"))).toBe(false);


### PR DESCRIPTION
## Summary

- split the OpenAI-compatible backend into request shaping, response parsing, streaming, wire types, and structured provider errors
- keep `OpenAIChatCompatibleAdapter` as the orchestration boundary while preserving the public provider entrypoint
- add provider backend tests for request body shape, structured errors, SSE parsing, and provider-layer import boundaries

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run doctor`

## Notes / Follow-ups

- This intentionally does not add new provider protocols yet; it hardens the existing OpenAI-compatible path as the template for later adapters.