### PR TITLE
feat(tui): show collapsible reasoning content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ project follows Semantic Versioning once releases begin.
   control, plus `/think auto`/`unset` to return to provider defaults. Selected
   tiers are passed through the agent loop, persisted in session metadata, and
   restored on resume.
+- TUI `/reasoning hidden|collapsed|expanded` command and independent thinking
+  blocks for provider `reasoning_content`, including live streamed reasoning
+  display and bounded collapsed/expanded tail views.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ switch with `/providers`, `/models`, `/use <provider> <model>`, and
 `/model <model>`. Use `/think off|low|midium|high|xhigh|max` to set the
 thinking tier for subsequent provider requests, or `/think auto` to clear the
 explicit choice. Before this command is used, Vesicle leaves thinking behavior
-at the provider/model default.
+at the provider/model default. Use `/reasoning hidden|collapsed|expanded` to
+control whether provider reasoning content is shown in the TUI; the default is
+collapsed with a bounded tail preview.
 The provider file intentionally supports only Vesicle's small YAML subset:
 `default`, `providers`, scalar provider fields, and `models` string lists.
 Provider secrets are not read from this file; every provider must name an
@@ -73,6 +75,9 @@ return to an unresolved gate.
   plus `/think auto` to return to provider defaults; OpenAI-compatible requests
   map `off` to disabled thinking, `low`/`midium`/`high` to high effort, and
   `xhigh`/`max` to max effort
+- Reasoning visibility for models that return `reasoning_content`: the TUI
+  renders reasoning as a separate bounded block, defaults to collapsed preview,
+  and offers `/reasoning hidden|collapsed|expanded`
 - Engine profiles drive systemPrompt, tools, validators, and stop gates from
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker

--- a/STATUS.md
+++ b/STATUS.md
@@ -15,6 +15,7 @@ _Last updated: 2026-07-08_
 | Streaming | OpenAI-compatible SSE | In progress on 0.2 branch |
 | Provider registry | OpenAI-compatible profiles | In progress on 0.3 branch |
 | Thinking control | OpenAI-compatible reasoning controls | In progress on 0.3 branch |
+| Reasoning visibility | TUI collapsed/expanded reasoning blocks | In progress on 0.3 branch |
 | Artifact workbench | TUI commands + validation | In progress on 0.3 branch |
 
 ## Current Scope
@@ -39,6 +40,9 @@ Chat wrapper:
   `/think off|low|midium|high|xhigh|max`; `/think auto` clears the explicit
   choice. Unset sessions preserve the provider/model default instead of
   sending control fields.
+- Show provider `reasoning_content` as a separate TUI thinking block before
+  assistant text, with `/reasoning hidden|collapsed|expanded`; the default
+  collapsed mode keeps long reasoning bounded to a short tail preview.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
 - Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a
@@ -140,8 +144,10 @@ never abort a turn. Validators run only on artifact-shaped assistant content
   assistant content deltas and streamed tool-call reconstruction. Other
   provider protocols are still deferred.
 - Thinking-tier control maps to OpenAI-compatible `thinking` and
-  `reasoning_effort` request fields. Reasoning content is preserved for
-  tool-loop continuity but is not rendered as a user-visible thinking stream.
+  `reasoning_effort` request fields. User-visible reasoning is currently a TUI
+  display feature for preserved OpenAI-compatible `reasoning_content`; native
+  Anthropic, Gemini, and OpenAI Responses thinking surfaces are deferred with
+  their provider adapters.
 - TUI engine switching is hardcoded to ETL (runtime/evaluate profiles exist
   and load, but the TUI does not yet offer a selector).
 - Gate UI is Select-style for ETL blueprint and phase checkpoints, with a

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -132,8 +132,8 @@ Prompts are runtime assets, not hardcoded source literals.
 - Tool calls and tool results should be persisted for replay/debugging.
 - User-selected reasoning tiers should be persisted as session metadata so
   interactive resume restores runtime generation behavior. Provider
-  `reasoning_content` is preserved for protocol continuity, not treated as
-  user-visible assistant prose by default.
+  `reasoning_content` is preserved for protocol continuity and TUI display,
+  but it is metadata and must not be merged into normal assistant prose.
 - Session lists should mark unresolved gates so the user can distinguish a
   normal transcript from a workflow waiting for confirmation.
 - Long-running turns should emit host-visible activity events before and after
@@ -163,6 +163,10 @@ Prompts are runtime assets, not hardcoded source literals.
 - Provider/model switching commands and artifact workbench commands are local
   host actions. They should add concise host notices to the transcript and must
   not call the provider unless the command explicitly starts a revision prompt.
