### PR TITLE
feat(provider): add runtime thinking tier control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,10 @@ Read asset-specific docs when touching assets:
 If a task touches architecture, provider behavior, TUI interaction, session
 semantics, or command UX, look for existing implementation patterns before
 inventing a new one. The ignored local `dev/docs/` area may contain private
-reference-project notes and local paths; use those notes when available, but do
-not copy local absolute paths or private machine details into public docs.
+reference-project notes and local paths. When present, start with
+`dev/docs/REFERENCE_PROJECTS.md` to find the local reference project locations;
+use those notes when available, but do not copy local absolute paths or private
+machine details into public docs.
 
 ## Documentation Map
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,12 @@ Read asset-specific docs when touching assets:
   plan; useful context, but current code plus `STATUS.md` and `docs/dev/*` are
   authoritative when they differ.
 
+If a task touches architecture, provider behavior, TUI interaction, session
+semantics, or command UX, look for existing implementation patterns before
+inventing a new one. The ignored local `dev/docs/` area may contain private
+reference-project notes and local paths; use those notes when available, but do
+not copy local absolute paths or private machine details into public docs.
+
 ## Documentation Map
 
 Use the docs by responsibility:
@@ -115,6 +121,10 @@ as supported configuration.
 
 These are non-negotiable boundaries; see `docs/dev/STYLE.md` for detail.
 
+- Prefer adapting proven patterns from the documented reference projects over
+  rebuilding familiar agent/runtime behavior from scratch. Record borrowed
+  behavior in public docs/tests when it affects Vesicle's runtime contract, but
+  keep private reference paths confined to ignored local notes.
 - Provider adapters convert normalized Vesicle requests to provider wire
   format and back. They must not read/write project files, mutate sessions,
   know Prism phases, or execute host tools.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ project follows Semantic Versioning once releases begin.
 - Agent-loop streaming events for assistant deltas and streamed tool-call
   deltas.
 - TUI live assistant draft rendering while a provider response is in flight.
+- TUI `/think off|low|midium|high|xhigh|max` command for runtime thinking-tier
+  control. Selected tiers are passed through the agent loop, persisted in
+  session metadata, and restored on resume.
 
 ### Changed
 
@@ -42,6 +45,10 @@ project follows Semantic Versioning once releases begin.
   it.
 - `vesicle doctor` now reports whether the user-level provider `.env` file was
   found, without printing secret values.
+- OpenAI-compatible request shaping now maps normalized thinking tiers to
+  provider wire controls: `off` disables thinking, `low`/`midium`/`high` map to
+  high effort, and `xhigh`/`max` map to max effort. Unset sessions keep the
+  provider/model default and do not send thinking control fields.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ project follows Semantic Versioning once releases begin.
   deltas.
 - TUI live assistant draft rendering while a provider response is in flight.
 - TUI `/think off|low|midium|high|xhigh|max` command for runtime thinking-tier
-  control. Selected tiers are passed through the agent loop, persisted in
-  session metadata, and restored on resume.
+  control, plus `/think auto`/`unset` to return to provider defaults. Selected
+  tiers are passed through the agent loop, persisted in session metadata, and
+  restored on resume.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,9 @@ Also read:
 For architecture, provider, TUI, session, or command-UX changes, first check
 whether the documented reference projects already solved a similar problem.
 Ignored local notes under `dev/docs/` may describe private reference locations;
-use them when available, but never copy local absolute paths or machine-private
-details into public docs.
+when present, start with `dev/docs/REFERENCE_PROJECTS.md` to find those local
+absolute paths. Use the notes, but never copy local absolute paths or
+machine-private details into public docs.
 
 ## High-Risk Boundaries
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,16 @@ Also read:
 - `assets/README.md` before editing copied Prism assets.
 - `docs/examples/providers.yaml` before changing provider config behavior.
 
+For architecture, provider, TUI, session, or command-UX changes, first check
+whether the documented reference projects already solved a similar problem.
+Ignored local notes under `dev/docs/` may describe private reference locations;
+use them when available, but never copy local absolute paths or machine-private
+details into public docs.
+
 ## High-Risk Boundaries
 
+- Prefer proven reference-project patterns over needless reinvention, while
+  preserving Vesicle's Prism-host product boundary.
 - Do not store provider secrets in `providers.yaml`.
 - Do not depend on a project-root `.env`; provider secrets belong beside the
   user-level `providers.yaml`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ config path is
 `$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` or
 `~/.config/prism-vesicle/providers.yaml` on Linux/macOS. The TUI can then
 switch with `/providers`, `/models`, `/use <provider> <model>`, and