+- Reasoning content should follow the RikkaHub-style pattern of a separate
+  thinking block before assistant text: it is independent from the assistant
+  markdown body, collapsible or hideable, and bounded by height/tail display so
+  long thinking does not dominate the transcript.
 - Ctrl+C behavior:
   - With a selectable OpenTUI range, copy selection.
   - Without a selection, first press arms exit and the second press exits.

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -34,8 +34,14 @@ export type RunPromptOptions = {
 export type AgentLoopEvent =
   | { type: "provider_request"; iteration: number }
   | { type: "assistant_delta"; delta: string }
+  | { type: "assistant_reasoning_delta"; delta: string }
   | { type: "tool_call_delta"; name?: string; argumentsDelta?: string }
-  | { type: "assistant_response"; content: string; toolCalls: Array<{ id: string; name: string; arguments: string }> }
+  | {
+      type: "assistant_response";
+      content: string;
+      reasoningContent?: string;
+      toolCalls: Array<{ id: string; name: string; arguments: string }>;
+    }
   | { type: "tool_call"; name: string; callId: string; arguments: string }
   | { type: "tool_result"; name: string; callId: string; ok: boolean; content: string }
   | { type: "gate_pending"; gate: string }
@@ -232,6 +238,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
     onEvent?.({
       type: "assistant_response",
       content: response.content,
+      ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
       toolCalls: toolCalls.map((call) => ({ id: call.id, name: call.name, arguments: call.arguments })),
     });
     if (toolCalls.length === 0) {
@@ -443,6 +450,7 @@ async function completeWithStreaming(
         onEvent?.({ type: "assistant_delta", delta: event.delta });
         break;
       case "reasoning_delta":
+        onEvent?.({ type: "assistant_reasoning_delta", delta: event.delta });
         break;
       case "tool_call_delta":
         onEvent?.({

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -6,6 +6,8 @@ import type { ProviderSelection } from "../../config/providers";
 import { reasoningTiers } from "../../providers/shared/types";
 import type { ReasoningTier } from "../../providers/shared/types";
 
+export type ReasoningDisplayMode = "hidden" | "collapsed" | "expanded";
+
 export type SessionRole = "user" | "assistant" | "system" | "tool";
 
 type ResumedToolCall = {
@@ -160,6 +162,7 @@ export type SessionSnapshot = {
   messages: ResumedMessage[];
   providerSelection?: ProviderSelection;
   reasoningTier?: ReasoningTier;
+  reasoningDisplayMode?: ReasoningDisplayMode;
   pendingGate?: {
     gate: GateRequest;
     toolCallId: string;
@@ -186,6 +189,7 @@ export async function loadSessionSnapshot(
   let skippedFirstSystem = false;
   let providerSelection: ProviderSelection | undefined;
   let reasoningTier: ReasoningTier | undefined;
+  let reasoningDisplayMode: ReasoningDisplayMode | undefined;
 
   for (const record of records) {
     const providerId = record.metadata?.providerId;
@@ -195,6 +199,9 @@ export async function loadSessionSnapshot(
     }
     if (record.metadata && Object.hasOwn(record.metadata, "reasoningTier")) {
       reasoningTier = readReasoningTier(record.metadata.reasoningTier);
+    }
+    if (record.metadata && Object.hasOwn(record.metadata, "reasoningDisplayMode")) {
+      reasoningDisplayMode = readReasoningDisplayMode(record.metadata.reasoningDisplayMode);
     }
 
     if (record.role === "system") {
@@ -253,6 +260,7 @@ export async function loadSessionSnapshot(
     messages,
     ...(providerSelection ? { providerSelection } : {}),
     ...(reasoningTier ? { reasoningTier } : {}),
+    ...(reasoningDisplayMode ? { reasoningDisplayMode } : {}),
     ...(pendingGate
       ? {
           pendingGate: {
@@ -268,6 +276,12 @@ export async function loadSessionSnapshot(
 function readReasoningTier(value: unknown): ReasoningTier | undefined {
   return typeof value === "string" && (reasoningTiers as readonly string[]).includes(value)
     ? value as ReasoningTier
+    : undefined;
+}
+
+function readReasoningDisplayMode(value: unknown): ReasoningDisplayMode | undefined {
+  return value === "hidden" || value === "collapsed" || value === "expanded"
+    ? value
     : undefined;
 }
 

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -16,7 +16,7 @@ import { sharedSyntaxStyle, palette } from "./theme";
 import { GatePrompt, gateFocusOrder, gateResolutionFromState } from "./GatePrompt";
 import type { GateFocusTarget } from "./GatePrompt";
 import { createSessionStore, listSessions, loadSessionSnapshot } from "../core/session/store";
-import type { SessionSummary } from "../core/session/store";
+import type { ReasoningDisplayMode, ResumedMessage, SessionSummary } from "../core/session/store";
 import { resolveValidators, runValidators } from "../core/validators/registry";
 import { executeFileTool } from "../core/tools";
 import { resolveTuiLayout } from "./layout";
@@ -29,10 +29,10 @@ import {
 } from "./tool-summary";
 
 type Role = "user" | "assistant" | "system" | "tool";
-
 type Message = {
   role: Role;
   content: string;
+  kind?: "reasoning";
 };
 
 type PendingGate = Extract<RunPromptResult, { kind: "needs_user" }>;
@@ -68,6 +68,7 @@ export function App() {
   const [activeProvider, setActiveProvider] = createSignal("loading");
   const [activeModel, setActiveModel] = createSignal("loading");
   const [thinkingTier, setThinkingTier] = createSignal<ReasoningTier | undefined>();
+  const [reasoningDisplayMode, setReasoningDisplayMode] = createSignal<ReasoningDisplayMode>("collapsed");
   const [providerHasApiKey, setProviderHasApiKey] = createSignal(false);
   const [providerConfigReady, setProviderConfigReady] = createSignal(false);
   const [messages, setMessages] = createSignal<Message[]>([
@@ -91,6 +92,7 @@ export function App() {
     { kind: "system", text: "Activity will show provider requests, tool calls, gates, and validation." },
   ]);
   const [streamingAssistant, setStreamingAssistant] = createSignal("");
+  const [streamingReasoning, setStreamingReasoning] = createSignal("");
   const [lastDisplayedToolAssistantContent, setLastDisplayedToolAssistantContent] = createSignal<string | null>(null);
   const [promptHistory, setPromptHistory] = createSignal<string[]>([]);
   const [historyIndex, setHistoryIndex] = createSignal<number | null>(null);
@@ -251,30 +253,30 @@ export function App() {
     }
   }
 
-	  const submitPrompt = async (value: string) => {
-	    const prompt = value.trim();
-	    if (!prompt || busy()) return;
+  const submitPrompt = async (value: string) => {
+    const prompt = value.trim();
+    if (!prompt || busy()) return;
 
-	    // Slash commands for session management. These never hit the provider.
-	    if (prompt.startsWith("/")) {
-	      try {
-	        await handleCommand(prompt);
-	      } catch (error) {
-	        reportError(error);
-	      }
-	      return;
-	    }
+    // Slash commands for session management. These never hit the provider.
+    if (prompt.startsWith("/")) {
+      try {
+        await handleCommand(prompt);
+      } catch (error) {
+        reportError(error);
+      }
+      return;
+    }
 
-	    if (!providerConfigReady()) {
-	      setStatus("loading provider config");
-	      try {
-	        await loadProviderConfigOnce();
-	      } catch (error) {
-	        setProviderConfigReady(true);
-	        reportError(error);
-	        return;
-	      }
-	    }
+    if (!providerConfigReady()) {
+      setStatus("loading provider config");
+      try {
+        await loadProviderConfigOnce();
+      } catch (error) {
+        setProviderConfigReady(true);
+        reportError(error);
+        return;
+      }
+    }
 
     setPromptHistory((prev) => [...prev.filter((entry) => entry !== prompt), prompt].slice(-50));
     setHistoryIndex(null);
@@ -282,7 +284,7 @@ export function App() {
     setLastDisplayedToolAssistantContent(null);
     setBusy(true);
     setStatus("sending request");
-	    recordActivity({ kind: "provider", text: "sending provider request" });
+    recordActivity({ kind: "provider", text: "sending provider request" });
     const requestMessages: VesicleMessage[] = [
       ...conversation(),
       { role: "user", content: prompt },
@@ -293,12 +295,12 @@ export function App() {
       const result = await runPrompt({
         input: prompt,
         engine: "etl",
-	        sessionId: sessionId(),
-	        messages: requestMessages,
-	        providerSelection: activeProviderSelection(),
-	        generation: activeGeneration(),
-	        onEvent: handleAgentEvent,
-	      });
+        sessionId: sessionId(),
+        messages: requestMessages,
+        providerSelection: activeProviderSelection(),
+        generation: activeGeneration(),
+        onEvent: handleAgentEvent,
+      });
       handleResult(result, requestMessages);
     } catch (error) {
       reportError(error);
@@ -328,12 +330,12 @@ export function App() {
         sessionId: gate.sessionId,
         messages: gate.messages,
         toolCallId: gate.toolCallId,
-	        gate: gate.gate,
-	        resolution,
-	        providerSelection: activeProviderSelection(),
-	        generation: activeGeneration(),
-	        onEvent: handleAgentEvent,
-	      });
+        gate: gate.gate,
+        resolution,
+        providerSelection: activeProviderSelection(),
+        generation: activeGeneration(),
+        onEvent: handleAgentEvent,
+      });
       handleResult(result, gate.messages);
     } catch (error) {
       setPendingGate(gate);
@@ -387,6 +389,9 @@ export function App() {
     void refreshArtifacts();
 
     const appended: Message[] = [];
+    if (!result.response.toolCalls?.length && result.response.reasoningContent?.trim()) {
+      appended.push({ role: "system", content: result.response.reasoningContent, kind: "reasoning" });
+    }
     if (!result.response.toolCalls?.length && result.response.content.trim()) {
       appended.push({ role: "assistant", content: result.response.content });
     }
@@ -402,6 +407,7 @@ export function App() {
     setStatus("error");
     setOutput(message);
     setStreamingAssistant("");
+    setStreamingReasoning("");
     recordActivity({ kind: "system", text: `error: ${message}` });
     setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${message}` }]);
   }
@@ -410,10 +416,14 @@ export function App() {
     switch (event.type) {
       case "provider_request":
         setStreamingAssistant("");
+        setStreamingReasoning("");
         recordActivity({ kind: "provider", text: `provider request #${event.iteration + 1}` });
         return;
       case "assistant_delta":
         setStreamingAssistant((prev) => `${prev}${event.delta}`);
+        return;
+      case "assistant_reasoning_delta":
+        setStreamingReasoning((prev) => `${prev}${event.delta}`);
         return;
       case "tool_call_delta":
         if (event.name) {
@@ -422,6 +432,10 @@ export function App() {
         return;
       case "assistant_response":
         setStreamingAssistant("");
+        setStreamingReasoning("");
+        if (event.reasoningContent && event.toolCalls.length > 0) {
+          appendReasoningMessage(event.reasoningContent);
+        }
         if (event.toolCalls.length > 0) {
           const content = renderAssistantToolTurn(event.content, event.toolCalls);
           setMessages((prev) => [...prev, { role: "assistant", content }]);
@@ -453,6 +467,11 @@ export function App() {
 
   function recordActivity(entry: ActivityEntry) {
     setActivity((prev) => [...prev, entry].slice(-60));
+  }
+
+  function appendReasoningMessage(content: string) {
+    if (!content.trim()) return;
+    setMessages((prev) => [...prev, { role: "system", content, kind: "reasoning" }]);
   }
 
   async function refreshProviderConfig(selection?: Partial<ProviderSelection>) {
@@ -534,6 +553,20 @@ export function App() {
     });
   }
 
+  async function persistReasoningSwitch(mode: ReasoningDisplayMode) {
+    const id = sessionId();
+    if (!id) return;
+    const store = await createSessionStore(process.cwd(), id);
+    await store.append({
+      role: "system",
+      content: `Reasoning display switched to ${mode}.`,
+      metadata: {
+        kind: "reasoning-switch",
+        reasoningDisplayMode: mode,
+      },
+    });
+  }
+
   const handleSubmit = (value: unknown) => {
     if (pendingGate()) return; // gate mode owns the input
     const submitted = typeof value === "string" ? value : inputValue();
@@ -546,20 +579,21 @@ export function App() {
    * Slash commands for session management and help. These run locally and
    * never touch the provider:
    *   /resume           list resumable sessions with numeric indices
-	 *   /resume <n>       resume the nth session from the last /resume list
-	 *   /resume <id>      resume a session by full id prefix
-	 *   /providers        list configured providers
-	 *   /models [id]      list models for a provider
-	 *   /use <id> <model> switch provider and model
-	 *   /model <model>    switch model within the active provider
-	 *   /think <tier>     set thinking tier: off/low/midium/high/xhigh/max/auto
-	 *   /artifacts        list generated artifacts
-	 *   /artifact <n|path> preview an artifact
-	 *   /validate <n|path> validate an artifact file
-	 *   /revise <n|path> <instructions> revise an artifact
-	 *   /new              abandon the current session and start fresh
-	 *   /help             show available commands
-	 */
+   *   /resume <n>       resume the nth session from the last /resume list
+   *   /resume <id>      resume a session by full id prefix
+   *   /providers        list configured providers
+   *   /models [id]      list models for a provider
+   *   /use <id> <model> switch provider and model
+   *   /model <model>    switch model within the active provider
+   *   /think <tier>     set thinking tier: off/low/midium/high/xhigh/max/auto
+   *   /reasoning <mode> show reasoning: hidden/collapsed/expanded
+   *   /artifacts        list generated artifacts
+   *   /artifact <n|path> preview an artifact
+   *   /validate <n|path> validate an artifact file
+   *   /revise <n|path> <instructions> revise an artifact
+   *   /new              abandon the current session and start fresh
+   *   /help             show available commands
+   */
   async function handleCommand(input: string) {
     const [command, ...rest] = input.slice(1).split(/\s+/);
     const arg = rest.join(" ").trim();
@@ -569,136 +603,158 @@ export function App() {
         ...prev,
         { role: "user", content: input },
         {
-	          role: "system",
-	          content: "Commands:\n  /providers        list configured providers\n  /models [id]      list models for a provider\n  /use <id> <model> switch provider/model\n  /model <model>    switch model in active provider\n  /think <tier>     set thinking tier: off/low/midium/high/xhigh/max/auto\n  /artifacts        list generated artifacts\n  /artifact <n|path> preview an artifact\n  /validate <n|path> validate an artifact file\n  /revise <n|path> <instructions> revise an artifact\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
-	        },
-	      ]);
-	      return;
-	    }
+          role: "system",
+          content: "Commands:\n  /providers        list configured providers\n  /models [id]      list models for a provider\n  /use <id> <model> switch provider/model\n  /model <model>    switch model in active provider\n  /think <tier>     set thinking tier: off/low/midium/high/xhigh/max/auto\n  /reasoning <mode> show reasoning: hidden/collapsed/expanded (aliases: off/preview/on)\n  /artifacts        list generated artifacts\n  /artifact <n|path> preview an artifact\n  /validate <n|path> validate an artifact file\n  /revise <n|path> <instructions> revise an artifact\n  /resume           list sessions\n  /resume <n|id>    resume a session\n  /new              start a fresh session\n  /help             show this help",
+        },
+      ]);
+      return;
+    }
 
-	    if (command === "providers") {
-	      const registry = await ensureProviderRegistry();
-	      setMessages((prev) => [
-	        ...prev,
-	        { role: "user", content: input },
-	        { role: "system", content: renderProviderList(registry, activeProvider()) },
-	      ]);
-	      return;
-	    }
+    if (command === "providers") {
+      const registry = await ensureProviderRegistry();
+      setMessages((prev) => [
+        ...prev,
+        { role: "user", content: input },
+        { role: "system", content: renderProviderList(registry, activeProvider()) },
+      ]);
+      return;
+    }
 
-	    if (command === "models") {
-	      const registry = await ensureProviderRegistry();
-	      const providerId = arg || activeProvider();
-	      setMessages((prev) => [
-	        ...prev,
-	        { role: "user", content: input },
-	        { role: "system", content: renderModelList(registry, providerId, activeModel()) },
-	      ]);
-	      return;
-	    }
+    if (command === "models") {
+      const registry = await ensureProviderRegistry();
+      const providerId = arg || activeProvider();
+      setMessages((prev) => [
+        ...prev,
+        { role: "user", content: input },
+        { role: "system", content: renderModelList(registry, providerId, activeModel()) },
+      ]);
+      return;
+    }
 
-	    if (command === "use") {
-	      const [providerId, ...modelParts] = arg.split(/\s+/).filter(Boolean);
-	      const model = modelParts.join(" ");
-	      if (!providerId || !model) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /use <provider> <model>" }]);
-	        return;
-	      }
-	      const selection = await applyProviderSelection({ provider: providerId, model });
-	      await persistProviderSwitch(selection);
-	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
-	      return;
-	    }
+    if (command === "use") {
+      const [providerId, ...modelParts] = arg.split(/\s+/).filter(Boolean);
+      const model = modelParts.join(" ");
+      if (!providerId || !model) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /use <provider> <model>" }]);
+        return;
+      }
+      const selection = await applyProviderSelection({ provider: providerId, model });
+      await persistProviderSwitch(selection);
+      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
+      return;
+    }
 
-	    if (command === "model") {
-	      if (!arg) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /model <model>" }]);
-	        return;
-	      }
-	      const selection = await applyProviderSelection({ provider: activeProvider(), model: arg });
-	      await persistProviderSwitch(selection);
-	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
-	      return;
-	    }
+    if (command === "model") {
+      if (!arg) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /model <model>" }]);
+        return;
+      }
+      const selection = await applyProviderSelection({ provider: activeProvider(), model: arg });
+      await persistProviderSwitch(selection);
+      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
+      return;
+    }
 
-	    if (command === "think") {
-	      if (!arg) {
-	        setMessages((prev) => [
-	          ...prev,
-	          { role: "user", content: input },
-	          { role: "system", content: `Thinking tier: ${thinkingTier() ?? "provider default"}. Use /think off|low|midium|high|xhigh|max|auto.` },
-	        ]);
-	        return;
-	      }
-	      const tier = parseThinkingTier(arg);
-	      if (!tier) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /think off|low|midium|high|xhigh|max|auto" }]);
-	        return;
-	      }
-	      if (tier === "auto") {
-	        setThinkingTier(undefined);
-	        setStatus("thinking provider default");
-	        recordActivity({ kind: "provider", text: "thinking tier provider default" });
-	        await persistThinkingSwitch(undefined);
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Thinking tier reset to provider default." }]);
-	        return;
-	      }
-	      setThinkingTier(tier);
-	      setStatus(`thinking ${tier}`);
-	      recordActivity({ kind: "provider", text: `thinking tier ${tier}` });
-	      await persistThinkingSwitch(tier);
-	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Thinking tier set to ${tier}.` }]);
-	      return;
-	    }
+    if (command === "think") {
+      if (!arg) {
+        setMessages((prev) => [
+          ...prev,
+          { role: "user", content: input },
+          { role: "system", content: `Thinking tier: ${thinkingTier() ?? "provider default"}. Use /think off|low|midium|high|xhigh|max|auto.` },
+        ]);
+        return;
+      }
+      const tier = parseThinkingTier(arg);
+      if (!tier) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /think off|low|midium|high|xhigh|max|auto" }]);
+        return;
+      }
+      if (tier === "auto") {
+        setThinkingTier(undefined);
+        setStatus("thinking provider default");
+        recordActivity({ kind: "provider", text: "thinking tier provider default" });
+        await persistThinkingSwitch(undefined);
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Thinking tier reset to provider default." }]);
+        return;
+      }
+      setThinkingTier(tier);
+      setStatus(`thinking ${tier}`);
+      recordActivity({ kind: "provider", text: `thinking tier ${tier}` });
+      await persistThinkingSwitch(tier);
+      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Thinking tier set to ${tier}.` }]);
+      return;
+    }
 
-	    if (command === "artifacts") {
-	      const entries = await refreshArtifacts();
-	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: renderArtifactList(entries) }]);
-	      return;
-	    }
+    if (command === "reasoning") {
+      if (!arg) {
+        setMessages((prev) => [
+          ...prev,
+          { role: "user", content: input },
+          { role: "system", content: `Reasoning display: ${reasoningDisplayMode()}. Use /reasoning hidden|collapsed|expanded (aliases: off|preview|on).` },
+        ]);
+        return;
+      }
+      const mode = parseReasoningDisplayMode(arg);
+      if (!mode) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /reasoning hidden|collapsed|expanded" }]);
+        return;
+      }
+      setReasoningDisplayMode(mode);
+      setStatus(`reasoning ${mode}`);
+      recordActivity({ kind: "provider", text: `reasoning display ${mode}` });
+      await persistReasoningSwitch(mode);
+      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Reasoning display set to ${mode}.` }]);
+      return;
+    }
 
-	    if (command === "artifact" || command === "open") {
-	      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
-	      const artifact = resolveArtifactTarget(entries, arg);
-	      if (!artifact) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${arg || "(empty)"}". Use /artifacts to list.` }]);
-	        return;
-	      }
-	      const selected = await loadArtifactPreview(artifact);
-	      setSelectedArtifact(selected);
-	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Selected artifact ${selected.path}. Preview is shown in the right pane.` }]);
-	      return;
-	    }
+    if (command === "artifacts") {
+      const entries = await refreshArtifacts();
+      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: renderArtifactList(entries) }]);
+      return;
+    }
 
-	    if (command === "validate") {
-	      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
-	      const artifact = resolveArtifactTarget(entries, arg);
-	      if (!artifact) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${arg || "(empty)"}". Use /artifacts to list.` }]);
-	        return;
-	      }
-	      const selected = await loadArtifactPreview(artifact, { validate: true });
-	      setSelectedArtifact(selected);
-	      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: selected.validation ?? `No validator matched ${selected.path}.` }]);
-	      return;
-	    }
+    if (command === "artifact" || command === "open") {
+      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
+      const artifact = resolveArtifactTarget(entries, arg);
+      if (!artifact) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${arg || "(empty)"}". Use /artifacts to list.` }]);
+        return;
+      }
+      const selected = await loadArtifactPreview(artifact);
+      setSelectedArtifact(selected);
+      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `Selected artifact ${selected.path}. Preview is shown in the right pane.` }]);
+      return;
+    }
 