-`/model <model>`.
+`/model <model>`. Use `/think off|low|midium|high|xhigh|max` to set the
+thinking tier for subsequent provider requests; before this command is used,
+Vesicle leaves thinking behavior at the provider/model default.
 The provider file intentionally supports only Vesicle's small YAML subset:
 `default`, `providers`, scalar provider fields, and `models` string lists.
 Provider secrets are not read from this file; every provider must name an
@@ -66,6 +68,9 @@ return to an unresolved gate.
   supports SSE, including streamed tool-call reconstruction
 - Provider/model registry from the user-level `providers.yaml`, with TUI
   commands to switch provider and model inside a session
+- Runtime thinking-tier control with `/think off|low|midium|high|xhigh|max`;
+  OpenAI-compatible requests map `off` to disabled thinking, `low`/`midium`/
+  `high` to high effort, and `xhigh`/`max` to max effort
 - Engine profiles drive systemPrompt, tools, validators, and stop gates from
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ config path is
 `~/.config/prism-vesicle/providers.yaml` on Linux/macOS. The TUI can then
 switch with `/providers`, `/models`, `/use <provider> <model>`, and
 `/model <model>`. Use `/think off|low|midium|high|xhigh|max` to set the
-thinking tier for subsequent provider requests; before this command is used,
-Vesicle leaves thinking behavior at the provider/model default.
+thinking tier for subsequent provider requests, or `/think auto` to clear the
+explicit choice. Before this command is used, Vesicle leaves thinking behavior
+at the provider/model default.
 The provider file intentionally supports only Vesicle's small YAML subset:
 `default`, `providers`, scalar provider fields, and `models` string lists.
 Provider secrets are not read from this file; every provider must name an
@@ -68,9 +69,10 @@ return to an unresolved gate.
   supports SSE, including streamed tool-call reconstruction
 - Provider/model registry from the user-level `providers.yaml`, with TUI
   commands to switch provider and model inside a session
-- Runtime thinking-tier control with `/think off|low|midium|high|xhigh|max`;
-  OpenAI-compatible requests map `off` to disabled thinking, `low`/`midium`/
-  `high` to high effort, and `xhigh`/`max` to max effort
+- Runtime thinking-tier control with `/think off|low|midium|high|xhigh|max`
+  plus `/think auto` to return to provider defaults; OpenAI-compatible requests
+  map `off` to disabled thinking, `low`/`midium`/`high` to high effort, and
+  `xhigh`/`max` to max effort
 - Engine profiles drive systemPrompt, tools, validators, and stop gates from
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Prism Vesicle Project Status
 
-_Last updated: 2026-07-07_
+_Last updated: 2026-07-08_
 
 ## Current Version
 
@@ -14,6 +14,7 @@ _Last updated: 2026-07-07_
 | Validators | Module A + Module B v9 schemas | Implemented |
 | Streaming | OpenAI-compatible SSE | In progress on 0.2 branch |
 | Provider registry | OpenAI-compatible profiles | In progress on 0.3 branch |
+| Thinking control | OpenAI-compatible reasoning controls | In progress on 0.3 branch |
 | Artifact workbench | TUI commands + validation | In progress on 0.3 branch |
 
 ## Current Scope
@@ -34,6 +35,9 @@ Chat wrapper:
   switch provider/model during a session. Provider files name `apiKeyEnv`
   variables only; actual secrets stay in the same user-level directory's
   `.env` file, with process environment variables used only as fallback.
+- Control thinking behavior for subsequent TUI turns with
+  `/think off|low|midium|high|xhigh|max`; unset sessions preserve the
+  provider/model default instead of sending control fields.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
 - Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a
@@ -134,6 +138,9 @@ never abort a turn. Validators run only on artifact-shaped assistant content
 - OpenAI-compatible SSE streaming is implemented on the 0.2 branch for
   assistant content deltas and streamed tool-call reconstruction. Other
   provider protocols are still deferred.
+- Thinking-tier control maps to OpenAI-compatible `thinking` and
+  `reasoning_effort` request fields. Reasoning content is preserved for
+  tool-loop continuity but is not rendered as a user-visible thinking stream.
 - TUI engine switching is hardcoded to ETL (runtime/evaluate profiles exist
   and load, but the TUI does not yet offer a selector).
 - Gate UI is Select-style for ETL blueprint and phase checkpoints, with a

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,8 +36,9 @@ Chat wrapper:
   variables only; actual secrets stay in the same user-level directory's
   `.env` file, with process environment variables used only as fallback.
 - Control thinking behavior for subsequent TUI turns with
-  `/think off|low|midium|high|xhigh|max`; unset sessions preserve the
-  provider/model default instead of sending control fields.
+  `/think off|low|midium|high|xhigh|max`; `/think auto` clears the explicit
+  choice. Unset sessions preserve the provider/model default instead of
+  sending control fields.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
 - Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -56,7 +56,8 @@ configured provider/model profiles, but adapters still receive a normalized
 Generation controls follow the same rule: core/TUI may pass the normalized
 `reasoningTier` values (`off`, `low`, `midium`, `high`, `xhigh`, `max`), but
 only the provider adapter maps them to wire fields such as `thinking` and
-`reasoning_effort`.
+`reasoning_effort`. TUI commands may offer `auto`/`unset` to clear an explicit
+selection; that means no `reasoningTier` is sent.
 Persistent provider profiles live in the user-level provider config, not in the
 project `.vesicle/` runtime state directory. The default path is
 `%APPDATA%\prism-vesicle\providers.yaml` on Windows and

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -53,6 +53,10 @@ Tool calls are normalized into `ToolCall` and executed by `core/tools`.
 Provider selection is host state, not prompt state. The TUI may switch among
 configured provider/model profiles, but adapters still receive a normalized
 `VesicleRequest` and must not know about sessions, artifacts, or Prism phases.
+Generation controls follow the same rule: core/TUI may pass the normalized
+`reasoningTier` values (`off`, `low`, `midium`, `high`, `xhigh`, `max`), but
+only the provider adapter maps them to wire fields such as `thinking` and
+`reasoning_effort`.
 Persistent provider profiles live in the user-level provider config, not in the
 project `.vesicle/` runtime state directory. The default path is
 `%APPDATA%\prism-vesicle\providers.yaml` on Windows and
@@ -125,6 +129,10 @@ Prompts are runtime assets, not hardcoded source literals.
 - Provider requests must include prior user/assistant turns when continuing a
   session.
 - Tool calls and tool results should be persisted for replay/debugging.
+- User-selected reasoning tiers should be persisted as session metadata so
+  interactive resume restores runtime generation behavior. Provider
+  `reasoning_content` is preserved for protocol continuity, not treated as
+  user-visible assistant prose by default.
 - Session lists should mark unresolved gates so the user can distinguish a
   normal transcript from a workflow waiting for confirmation.
 - Long-running turns should emit host-visible activity events before and after

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -27,6 +27,7 @@ export type RunPromptOptions = {
   sessionId?: string;
   messages?: VesicleMessage[];
   providerSelection?: Partial<ProviderSelection>;
+  generation?: VesicleRequest["generation"];
   onEvent?: (event: AgentLoopEvent) => void;
 };
 
@@ -149,6 +150,7 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
         provider: config.provider,
         providerId: config.providerId,
         model: config.model,
+        ...(options.generation?.reasoningTier ? { reasoningTier: options.generation.reasoningTier } : {}),
         profile: {
           displayName: profile.displayName,
           protocolVersion: profile.protocolVersion,
@@ -167,6 +169,7 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
       provider: config.provider,
       providerId: config.providerId,
       model: config.model,
+      ...(options.generation?.reasoningTier ? { reasoningTier: options.generation.reasoningTier } : {}),
     },
   });
 
@@ -177,7 +180,18 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
     },
   ];
 
-  return runLoop({ rootDir, config, provider, systemPrompt, tools, messages, session, profile, onEvent: options.onEvent });
+  return runLoop({
+    rootDir,
+    config,
+    provider,
+    systemPrompt,
+    tools,
+    messages,
+    session,
+    profile,
+    generation: options.generation,
+    onEvent: options.onEvent,
+  });
 }
 
 type RunLoopArgs = {
@@ -189,11 +203,12 @@ type RunLoopArgs = {
   messages: VesicleMessage[];
   session: SessionStore;
   profile: EngineProfile;
+  generation?: VesicleRequest["generation"];
   onEvent?: (event: AgentLoopEvent) => void;
 };
 
 async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
-  const { rootDir, config, provider, systemPrompt, tools, messages, session, profile, onEvent } = args;
+  const { rootDir, config, provider, systemPrompt, tools, messages, session, profile, generation, onEvent } = args;
   const declaredGates = new Set(profile.stopGates);
 
   let response: VesicleResponse | undefined;
@@ -210,6 +225,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
       system: [systemPrompt],
       messages,
       tools,
+      generation,
     }, onEvent);
 
     const toolCalls = response.toolCalls ?? [];