-	    if (command === "revise") {
-	      const [targetArg, ...instructionParts] = arg.split(/\s+/).filter(Boolean);
-	      const instructions = instructionParts.join(" ");
-	      if (!targetArg || !instructions) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /revise <n|path> <instructions>" }]);
-	        return;
-	      }
-	      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
-	      const artifact = resolveArtifactTarget(entries, targetArg);
-	      if (!artifact) {
-	        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${targetArg}". Use /artifacts to list.` }]);
-	        return;
-	      }
-	      await submitPrompt(`Revise artifact ${artifact.path}. First read_file that path, then apply this request and write_file the revised artifact back to the same path: ${instructions}`);
-	      return;
-	    }
+    if (command === "validate") {
+      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
+      const artifact = resolveArtifactTarget(entries, arg);
+      if (!artifact) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${arg || "(empty)"}". Use /artifacts to list.` }]);
+        return;
+      }
+      const selected = await loadArtifactPreview(artifact, { validate: true });
+      setSelectedArtifact(selected);
+      setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: selected.validation ?? `No validator matched ${selected.path}.` }]);
+      return;
+    }
+
+    if (command === "revise") {
+      const [targetArg, ...instructionParts] = arg.split(/\s+/).filter(Boolean);
+      const instructions = instructionParts.join(" ");
+      if (!targetArg || !instructions) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: "Usage: /revise <n|path> <instructions>" }]);
+        return;
+      }
+      const entries = artifacts().length > 0 ? artifacts() : await refreshArtifacts();
+      const artifact = resolveArtifactTarget(entries, targetArg);
+      if (!artifact) {
+        setMessages((prev) => [...prev, { role: "user", content: input }, { role: "system", content: `No artifact matches "${targetArg}". Use /artifacts to list.` }]);
+        return;
+      }
+      await submitPrompt(`Revise artifact ${artifact.path}. First read_file that path, then apply this request and write_file the revised artifact back to the same path: ${instructions}`);
+      return;
+    }
 
     if (command === "new") {
       setMessages((prev) => [...prev, { role: "user", content: input }]);
@@ -749,31 +805,35 @@ export function App() {
       const snapshot = await loadSessionSnapshot(process.cwd(), target.sessionId, {
         synthesizeDanglingToolResults: false,
       });
-      const resumedMessages = snapshot.messages as VesicleMessage[];
-      const transcript = resumedMessages.map(displayMessageFromResumed);
+      const resumedMessages = vesicleMessagesFromResumed(snapshot.messages);
+      const transcript = snapshot.messages.flatMap(displayMessagesFromResumed);
       setSessionId(target.sessionId);
       setSessionPath(joinSessionPath(target.sessionId));
       setConversation(resumedMessages);
       setOutput(snapshot.pendingGate?.assistantContent ?? "");
       setSessionPicker(null);
 
-	      const hostMessages: Message[] = [];
-	      if (commandEcho) hostMessages.push({ role: "user", content: commandEcho });
-	      if (snapshot.providerSelection) {
-	        try {
-	          const selection = await applyProviderSelection(snapshot.providerSelection);
-	          hostMessages.push({ role: "system", content: `Restored provider ${selection.provider}/${selection.model} from session.` });
-	        } catch (error) {
-	          const message = error instanceof Error ? error.message : String(error);
-	          hostMessages.push({ role: "system", content: `Session provider was not restored: ${message}` });
-	        }
-	      }
-	      if (snapshot.reasoningTier) {
-	        setThinkingTier(snapshot.reasoningTier);
-	        hostMessages.push({ role: "system", content: `Restored thinking tier ${snapshot.reasoningTier} from session.` });
-	      }
+      const hostMessages: Message[] = [];
+      if (commandEcho) hostMessages.push({ role: "user", content: commandEcho });
+      if (snapshot.providerSelection) {
+        try {
+          const selection = await applyProviderSelection(snapshot.providerSelection);
+          hostMessages.push({ role: "system", content: `Restored provider ${selection.provider}/${selection.model} from session.` });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          hostMessages.push({ role: "system", content: `Session provider was not restored: ${message}` });
+        }
+      }
+      if (snapshot.reasoningTier) {
+        setThinkingTier(snapshot.reasoningTier);
+        hostMessages.push({ role: "system", content: `Restored thinking tier ${snapshot.reasoningTier} from session.` });
+      }
+      if (snapshot.reasoningDisplayMode) {
+        setReasoningDisplayMode(snapshot.reasoningDisplayMode);
+        hostMessages.push({ role: "system", content: `Restored reasoning display ${snapshot.reasoningDisplayMode} from session.` });
+      }
 
-	      if (snapshot.pendingGate) {
+      if (snapshot.pendingGate) {
         setPendingGate({
           kind: "needs_user",
           sessionId: target.sessionId,
@@ -807,14 +867,42 @@ export function App() {
     }
   }
 
-	  async function refreshArtifacts(): Promise<ArtifactEntry[]> {
-	    const entries = await scanArtifacts(process.cwd());
-	    setArtifacts(entries);
-	    setSelectedArtifact((selected) => selected && entries.some((entry) => entry.path === selected.path) ? selected : null);
-	    return entries;
-	  }
+  async function refreshArtifacts(): Promise<ArtifactEntry[]> {
+    const entries = await scanArtifacts(process.cwd());
+    setArtifacts(entries);
+    setSelectedArtifact((selected) => selected && entries.some((entry) => entry.path === selected.path) ? selected : null);
+    return entries;
+  }
+
+  function renderReasoningBlock(content: string, streaming: boolean) {
+    const mode = reasoningDisplayMode();
+    if (mode === "hidden" || !content.trim()) return <box height={0} />;
+
+    const sideWidth = (layout().showWorkspace ? layout().leftPanelWidth : 0) + (layout().showOutput ? layout().rightPanelWidth : 0);
+    const width = Math.max(20, layout().width - sideWidth - 12);
+    const maxLines = mode === "expanded" ? 14 : 4;
+    const lines = reasoningDisplayLines(content, width, maxLines);
+    const rawLines = content.split(/\r?\n/).length;
+    const label = mode === "expanded" ? "thinking expanded" : "thinking collapsed";
+    const hint = mode === "expanded" ? "/reasoning collapse" : "/reasoning expand";
+    const stats = `${content.length} chars, ${rawLines} line${rawLines === 1 ? "" : "s"}`;
+
+    return (
+      <box flexDirection="column">
+        <text content={`━━━━━━━━ ${streaming ? "thinking streaming" : label} (${stats}) ${hint}`} fg={palette.textMuted} attributes={1} />
+        <For each={lines}>
+          {(line) => <text content={line} fg={palette.textDim} />}
+        </For>
+        <text content=" " fg={palette.textDim} />
+      </box>
+    );
+  }
 
   const renderMessage = (message: Message) => {
+    if (message.kind === "reasoning") {
+      return renderReasoningBlock(message.content, false);
+    }
+
     const color =
       message.role === "user" ? palette.user
         : message.role === "assistant" ? palette.assistant
@@ -856,8 +944,8 @@ export function App() {
   return (
     <box flexDirection="column" width="100%" height="100%" backgroundColor={palette.bg}>
       <box height={3} border borderColor={palette.panelBorder} paddingX={1} flexDirection="row">
-	        <text
-	          content={headerLine(activeProvider(), activeModel(), status(), layout().width)}
+        <text
+          content={headerLine(activeProvider(), activeModel(), status(), layout().width)}
           fg={busy() ? palette.warn : pendingGate() ? palette.gateAccent : palette.success}
           attributes={1}
         />
@@ -869,10 +957,11 @@ export function App() {
             <PanelLine content="Engine" fg={palette.textMuted} />
             <PanelLine content="etl" fg={palette.textPrimary} attributes={1} />
             <PanelLine content=" " fg={palette.textDim} />
-	            <PanelLine content="Provider" fg={palette.textMuted} />
-	            <PanelLine content={truncateLine(`${activeProvider()}/${activeModel()}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
-	            <PanelLine content={providerHasApiKey() ? "API key: available" : "API key: missing"} fg={providerHasApiKey() ? palette.success : palette.error} />
-	            <PanelLine content={truncateLine(`Thinking: ${thinkingTier() ?? "provider default"}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
+            <PanelLine content="Provider" fg={palette.textMuted} />
+            <PanelLine content={truncateLine(`${activeProvider()}/${activeModel()}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
+            <PanelLine content={providerHasApiKey() ? "API key: available" : "API key: missing"} fg={providerHasApiKey() ? palette.success : palette.error} />
+            <PanelLine content={truncateLine(`Thinking: ${thinkingTier() ?? "provider default"}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
+            <PanelLine content={truncateLine(`Reasoning: ${reasoningDisplayMode()}`, layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
             <PanelLine content=" " fg={palette.textDim} />
             <PanelLine content="Session" fg={palette.textMuted} />
             <PanelLine content={truncateMiddle(sessionPath(), layout().leftPanelWidth - 4)} fg={palette.textSecondary} />
@@ -890,6 +979,9 @@ export function App() {
           <scrollbox width="100%" height="100%" stickyScroll stickyStart="bottom">
             <box flexDirection="column">
               {messages().map((message) => renderMessage(message))}
+              <Show when={streamingReasoning().trim().length > 0 && reasoningDisplayMode() !== "hidden"} fallback={<box height={0} />}>
+                {renderReasoningBlock(streamingReasoning(), true)}
+              </Show>
               <Show when={streamingAssistant().trim().length > 0} fallback={<box height={0} />}>
                 <box flexDirection="column">
                   <text content="━━━━━━━━ assistant streaming" fg={palette.assistant} attributes={1} />
@@ -905,24 +997,24 @@ export function App() {
             <scrollbox width="100%" height="100%" stickyScroll stickyStart="top">
               <box flexDirection="column">
                 <text content="Activity" fg={palette.textMuted} />
-	                <For each={activity().slice(-10)}>
-	                  {(entry) => <text content={activityLine(entry, layout().rightPanelWidth - 4)} fg={activityColor(entry.kind)} />}
-	                </For>
-	                <text content=" " />
-	                <text content="Selected artifact" fg={palette.textMuted} />
-	                <Show when={selectedArtifact()} fallback={<text content="none selected" fg={palette.textDim} />}>
-	                  {(artifact) => (
-	                    <box flexDirection="column">
-	                      <text content={truncateMiddle(artifact().path, layout().rightPanelWidth - 4)} fg={palette.textSecondary} />
-	                      <Show when={artifact().validation} fallback={<box height={0} />}>
-	                        {(validation) => <text content={truncateLine(validation().split("\n")[0] ?? "", layout().rightPanelWidth - 4)} fg={validation().includes("found issues") ? palette.warn : palette.success} />}
-	                      </Show>
-	                      <text content={truncateLine(artifact().preview, layout().rightPanelWidth - 4)} fg={palette.textPrimary} />
-	                    </box>
-	                  )}
-	                </Show>
-	                <text content=" " />
-	                <text content="Recent artifacts" fg={palette.textMuted} />
+                <For each={activity().slice(-10)}>
+                  {(entry) => <text content={activityLine(entry, layout().rightPanelWidth - 4)} fg={activityColor(entry.kind)} />}
+                </For>
+                <text content=" " />
+                <text content="Selected artifact" fg={palette.textMuted} />
+                <Show when={selectedArtifact()} fallback={<text content="none selected" fg={palette.textDim} />}>
+                  {(artifact) => (
+                    <box flexDirection="column">
+                      <text content={truncateMiddle(artifact().path, layout().rightPanelWidth - 4)} fg={palette.textSecondary} />
+                      <Show when={artifact().validation} fallback={<box height={0} />}>
+                        {(validation) => <text content={truncateLine(validation().split("\n")[0] ?? "", layout().rightPanelWidth - 4)} fg={validation().includes("found issues") ? palette.warn : palette.success} />}
+                      </Show>
+                      <text content={truncateLine(artifact().preview, layout().rightPanelWidth - 4)} fg={palette.textPrimary} />
+                    </box>
+                  )}
+                </Show>
+                <text content=" " />
+                <text content="Recent artifacts" fg={palette.textMuted} />
                 <Show when={artifacts().length > 0} fallback={<text content="none yet" fg={palette.textDim} />}>
                   <For each={artifacts().slice(0, 6)}>
                     {(artifact) => <text content={truncateMiddle(artifact.path, layout().rightPanelWidth - 4)} fg={palette.textSecondary} />}
@@ -943,15 +1035,15 @@ export function App() {
               <box height={inputValue().startsWith("/") ? layout().bottomHeight : 3} border borderColor={palette.panelBorder} paddingX={1} flexDirection="column">
                 <Show when={inputValue().startsWith("/")} fallback={<box height={0} />}>
                   <box flexDirection="column">
-	                    <text content="/providers  list providers    /models  list models    /use <p> <m>  switch" fg={palette.textDim} />
-	                    <text content="/think <tier>  off/low/midium/high/xhigh/max/auto    /help" fg={palette.textDim} />
-	                    <text content="/resume  list sessions    /new  start fresh" fg={palette.textDim} />
+                    <text content="/providers  list providers    /models  list models    /use <p> <m>  switch" fg={palette.textDim} />
+                    <text content="/think <tier> off/low/midium/high/xhigh/max/auto    /reasoning <mode>" fg={palette.textDim} />
+                    <text content="/resume  list sessions    /new  start fresh    /help" fg={palette.textDim} />
                     <text content="Up/Down recalls prompt history" fg={palette.textDim} />
                   </box>
                 </Show>
-	                <input
-	                  focused
-	                  placeholder={busy() ? "Request in flight..." : !providerConfigReady() ? "Loading provider config..." : "Type prompt, Enter to send, /help for commands"}
+                <input
+                  focused
+                  placeholder={busy() ? "Request in flight..." : !providerConfigReady() ? "Loading provider config..." : "Type prompt, Enter to send, /help for commands"}
                   value={inputValue()}
                   onInput={setInputValue}
                   onSubmit={handleSubmit}
@@ -1023,6 +1115,14 @@ function parseThinkingTier(value: string): ReasoningTier | "auto" | null {
   if (raw === "auto" || raw === "unset" || raw === "default") return "auto";
   const normalized = raw === "medium" ? "midium" : raw;
   return (reasoningTiers as readonly string[]).includes(normalized) ? normalized as ReasoningTier : null;
+}
+
+function parseReasoningDisplayMode(value: string): ReasoningDisplayMode | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "hide" || normalized === "hidden" || normalized === "off") return "hidden";
+  if (normalized === "collapse" || normalized === "collapsed" || normalized === "fold" || normalized === "preview") return "collapsed";
+  if (normalized === "expand" || normalized === "expanded" || normalized === "show" || normalized === "on") return "expanded";
+  return null;
 }
 
 function renderArtifactList(entries: ArtifactEntry[]): string {
@@ -1112,26 +1212,51 @@ function activityColor(kind: ActivityEntry["kind"]): string {
   }
 }
 
-function displayMessageFromResumed(message: VesicleMessage): Message {
+function vesicleMessagesFromResumed(messages: ResumedMessage[]): VesicleMessage[] {
+  return messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+    ...(message.reasoningContent ? { reasoningContent: message.reasoningContent } : {}),
+    ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
+    ...(message.toolCalls ? { toolCalls: message.toolCalls.map((call) => ({ ...call })) } : {}),
+  }));
+}
+
+function displayMessagesFromResumed(message: ResumedMessage): Message[] {
   if (message.role === "assistant") {
     const content = message.toolCalls && message.toolCalls.length > 0
       ? renderAssistantToolTurn(message.content, message.toolCalls)
       : message.content;
-    return { role: "assistant", content };
+    return [
+      ...(message.reasoningContent?.trim() ? [{ role: "system" as const, content: message.reasoningContent, kind: "reasoning" as const }] : []),
+      { role: "assistant", content },
+    ];
   }
   if (message.role === "tool") {
-    return { role: "tool", content: renderResumedToolResultSummary(message.content) };
+    return [{ role: "tool", content: renderResumedToolResultSummary(message.content) }];
   }
   if (message.role === "user") {
-    return { role: message.role, content: message.content };
+    return [{ role: message.role, content: message.content }];
   }
-  return { role: "system", content: message.content };
+  return [{ role: "system", content: message.content }];
 }
 
 function truncateLine(value: string, width: number): string {
   const limit = Math.max(8, width);
   if (value.length <= limit) return value;
   return `${value.slice(0, limit - 3)}...`;
+}
+
+function reasoningDisplayLines(content: string, width: number, maxLines: number): string[] {
+  const cleaned = content.replace(/\t/g, "  ");
+  const rawLines = cleaned.split(/\r?\n/).map((line) => truncateLine(line || " ", width));
+  if (rawLines.length <= maxLines) return rawLines;
+  const visibleTailLines = Math.max(0, maxLines - 1);
+  const hidden = rawLines.length - visibleTailLines;
+  return [
+    `... ${hidden} earlier reasoning line${hidden === 1 ? "" : "s"} hidden`,
+    ...rawLines.slice(-visibleTailLines),
+  ];
 }
 
 function truncateMiddle(value: string, width: number): string {

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { resolveGate, runPrompt } from "../src/core/agent-loop/run";
+import type { AgentLoopEvent } from "../src/core/agent-loop/run";
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
@@ -103,6 +104,37 @@ describe("agent loop sessions", () => {
     expect(requestBodies[0]).toMatchObject({
       thinking: { type: "enabled" },
       reasoning_effort: "max",
+    });
+  });
+
+  test("emits streamed reasoning deltas from the provider", async () => {
+    const rootDir = await createPromptRoot();
+    const events: AgentLoopEvent[] = [];
+
+    globalThis.fetch = (async () => {
+      return new Response(rawSse([
+        'data: {"id":"chatcmpl-reasoning","choices":[{"delta":{"reasoning_content":"considering context"}}]}',
+        'data: {"id":"chatcmpl-reasoning","choices":[{"delta":{"content":"answer"},"finish_reason":"stop"}]}',
+        "data: [DONE]",
+      ]), {
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runPrompt({
+      input: "stream reasoning",
+      rootDir,
+      onEvent: (event) => events.push(event),
+    });
+
+    if (result.kind !== "complete") throw new Error("expected complete");
+    expect(result.response.reasoningContent).toBe("considering context");
+    expect(events).toContainEqual({ type: "assistant_reasoning_delta", delta: "considering context" });
+    expect(events).toContainEqual({
+      type: "assistant_response",
+      content: "answer",
+      reasoningContent: "considering context",
+      toolCalls: [],
     });
   });
 
@@ -525,4 +557,16 @@ async function configureTestProviderEnv(): Promise<void> {
 async function cleanupProviderConfigDirs(): Promise<void> {
   const dirs = providerConfigDirs.splice(0);
   await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })));
+}
+
+function rawSse(blocks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const block of blocks) {
+        controller.enqueue(encoder.encode(`${block}\n\n`));
+      }
+      controller.close();
+    },
+  });
 }

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -201,6 +201,27 @@ describe("session resume", () => {
     expect(snapshot.reasoningTier).toBeUndefined();
   });
 
+  test("loadSessionSnapshot restores the latest reasoning display mode", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-reasoning-display-session-"));
+    const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-reasoning-display");
+
+    await store.append({ role: "system", content: "prompt" });
+    await store.append({
+      role: "system",
+      content: "Reasoning display switched to hidden.",
+      metadata: { kind: "reasoning-switch", reasoningDisplayMode: "hidden" },
+    });
+    await store.append({
+      role: "system",
+      content: "Reasoning display switched to expanded.",
+      metadata: { kind: "reasoning-switch", reasoningDisplayMode: "expanded" },
+    });
+
+    const snapshot = await loadSessionSnapshot(rootDir, "2026-05-01T00-00-00-000Z-reasoning-display");
+
+    expect(snapshot.reasoningDisplayMode).toBe("expanded");
+  });
+
   test("loadSessionMessages does not synthesise results when tool results already exist", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-answered-"));
     const store = await createSessionStore(rootDir, "2026-05-01T00-00-00-000Z-eeeeeeee");


### PR DESCRIPTION
## Summary

- surface provider `reasoning_content` through agent-loop streaming events and final assistant response events
- render reasoning as a separate TUI thinking block with `/reasoning hidden|collapsed|expanded`, default collapsed bounded preview, and resumed-session support
- document reasoning visibility behavior and the RikkaHub-style separate reasoning block pattern

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test tests\agent-loop.test.ts tests\provider-backend.test.ts tests\tui.test.tsx`
- [x] `bun test`
- [x] `bun run doctor`
- [x] manual TUI smoke by user

## Notes / Follow-ups

- This keeps reasoning metadata separate from assistant prose; native Anthropic/Gemini/OpenAI Responses thinking surfaces remain deferred with their adapters.