@@ -490,6 +506,7 @@ export async function resolveGate(options: {
   gate: GateRequest;
   resolution: GateResolution;
   providerSelection?: Partial<ProviderSelection>;
+  generation?: VesicleRequest["generation"];
   onEvent?: (event: AgentLoopEvent) => void;
 }): Promise<RunPromptResult> {
   const rootDir = options.rootDir ?? process.cwd();
@@ -535,11 +552,23 @@ export async function resolveGate(options: {
     metadata: {
       provider: config.provider,
       providerId: config.providerId,
-      model: config.model,
-    },
-  });
+        model: config.model,
+        ...(options.generation?.reasoningTier ? { reasoningTier: options.generation.reasoningTier } : {}),
+      },
+    });
 
-  return runLoop({ rootDir, config, provider, systemPrompt, tools, messages, session, profile, onEvent: options.onEvent });
+  return runLoop({
+    rootDir,
+    config,
+    provider,
+    systemPrompt,
+    tools,
+    messages,
+    session,
+    profile,
+    generation: options.generation,
+    onEvent: options.onEvent,
+  });
 }
 
 function gateResultMessage(resolution: GateResolution): string {

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -193,9 +193,8 @@ export async function loadSessionSnapshot(
     if (typeof providerId === "string" && typeof model === "string") {
       providerSelection = { provider: providerId, model };
     }
-    const recordReasoningTier = readReasoningTier(record.metadata?.reasoningTier);
-    if (recordReasoningTier) {
-      reasoningTier = recordReasoningTier;
+    if (record.metadata && Object.hasOwn(record.metadata, "reasoningTier")) {
+      reasoningTier = readReasoningTier(record.metadata.reasoningTier);
     }
 
     if (record.role === "system") {

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { parseGateRequest } from "../gate/types";
 import type { GateRequest } from "../gate/types";
 import type { ProviderSelection } from "../../config/providers";
+import { reasoningTiers } from "../../providers/shared/types";
+import type { ReasoningTier } from "../../providers/shared/types";
 
 export type SessionRole = "user" | "assistant" | "system" | "tool";
 
@@ -157,6 +159,7 @@ export type SessionSnapshot = {
   sessionId: string;
   messages: ResumedMessage[];
   providerSelection?: ProviderSelection;
+  reasoningTier?: ReasoningTier;
   pendingGate?: {
     gate: GateRequest;
     toolCallId: string;
@@ -182,12 +185,17 @@ export async function loadSessionSnapshot(
   const messages: ResumedMessage[] = [];
   let skippedFirstSystem = false;
   let providerSelection: ProviderSelection | undefined;
+  let reasoningTier: ReasoningTier | undefined;
 
   for (const record of records) {
     const providerId = record.metadata?.providerId;
     const model = record.metadata?.model;
     if (typeof providerId === "string" && typeof model === "string") {
       providerSelection = { provider: providerId, model };
+    }
+    const recordReasoningTier = readReasoningTier(record.metadata?.reasoningTier);
+    if (recordReasoningTier) {
+      reasoningTier = recordReasoningTier;
     }
 
     if (record.role === "system") {
@@ -245,6 +253,7 @@ export async function loadSessionSnapshot(
     sessionId,
     messages,
     ...(providerSelection ? { providerSelection } : {}),
+    ...(reasoningTier ? { reasoningTier } : {}),
     ...(pendingGate
       ? {
           pendingGate: {
@@ -255,6 +264,12 @@ export async function loadSessionSnapshot(
         }
       : {}),
   };
+}
+
+function readReasoningTier(value: unknown): ReasoningTier | undefined {
+  return typeof value === "string" && (reasoningTiers as readonly string[]).includes(value)
+    ? value as ReasoningTier
+    : undefined;
 }
 
 function findPendingGate(records: SessionRecord[]): { gate: GateRequest; toolCallId: string; assistantContent: string } | undefined {

--- a/src/providers/openai-chat/request.ts
+++ b/src/providers/openai-chat/request.ts
@@ -1,4 +1,4 @@
-import type { VesicleRequest } from "../shared/types";
+import type { ReasoningTier, VesicleRequest } from "../shared/types";
 
 export function toChatCompletionBody(request: VesicleRequest, stream: boolean, includeUsage = false): Record<string, unknown> {
   const hasTools = Boolean(request.tools && request.tools.length > 0);
@@ -45,7 +45,19 @@ export function toChatCompletionBody(request: VesicleRequest, stream: boolean, i
     tool_choice: hasTools ? "auto" : undefined,
     temperature: request.generation?.temperature ?? 0.7,
     max_tokens: request.generation?.maxTokens,
+    ...reasoningControls(request.generation?.reasoningTier),
     stream,
     stream_options: stream && includeUsage ? { include_usage: true } : undefined,
+  };
+}
+
+function reasoningControls(tier: ReasoningTier | undefined): Record<string, unknown> {
+  if (!tier) return {};
+  if (tier === "off") {
+    return { thinking: { type: "disabled" } };
+  }
+  return {
+    thinking: { type: "enabled" },
+    reasoning_effort: tier === "xhigh" || tier === "max" ? "max" : "high",
   };
 }

--- a/src/providers/shared/types.ts
+++ b/src/providers/shared/types.ts
@@ -1,5 +1,8 @@
 import type { ToolCall, ToolDefinition } from "../../core/tools";
 
+export const reasoningTiers = ["off", "low", "midium", "high", "xhigh", "max"] as const;
+export type ReasoningTier = typeof reasoningTiers[number];
+
 export type ModelRef = {
   provider: string;
   model: string;
@@ -22,6 +25,7 @@ export type VesicleRequest = {
   generation?: {
     temperature?: number;
     maxTokens?: number;
+    reasoningTier?: ReasoningTier;
   };
   metadata?: Record<string, unknown>;
 };

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -520,16 +520,16 @@ export function App() {
     });
   }
 
-  async function persistThinkingSwitch(tier: ReasoningTier) {
+  async function persistThinkingSwitch(tier: ReasoningTier | undefined) {
     const id = sessionId();
     if (!id) return;
     const store = await createSessionStore(process.cwd(), id);
     await store.append({
       role: "system",
-      content: `Thinking tier switched to ${tier}.`,
+      content: tier ? `Thinking tier switched to ${tier}.` : "Thinking tier reset to provider default.",
       metadata: {
         kind: "thinking-switch",
-        reasoningTier: tier,
+        reasoningTier: tier ?? null,
       },
     });
   }
@@ -552,7 +552,7 @@ export function App() {
 	 *   /models [id]      list models for a provider
 	 *   /use <id> <model> switch provider and model
 	 *   /model <model>    switch model within the active provider
-	 *   /think <tier>     set thinking tier: off/low/midium/high/xhigh/max
+	 *   /think <tier>     set thinking tier: off/low/midium/high/xhigh/max/auto
 	 *   /artifacts        list generated artifacts
 	 *   /artifact <n|path> preview an artifact
 	 *   /validate <n|path> validate an artifact file
@@ -570,7 +570,7 @@ export function App() {
         { role: "user", content: input },
         {
 	          role: "system",
-	          content: "Commands:\n  /providers        list configured providers\n  /models [id]      list models for a provider\n  /use <id> <model> switch provider/model\n  /model <model>    switch model in active provider\n  /think <tier>     set thinking tier: off/low/midium/high/xhigh/max\n  /artifacts        list generated artifacts\n  /artifact <n|path> preview an artifact\n  /validate <n|path> validate an artifact file\n  /revise <n|path> <instructions> revise an artifact\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
+	          content: "Commands:\n  /providers        list configured providers\n  /models [id]      list models for a provider\n  /use <id> <model> switch provider/model\n  /model <model>    switch model in active provider\n  /think <tier>     set thinking tier: off/low/midium/high/xhigh/max/auto\n  /artifacts        list generated artifacts\n  /artifact <n|path> preview an artifact\n  /validate <n|path> validate an artifact file\n  /revise <n|path> <instructions> revise an artifact\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
 	        },
 	      ]);
 	      return;
@@ -626,13 +626,21 @@ export function App() {
 	        setMessages((prev) => [
 	          ...prev,
 	          { role: "user", content: input },
-	          { role: "system", content: `Thinking tier: ${thinkingTier() ?? "provider default"}. Use /think off|low|midium|high|xhigh|max.` },
+	          { role: "system", content: `Thinking tier: ${thinkingTier() ?? "provider default"}. Use /think off|low|midium|high|xhigh|max|auto.` },
 	        ]);
 	        return;
 	      }
 	      const tier = parseThinkingTier(arg);
 	      if (!tier) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /think off|low|midium|high|xhigh|max" }]);
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /think off|low|midium|high|xhigh|max|auto" }]);
+	        return;
+	      }
+	      if (tier === "auto") {
+	        setThinkingTier(undefined);
+	        setStatus("thinking provider default");
+	        recordActivity({ kind: "provider", text: "thinking tier provider default" });
+	        await persistThinkingSwitch(undefined);
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Thinking tier reset to provider default." }]);
 	        return;
 	      }
 	      setThinkingTier(tier);
@@ -936,7 +944,7 @@ export function App() {
                 <Show when={inputValue().startsWith("/")} fallback={<box height={0} />}>
                   <box flexDirection="column">
 	                    <text content="/providers  list providers    /models  list models    /use <p> <m>  switch" fg={palette.textDim} />
-	                    <text content="/think <tier>  off/low/midium/high/xhigh/max    /help  commands" fg={palette.textDim} />
+	                    <text content="/think <tier>  off/low/midium/high/xhigh/max/auto    /help" fg={palette.textDim} />
 	                    <text content="/resume  list sessions    /new  start fresh" fg={palette.textDim} />
                     <text content="Up/Down recalls prompt history" fg={palette.textDim} />
                   </box>
@@ -1010,8 +1018,10 @@ function renderModelList(registry: ProviderRegistry, providerId: string, activeM
   return lines.join("\n");
 }
 
-function parseThinkingTier(value: string): ReasoningTier | null {
-  const normalized = value.trim().toLowerCase() === "medium" ? "midium" : value.trim().toLowerCase();
+function parseThinkingTier(value: string): ReasoningTier | "auto" | null {
+  const raw = value.trim().toLowerCase();
+  if (raw === "auto" || raw === "unset" || raw === "default") return "auto";
+  const normalized = raw === "medium" ? "midium" : raw;
   return (reasoningTiers as readonly string[]).includes(normalized) ? normalized as ReasoningTier : null;
 }
 

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -8,6 +8,8 @@ import { resolveGate, runPrompt } from "../core/agent-loop/run";
 import type { RunPromptResult } from "../core/agent-loop/run";
 import type { AgentLoopEvent } from "../core/agent-loop/run";
 import type { VesicleMessage } from "../providers/shared/types";
+import { reasoningTiers } from "../providers/shared/types";
+import type { ReasoningTier } from "../providers/shared/types";
 import type { GateResolution } from "../core/gate/types";
 import { copySelectionToClipboard } from "./clipboard";
 import { sharedSyntaxStyle, palette } from "./theme";
@@ -65,6 +67,7 @@ export function App() {
   const [providerRegistry, setProviderRegistry] = createSignal<ProviderRegistry | null>(null);
   const [activeProvider, setActiveProvider] = createSignal("loading");
   const [activeModel, setActiveModel] = createSignal("loading");
+  const [thinkingTier, setThinkingTier] = createSignal<ReasoningTier | undefined>();
   const [providerHasApiKey, setProviderHasApiKey] = createSignal(false);
   const [providerConfigReady, setProviderConfigReady] = createSignal(false);
   const [messages, setMessages] = createSignal<Message[]>([
@@ -293,6 +296,7 @@ export function App() {
 	        sessionId: sessionId(),
 	        messages: requestMessages,
 	        providerSelection: activeProviderSelection(),
+	        generation: activeGeneration(),
 	        onEvent: handleAgentEvent,
 	      });
       handleResult(result, requestMessages);
@@ -327,6 +331,7 @@ export function App() {
 	        gate: gate.gate,
 	        resolution,
 	        providerSelection: activeProviderSelection(),
+	        generation: activeGeneration(),
 	        onEvent: handleAgentEvent,
 	      });
       handleResult(result, gate.messages);
@@ -495,6 +500,11 @@ export function App() {
     return { provider: activeProvider(), model: activeModel() };
   }
 
+  function activeGeneration() {
+    const reasoningTier = thinkingTier();
+    return reasoningTier ? { reasoningTier } : undefined;
+  }
+
   async function persistProviderSwitch(selection: ProviderSelection) {
     const id = sessionId();
     if (!id) return;
@@ -506,6 +516,20 @@ export function App() {
         kind: "provider-switch",
         providerId: selection.provider,
         model: selection.model,
+      },
+    });
+  }
+
+  async function persistThinkingSwitch(tier: ReasoningTier) {
+    const id = sessionId();
+    if (!id) return;
+    const store = await createSessionStore(process.cwd(), id);
+    await store.append({
+      role: "system",
+      content: `Thinking tier switched to ${tier}.`,
+      metadata: {
+        kind: "thinking-switch",
+        reasoningTier: tier,
       },
     });
   }
@@ -528,6 +552,7 @@ export function App() {
 	 *   /models [id]      list models for a provider
 	 *   /use <id> <model> switch provider and model
 	 *   /model <model>    switch model within the active provider
+	 *   /think <tier>     set thinking tier: off/low/midium/high/xhigh/max
 	 *   /artifacts        list generated artifacts
 	 *   /artifact <n|path> preview an artifact
 	 *   /validate <n|path> validate an artifact file
@@ -545,7 +570,7 @@ export function App() {
         { role: "user", content: input },
         {
 	          role: "system",
-	          content: "Commands:\n  /providers        list configured providers\n  /models [id]      list models for a provider\n  /use <id> <model> switch provider/model\n  /model <model>    switch model in active provider\n  /artifacts        list generated artifacts\n  /artifact <n|path> preview an artifact\n  /validate <n|path> validate an artifact file\n  /revise <n|path> <instructions> revise an artifact\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
+	          content: "Commands:\n  /providers        list configured providers\n  /models [id]      list models for a provider\n  /use <id> <model> switch provider/model\n  /model <model>    switch model in active provider\n  /think <tier>     set thinking tier: off/low/midium/high/xhigh/max\n  /artifacts        list generated artifacts\n  /artifact <n|path> preview an artifact\n  /validate <n|path> validate an artifact file\n  /revise <n|path> <instructions> revise an artifact\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
 	        },
 	      ]);
 	      return;
@@ -593,6 +618,28 @@ export function App() {
 	      const selection = await applyProviderSelection({ provider: activeProvider(), model: arg });
 	      await persistProviderSwitch(selection);
 	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
+	      return;
+	    }
+
+	    if (command === "think") {
+	      if (!arg) {
+	        setMessages((prev) => [
+	          ...prev,
+	          { role: "user", content: input },
+	          { role: "system", content: `Thinking tier: ${thinkingTier() ?? "provider default"}. Use /think off|low|midium|high|xhigh|max.` },
+	        ]);
+	        return;
+	      }
+	      const tier = parseThinkingTier(arg);
+	      if (!tier) {
+	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /think off|low|midium|high|xhigh|max" }]);
+	        return;
+	      }
+	      setThinkingTier(tier);
+	      setStatus(`thinking ${tier}`);
+	      recordActivity({ kind: "provider", text: `thinking tier ${tier}` });
+	      await persistThinkingSwitch(tier);
+	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Thinking tier set to ${tier}.` }]);
 	      return;
 	    }
 
@@ -713,6 +760,10 @@ export function App() {
 	          hostMessages.push({ role: "system", content: `Session provider was not restored: ${message}` });
 	        }
 	      }
+	      if (snapshot.reasoningTier) {
+	        setThinkingTier(snapshot.reasoningTier);
+	        hostMessages.push({ role: "system", content: `Restored thinking tier ${snapshot.reasoningTier} from session.` });
+	      }
 
 	      if (snapshot.pendingGate) {
         setPendingGate({
@@ -813,6 +864,7 @@ export function App() {
 	            <PanelLine content="Provider" fg={palette.textMuted} />
 	            <PanelLine content={truncateLine(`${activeProvider()}/${activeModel()}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
 	            <PanelLine content={providerHasApiKey() ? "API key: available" : "API key: missing"} fg={providerHasApiKey() ? palette.success : palette.error} />
+	            <PanelLine content={truncateLine(`Thinking: ${thinkingTier() ?? "provider default"}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
             <PanelLine content=" " fg={palette.textDim} />
             <PanelLine content="Session" fg={palette.textMuted} />
             <PanelLine content={truncateMiddle(sessionPath(), layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
@@ -884,7 +936,8 @@ export function App() {
                 <Show when={inputValue().startsWith("/")} fallback={<box height={0} />}>
                   <box flexDirection="column">
 	                    <text content="/providers  list providers    /models  list models    /use <p> <m>  switch" fg={palette.textDim} />
-	                    <text content="/resume  list sessions    /new  start fresh    /help  commands" fg={palette.textDim} />
+	                    <text content="/think <tier>  off/low/midium/high/xhigh/max    /help  commands" fg={palette.textDim} />
+	                    <text content="/resume  list sessions    /new  start fresh" fg={palette.textDim} />
                     <text content="Up/Down recalls prompt history" fg={palette.textDim} />
                   </box>
                 </Show>
@@ -955,6 +1008,11 @@ function renderModelList(registry: ProviderRegistry, providerId: string, activeM
   lines.push("");
   lines.push(`Use /use ${provider.id} <model> or /model <model> to switch.`);
   return lines.join("\n");
+}
+
+function parseThinkingTier(value: string): ReasoningTier | null {
+  const normalized = value.trim().toLowerCase() === "medium" ? "midium" : value.trim().toLowerCase();
+  return (reasoningTiers as readonly string[]).includes(normalized) ? normalized as ReasoningTier : null;
 }
 
 function renderArtifactList(entries: ArtifactEntry[]): string {

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -80,6 +80,32 @@ describe("agent loop sessions", () => {
     ]);
   });
 
+  test("passes generation thinking tier to the provider request", async () => {
+    const rootDir = await createPromptRoot();
+    const requestBodies: Array<{ thinking?: unknown; reasoning_effort?: string }> = [];
+
+    globalThis.fetch = (async (_input: unknown, init: RequestInit & { body?: unknown }) => {
+      requestBodies.push(JSON.parse(String(init?.body)));
+
+      return Response.json({
+        id: "chatcmpl-thinking",
+        choices: [{ message: { content: "reply" } }],
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runPrompt({
+      input: "think hard",
+      rootDir,
+      generation: { reasoningTier: "max" },
+    });
+
+    if (result.kind !== "complete") throw new Error("expected complete");
+    expect(requestBodies[0]).toMatchObject({
+      thinking: { type: "enabled" },
+      reasoning_effort: "max",
+    });
+  });
+
   test("executes model-requested write_file calls", async () => {
     const rootDir = await createPromptRoot();
     const requestBodies: Array<{ messages: Array<{ role: string; content: string; reasoning_content?: string }> }> = [];

--- a/tests/provider-backend.test.ts
+++ b/tests/provider-backend.test.ts
@@ -23,6 +23,26 @@ describe("OpenAI-compatible request shaping", () => {
     expect(body.stream).toBe(false);
     expect(body.tools).toBeUndefined();
     expect(body.tool_choice).toBeUndefined();
+    expect(body.thinking).toBeUndefined();
+    expect(body.reasoning_effort).toBeUndefined();
+  });
+
+  test("maps normalized thinking tiers to OpenAI-compatible reasoning controls", () => {
+    const off = toChatCompletionBody({ ...request(), generation: { reasoningTier: "off" } }, false);
+    expect(off.thinking).toEqual({ type: "disabled" });
+    expect(off.reasoning_effort).toBeUndefined();
+
+    for (const tier of ["low", "midium", "high"] as const) {
+      const body = toChatCompletionBody({ ...request(), generation: { reasoningTier: tier } }, false);
+      expect(body.thinking).toEqual({ type: "enabled" });
+      expect(body.reasoning_effort).toBe("high");
+    }
+
+    for (const tier of ["xhigh", "max"] as const) {
+      const body = toChatCompletionBody({ ...request(), generation: { reasoningTier: tier } }, false);
+      expect(body.thinking).toEqual({ type: "enabled" });
+      expect(body.reasoning_effort).toBe("max");
+    }
   });
 
   test("serializes assistant tool calls and tool results for Chat Completions", () => {

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -159,6 +159,27 @@ describe("session resume", () => {
     expect(snapshot.providerSelection).toEqual({ provider: "local", model: "qwen3" });
   });
 
+  test("loadSessionSnapshot restores the latest thinking tier", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-thinking-session-"));
+    const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-thinking");
+
+    await store.append({ role: "system", content: "prompt" });
+    await store.append({
+      role: "system",
+      content: "Thinking tier switched to low.",
+      metadata: { kind: "thinking-switch", reasoningTier: "low" },
+    });
+    await store.append({
+      role: "user",
+      content: "second",
+      metadata: { reasoningTier: "max" },
+    });
+
+    const snapshot = await loadSessionSnapshot(rootDir, "2026-05-01T00-00-00-000Z-thinking");
+
+    expect(snapshot.reasoningTier).toBe("max");
+  });
+
   test("loadSessionMessages does not synthesise results when tool results already exist", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-answered-"));
     const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-eeeeeeee");

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -180,6 +180,27 @@ describe("session resume", () => {
     expect(snapshot.reasoningTier).toBe("max");
   });
 
+  test("loadSessionSnapshot restores cleared thinking tier as provider default", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-thinking-clear-session-"));
+    const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-thinking-clear");
+
+    await store.append({ role: "system", content: "prompt" });
+    await store.append({
+      role: "system",
+      content: "Thinking tier switched to max.",
+      metadata: { kind: "thinking-switch", reasoningTier: "max" },
+    });
+    await store.append({
+      role: "system",
+      content: "Thinking tier reset to provider default.",
+      metadata: { kind: "thinking-switch", reasoningTier: null },
+    });
+
+    const snapshot = await loadSessionSnapshot(rootDir, "2026-05-01T00-00-00-000Z-thinking-clear");
+
+    expect(snapshot.reasoningTier).toBeUndefined();
+  });
+
   test("loadSessionMessages does not synthesise results when tool results already exist", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-answered-"));
     const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-eeeeeeee");


### PR DESCRIPTION
## Summary

- Add a normalized `ReasoningTier` surface: `off`, `low`, `midium`, `high`, `xhigh`, `max`.
- Add TUI `/think <tier>` runtime control for subsequent turns, with session persistence and resume restoration.
- Thread generation controls through `runPrompt`/`resolveGate` into provider requests.
- Map OpenAI-compatible request controls so `off` disables thinking, `low`/`midium`/`high` use high effort, and `xhigh`/`max` use max effort.
- Keep unset sessions provider-default: no thinking control fields are sent until the user explicitly chooses a tier.

## Verification

- `bun run typecheck`
- `bun test` (78 pass)
- `bun run doctor`