### PR TITLE
feat(config): support model generation defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Read asset-specific docs when touching assets:
 
 - `assets/README.md`: Prism asset source and adaptation notes.
 - `docs/examples/providers.yaml`: canonical provider registry shape.
+- `docs/examples/provider.env.example`: user-level provider secret file shape.
 - `dev/docs/working/PLAN-Prism-Vesicle-architecture.md`: older architecture
   plan; useful context, but current code plus `STATUS.md` and `docs/dev/*` are
   authoritative when they differ.
@@ -110,10 +111,10 @@ Provider/model profiles are user-level host state, not project runtime state.
   `$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` and sibling `.env`, or
   `~/.config/prism-vesicle/providers.yaml` and sibling `.env`.
 
-`providers.yaml` must contain provider ids, protocols, base URLs, model lists,
-and `apiKeyEnv` names only. It must not contain API keys. The sibling `.env`
-contains the provider-specific secret values. Process environment variables are
-fallback only.
+`providers.yaml` must contain provider ids, protocols, base URLs, model entries,
+generation defaults, capability metadata, and `apiKeyEnv` names only. It must
+not contain API keys. The sibling `.env` contains the provider-specific secret
+values. Process environment variables are fallback only.
 
 Do not reintroduce a project-root `.env` dependency. If an old root `.env`
 appears during local work, treat it as legacy state to migrate or remove, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ project follows Semantic Versioning once releases begin.
 - TUI `/reasoning hidden|collapsed|expanded` command and independent thinking
   blocks for provider `reasoning_content`, including live streamed reasoning
   display and bounded collapsed/expanded tail views.
+- Object model entries in `providers.yaml` for config-driven generation
+  defaults (`temperature`, `maxTokens`) and model capability metadata, while
+  preserving existing string model entries.
 
 ### Changed
 
@@ -53,6 +56,8 @@ project follows Semantic Versioning once releases begin.
   provider wire controls: `off` disables thinking, `low`/`midium`/`high` map to
   high effort, and `xhigh`/`max` map to max effort. Unset sessions keep the
   provider/model default and do not send thinking control fields.
+- OpenAI-compatible request shaping now receives generation defaults from the
+  selected model config instead of inventing a hardcoded adapter temperature.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ Also read:
   docs-status, or tool-surface changes.
 - `assets/README.md` before editing copied Prism assets.
 - `docs/examples/providers.yaml` before changing provider config behavior.
+- `docs/examples/provider.env.example` before changing provider secret loading
+  behavior.
 
 For architecture, provider, TUI, session, or command-UX changes, first check
 whether the documented reference projects already solved a similar problem.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ Do not commit local runtime state or secrets:
 - generated test workspaces
 - provider API keys, tokens, or private base URLs
 
-Use `.env.example` for the user-level secret file shape.
+Use `docs/examples/provider.env.example` for the user-level secret file shape.
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Vesicle runs directly.
 bun install
 New-Item -ItemType Directory -Force $env:APPDATA\prism-vesicle
 Copy-Item docs\examples\providers.yaml $env:APPDATA\prism-vesicle\providers.yaml
-Copy-Item .env.example $env:APPDATA\prism-vesicle\.env
+Copy-Item docs\examples\provider.env.example $env:APPDATA\prism-vesicle\.env
 ```
 
 Edit your user-level provider config and set the environment variables named
@@ -30,11 +30,15 @@ at the provider/model default. Use `/reasoning hidden|collapsed|expanded` to
 control whether provider reasoning content is shown in the TUI; the default is
 collapsed with a bounded tail preview.
 The provider file intentionally supports only Vesicle's small YAML subset:
-`default`, `providers`, scalar provider fields, and `models` string lists.
-Provider secrets are not read from this file; every provider must name an
-`apiKeyEnv` variable and the actual key belongs in the same user-level
-directory's `.env` file. Process environment variables are used only when the
-user-level `.env` does not define that key.
+`default`, `providers`, scalar provider fields, and `models` entries. The
+canonical templates live together under `docs/examples/`: `providers.yaml` for
+the registry and `provider.env.example` for the sibling user-level `.env`.
+Models may be simple strings or object entries with `id`, optional
+`generation` defaults (`temperature`, `maxTokens`), and optional
+`capabilities`. Provider secrets are not read from the YAML file; every
+provider must name an `apiKeyEnv` variable and the actual key belongs in the
+same user-level directory's `.env` file. Process environment variables are
+used only when the user-level `.env` does not define that key.
 
 If you still have an old project-root `.env` from early testing, move the
 provider key variables into the user-level `.env` beside `providers.yaml`, then
@@ -71,6 +75,9 @@ return to an unresolved gate.
   supports SSE, including streamed tool-call reconstruction
 - Provider/model registry from the user-level `providers.yaml`, with TUI
   commands to switch provider and model inside a session
+- Config-driven model defaults and capability metadata in `providers.yaml`:
+  low-frequency generation knobs such as `temperature` and `maxTokens` stay in
+  config while high-frequency thinking control stays in the TUI
 - Runtime thinking-tier control with `/think off|low|midium|high|xhigh|max`
   plus `/think auto` to return to provider defaults; OpenAI-compatible requests
   map `off` to disabled thinking, `low`/`midium`/`high` to high effort, and

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,6 +14,7 @@ _Last updated: 2026-07-08_
 | Validators | Module A + Module B v9 schemas | Implemented |
 | Streaming | OpenAI-compatible SSE | In progress on 0.2 branch |
 | Provider registry | OpenAI-compatible profiles | In progress on 0.3 branch |
+| Model config | Generation defaults + capability metadata | In progress on 0.3 branch |
 | Thinking control | OpenAI-compatible reasoning controls | In progress on 0.3 branch |
 | Reasoning visibility | TUI collapsed/expanded reasoning blocks | In progress on 0.3 branch |
 | Artifact workbench | TUI commands + validation | In progress on 0.3 branch |
@@ -36,6 +37,10 @@ Chat wrapper:
   switch provider/model during a session. Provider files name `apiKeyEnv`
   variables only; actual secrets stay in the same user-level directory's
   `.env` file, with process environment variables used only as fallback.
+- Configure low-frequency model defaults in `providers.yaml` object model
+  entries: `generation.temperature`, `generation.maxTokens`, and capability
+  metadata for display and future protocol gating. String model entries remain
+  supported.
 - Control thinking behavior for subsequent TUI turns with
   `/think off|low|midium|high|xhigh|max`; `/think auto` clears the explicit
   choice. Unset sessions preserve the provider/model default instead of

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -58,6 +58,11 @@ Generation controls follow the same rule: core/TUI may pass the normalized
 only the provider adapter maps them to wire fields such as `thinking` and
 `reasoning_effort`. TUI commands may offer `auto`/`unset` to clear an explicit
 selection; that means no `reasoningTier` is sent.
+High-frequency thinking controls may be interactive TUI state. Lower-frequency
+generation defaults such as `temperature` and `maxTokens` belong in the
+user-level provider model config and are merged by `core/agent-loop` before
+calling adapters. Adapters should only map the normalized request shape to wire
+fields; they should not invent host policy defaults.
 Persistent provider profiles live in the user-level provider config, not in the
 project `.vesicle/` runtime state directory. The default path is
 `%APPDATA%\prism-vesicle\providers.yaml` on Windows and
@@ -68,6 +73,9 @@ inline in the provider file. The user-level `.env` file beside
 `providers.yaml` is the default place for those secret values; process
 environment variables are fallback only so a legacy project-root `.env` loaded
 by the runtime cannot override the user-level secret file.
+`providers.yaml` supports string model entries for the common case and object
+model entries for `id`, `generation`, and `capabilities` metadata. Keep this
+schema small and explicit until native protocol adapters require more fields.
 
 ## Tool Runtime
 

--- a/docs/examples/provider.env.example
+++ b/docs/examples/provider.env.example
@@ -1,4 +1,5 @@
 # Copy this file to the same user-level directory as providers.yaml.
 # Put only the variables named by each provider's apiKeyEnv here.
 DEEPSEEK_API_KEY=
+MIMO_API_KEY=
 LOCAL_OPENAI_COMPAT_API_KEY=

--- a/docs/examples/providers.yaml
+++ b/docs/examples/providers.yaml
@@ -9,7 +9,15 @@ providers:
     apiKeyEnv: DEEPSEEK_API_KEY
     models:
       - deepseek-v4-flash
-      - deepseek-reasoner
+      - id: deepseek-reasoner
+        generation:
+          temperature: 0.4
+          maxTokens: 8192
+        capabilities:
+          streaming: true
+          tools: true
+          reasoningTier: true
+          reasoningContent: true
 
   local:
     protocol: openai-chat-compatible

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,5 +1,19 @@
 export type VesicleProvider = "openai-chat-compatible";
 
+export type GenerationDefaults = {
+  temperature?: number;
+  maxTokens?: number;
+};
+
+export type ModelCapabilities = {
+  streaming?: boolean;
+  tools?: boolean;
+  reasoningTier?: boolean;
+  reasoningContent?: boolean;
+  temperature?: boolean;
+  maxTokens?: boolean;
+};
+
 export type VesicleConfig = {
   provider: VesicleProvider;
   providerId: string;
@@ -7,4 +21,6 @@ export type VesicleConfig = {
   model: string;
   apiKey?: string;
   apiKeyLabel?: string;
+  generation?: GenerationDefaults;
+  capabilities?: ModelCapabilities;
 };

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { VesicleConfig, VesicleProvider } from "./env";
+import type { GenerationDefaults, ModelCapabilities } from "./env";
 
 export type ProviderProtocol = VesicleProvider;
 
@@ -10,12 +11,18 @@ export type ProviderSelection = {
   model: string;
 };
 
+export type ProviderModelProfile = {
+  id: string;
+  generation?: GenerationDefaults;
+  capabilities?: ModelCapabilities;
+};
+
 export type ProviderProfile = {
   id: string;
   protocol: ProviderProtocol;
   baseUrl: string;
   apiKeyEnv: string;
-  models: string[];
+  models: ProviderModelProfile[];
 };
 
 export type ProviderRegistry = {
@@ -106,13 +113,11 @@ export function resolveProviderConfig(
 ): VesicleConfig {
   const providerId = selection?.provider ?? registry.default.provider;
   const profile = requireProvider(registry, providerId);
-  const model = selection?.model ?? (providerId === registry.default.provider ? registry.default.model : profile.models[0]);
+  const model = selection?.model ?? (providerId === registry.default.provider ? registry.default.model : profile.models[0]?.id);
   if (!model) {
     throw new Error(`Provider "${providerId}" does not declare any models.`);
   }
-  if (!profile.models.includes(model)) {
-    throw new Error(`Provider "${providerId}" does not declare model "${model}".`);
-  }
+  const modelProfile = requireModel(profile, model);
 
   return {
     provider: profile.protocol,
@@ -121,6 +126,8 @@ export function resolveProviderConfig(
     model,
     apiKey: env[profile.apiKeyEnv],
     apiKeyLabel: profile.apiKeyEnv,
+    ...(modelProfile.generation ? { generation: modelProfile.generation } : {}),
+    ...(modelProfile.capabilities ? { capabilities: modelProfile.capabilities } : {}),
   };
 }
 
@@ -185,8 +192,27 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
   let section: "default" | "providers" | null = null;
   let currentProvider: Partial<ProviderProfile> | null = null;
   let currentList: "models" | null = null;
+  let currentModel: Partial<ProviderModelProfile> | null = null;
+  let currentModelBlock: "generation" | "capabilities" | null = null;
+
+  const finishModel = () => {
+    if (!currentModel) return;
+    const id = currentModel.id;
+    if (!id) throw new Error(`Provider config ${path} has a model without an id.`);
+    currentProvider!.models = [
+      ...(currentProvider!.models ?? []),
+      {
+        id,
+        ...(currentModel.generation ? { generation: currentModel.generation } : {}),
+        ...(currentModel.capabilities ? { capabilities: currentModel.capabilities } : {}),
+      },
+    ];
+    currentModel = null;
+    currentModelBlock = null;
+  };
 
   const finishProvider = () => {
+    finishModel();
     if (!currentProvider) return;
     const id = currentProvider.id;
     if (!id) throw new Error(`Provider config ${path} has a provider without an id.`);
@@ -201,6 +227,8 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
     if (!apiKeyEnv) throw new Error(`Provider "${id}" is missing apiKeyEnv.`);
     const models = currentProvider.models ?? [];
     if (models.length === 0) throw new Error(`Provider "${id}" must declare at least one model.`);
+    const duplicateModel = firstDuplicate(models.map((model) => model.id));
+    if (duplicateModel) throw new Error(`Provider "${id}" declares duplicate model "${duplicateModel}".`);
     registry.providers.push({
       id,
       protocol,
@@ -210,6 +238,7 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
     });
     currentProvider = null;
     currentList = null;
+    currentModelBlock = null;
   };
 
   for (let index = 0; index < lines.length; index++) {
@@ -221,6 +250,7 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
     if (indent === 0) {
       finishProvider();
       currentList = null;
+      currentModelBlock = null;
       if (line === "default:") {
         section = "default";
         continue;
@@ -259,6 +289,7 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
     }
 
     if (indent === 4) {
+      finishModel();
       if (line === "models:") {
         currentList = "models";
         continue;
@@ -274,10 +305,54 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
     }
 
     if (indent === 6 && currentList === "models") {
+      finishModel();
       if (!line.startsWith("- ")) {
         throw new Error(`Provider config parse error on line ${index + 1}: model entries must start with "- ".`);
       }
-      currentProvider.models = [...(currentProvider.models ?? []), unquote(line.slice(2).trim())];
+      const entry = line.slice(2).trim();
+      if (entry.includes(":")) {
+        const [key, value] = readKeyValue(entry, index, path);
+        if (key !== "id") {
+          throw new Error(`Provider config parse error on line ${index + 1}: model object entries must start with id.`);
+        }
+        currentModel = { id: value };
+      } else {
+        currentProvider.models = [...(currentProvider.models ?? []), { id: unquote(entry) }];
+      }
+      continue;
+    }
+
+    if (indent === 8 && currentList === "models" && currentModel) {
+      if (line === "generation:") {
+        currentModel.generation = currentModel.generation ?? {};
+        currentModelBlock = "generation";
+        continue;
+      }
+      if (line === "capabilities:") {
+        currentModel.capabilities = currentModel.capabilities ?? {};
+        currentModelBlock = "capabilities";
+        continue;
+      }
+      currentModelBlock = null;
+      const [key, value] = readKeyValue(line, index, path);
+      if (key === "id") currentModel.id = value;
+      else throw new Error(`Provider config parse error on line ${index + 1}: unknown model field "${key}".`);
+      continue;
+    }
+
+    if (indent === 10 && currentList === "models" && currentModel && currentModelBlock) {
+      const [key, value] = readKeyValue(line, index, path);
+      if (currentModelBlock === "generation") {
+        currentModel.generation = {
+          ...(currentModel.generation ?? {}),
+          ...readGenerationField(key, value, index, path),
+        };
+        continue;
+      }
+      currentModel.capabilities = {
+        ...(currentModel.capabilities ?? {}),
+        ...readCapabilityField(key, value, index, path),
+      };
       continue;
     }
 
@@ -297,6 +372,12 @@ function requireProvider(registry: ProviderRegistry, providerId: string): Provid
   return profile;
 }
 
+function requireModel(profile: ProviderProfile, modelId: string): ProviderModelProfile {
+  const model = profile.models.find((entry) => entry.id === modelId);
+  if (!model) throw new Error(`Provider "${profile.id}" does not declare model "${modelId}".`);
+  return model;
+}
+
 function readProtocol(value: string, field: string): ProviderProtocol {
   if (value !== "openai-chat-compatible") {
     throw new Error(`Unsupported provider protocol "${value}" in ${field}.`);
@@ -311,6 +392,54 @@ function readKeyValue(line: string, index: number, path: string): [string, strin
   const value = unquote(line.slice(colon + 1).trim());
   if (!value) throw new Error(`Provider config parse error on line ${index + 1} in ${path}: empty value for ${key}.`);
   return [key, value];
+}
+
+function readGenerationField(key: string, value: string, index: number, path: string): GenerationDefaults {
+  if (key === "temperature") return { temperature: readFiniteNumber(value, key, index, path) };
+  if (key === "maxTokens") return { maxTokens: readPositiveInteger(value, key, index, path) };
+  throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown generation field "${key}".`);
+}
+
+function readCapabilityField(key: string, value: string, index: number, path: string): ModelCapabilities {
+  const enabled = readBoolean(value, key, index, path);
+  if (key === "streaming") return { streaming: enabled };
+  if (key === "tools") return { tools: enabled };
+  if (key === "reasoningTier") return { reasoningTier: enabled };
+  if (key === "reasoningContent") return { reasoningContent: enabled };
+  if (key === "temperature") return { temperature: enabled };
+  if (key === "maxTokens") return { maxTokens: enabled };
+  throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown capability field "${key}".`);
+}
+
+function readFiniteNumber(value: string, key: string, index: number, path: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Provider config parse error on line ${index + 1} in ${path}: ${key} must be a finite number.`);
+  }
+  return parsed;
+}
+
+function readPositiveInteger(value: string, key: string, index: number, path: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`Provider config parse error on line ${index + 1} in ${path}: ${key} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function readBoolean(value: string, key: string, index: number, path: string): boolean {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  throw new Error(`Provider config parse error on line ${index + 1} in ${path}: ${key} must be true or false.`);
+}
+
+function firstDuplicate(values: string[]): string | undefined {
+  const seen = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) return value;
+    seen.add(value);
+  }
+  return undefined;
 }
 
 function stripComment(line: string): string {

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -310,7 +310,7 @@ function parseProviderConfig(source: string, path: string, env: NodeJS.ProcessEn
         throw new Error(`Provider config parse error on line ${index + 1}: model entries must start with "- ".`);
       }
       const entry = line.slice(2).trim();
-      if (entry.includes(":")) {
+      if (/^id\s*:/.test(entry)) {
         const [key, value] = readKeyValue(entry, index, path);
         if (key !== "id") {
           throw new Error(`Provider config parse error on line ${index + 1}: model object entries must start with id.`);

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -586,10 +586,18 @@ function mergeGeneration(
   override: VesicleRequest["generation"],
 ): VesicleRequest["generation"] | undefined {
   const merged = {
-    ...(defaults ?? {}),
-    ...(override ?? {}),
+    ...definedGeneration(defaults),
+    ...definedGeneration(override),
   };
   return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function definedGeneration(source: VesicleRequest["generation"] | undefined): VesicleRequest["generation"] {
+  return {
+    ...(source?.temperature !== undefined ? { temperature: source.temperature } : {}),
+    ...(source?.maxTokens !== undefined ? { maxTokens: source.maxTokens } : {}),
+    ...(source?.reasoningTier !== undefined ? { reasoningTier: source.reasoningTier } : {}),
+  };
 }
 
 function generationMetadata(generation: VesicleRequest["generation"] | undefined): Record<string, unknown> {

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -139,6 +139,7 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
   const engine = options.engine ?? "etl";
   const rootDir = options.rootDir ?? process.cwd();
   const config = await loadConfigForSelection(options.providerSelection);
+  const generation = mergeGeneration(config.generation, options.generation);
   const provider = createProvider(config);
   const profile = await loadEngineProfile(engine, rootDir);
   const promptBundle = await loadPromptBundle(profile, rootDir);
@@ -156,7 +157,7 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
         provider: config.provider,
         providerId: config.providerId,
         model: config.model,
-        ...(options.generation?.reasoningTier ? { reasoningTier: options.generation.reasoningTier } : {}),
+        ...generationMetadata(generation),
         profile: {
           displayName: profile.displayName,
           protocolVersion: profile.protocolVersion,
@@ -175,7 +176,7 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
       provider: config.provider,
       providerId: config.providerId,
       model: config.model,
-      ...(options.generation?.reasoningTier ? { reasoningTier: options.generation.reasoningTier } : {}),
+      ...generationMetadata(generation),
     },
   });
 
@@ -195,7 +196,7 @@ export async function runPrompt(options: RunPromptOptions): Promise<RunPromptRes
     messages,
     session,
     profile,
-    generation: options.generation,
+    generation,
     onEvent: options.onEvent,
   });
 }
@@ -519,6 +520,7 @@ export async function resolveGate(options: {
 }): Promise<RunPromptResult> {
   const rootDir = options.rootDir ?? process.cwd();
   const config = await loadConfigForSelection(options.providerSelection);
+  const generation = mergeGeneration(config.generation, options.generation);
   const provider = createProvider(config);
   const profile = await loadEngineProfile(options.engine, rootDir);
   const promptBundle = await loadPromptBundle(profile, rootDir);
@@ -560,10 +562,10 @@ export async function resolveGate(options: {
     metadata: {
       provider: config.provider,
       providerId: config.providerId,
-        model: config.model,
-        ...(options.generation?.reasoningTier ? { reasoningTier: options.generation.reasoningTier } : {}),
-      },
-    });
+      model: config.model,
+      ...generationMetadata(generation),
+    },
+  });
 
   return runLoop({
     rootDir,
@@ -574,9 +576,28 @@ export async function resolveGate(options: {
     messages,
     session,
     profile,
-    generation: options.generation,
+    generation,
     onEvent: options.onEvent,
   });
+}
+
+function mergeGeneration(
+  defaults: VesicleConfig["generation"],
+  override: VesicleRequest["generation"],
+): VesicleRequest["generation"] | undefined {
+  const merged = {
+    ...(defaults ?? {}),
+    ...(override ?? {}),
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+function generationMetadata(generation: VesicleRequest["generation"] | undefined): Record<string, unknown> {
+  return {
+    ...(generation?.temperature !== undefined ? { temperature: generation.temperature } : {}),
+    ...(generation?.maxTokens !== undefined ? { maxTokens: generation.maxTokens } : {}),
+    ...(generation?.reasoningTier ? { reasoningTier: generation.reasoningTier } : {}),
+  };
 }
 
 function gateResultMessage(resolution: GateResolution): string {

--- a/src/providers/openai-chat/request.ts
+++ b/src/providers/openai-chat/request.ts
@@ -43,7 +43,7 @@ export function toChatCompletionBody(request: VesicleRequest, stream: boolean, i
     ],
     tools: hasTools ? request.tools : undefined,
     tool_choice: hasTools ? "auto" : undefined,
-    temperature: request.generation?.temperature ?? 0.7,
+    temperature: request.generation?.temperature,
     max_tokens: request.generation?.maxTokens,
     ...reasoningControls(request.generation?.reasoningTier),
     stream,

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1102,12 +1102,24 @@ function renderModelList(registry: ProviderRegistry, providerId: string, activeM
   if (!provider) return `Unknown provider "${providerId}". Use /providers to list configured providers.`;
   const lines = [`Models for ${provider.id}:`];
   for (const model of provider.models) {
-    const marker = model === activeModel ? "*" : " ";
-    lines.push(`${marker} ${model}`);
+    const marker = model.id === activeModel ? "*" : " ";
+    const details = renderModelDetails(model);
+    lines.push(`${marker} ${model.id}${details ? ` (${details})` : ""}`);
   }
   lines.push("");
   lines.push(`Use /use ${provider.id} <model> or /model <model> to switch.`);
   return lines.join("\n");
+}
+
+function renderModelDetails(model: ProviderRegistry["providers"][number]["models"][number]): string {
+  const details: string[] = [];
+  if (model.generation?.temperature !== undefined) details.push(`temp ${model.generation.temperature}`);
+  if (model.generation?.maxTokens !== undefined) details.push(`max ${model.generation.maxTokens}`);
+  const capabilities = Object.entries(model.capabilities ?? {})
+    .filter(([, enabled]) => enabled === true)
+    .map(([name]) => name);
+  if (capabilities.length > 0) details.push(`cap ${capabilities.join("/")}`);
+  return details.join(", ");
 }
 
 function parseThinkingTier(value: string): ReasoningTier | "auto" | null {

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -141,6 +141,41 @@ describe("agent loop sessions", () => {
     });
   });
 
+  test("does not let undefined generation overrides erase configured defaults", async () => {
+    await cleanupProviderConfigDirs();
+    await configureTestProviderEnv({
+      models: [
+        "      - id: test-model",
+        "        generation:",
+        "          temperature: 0.2",
+        "          maxTokens: 1234",
+      ],
+    });
+    const rootDir = await createPromptRoot();
+    const requestBodies: Array<{ temperature?: number; max_tokens?: number }> = [];
+
+    globalThis.fetch = (async (_input: unknown, init: RequestInit & { body?: unknown }) => {
+      requestBodies.push(JSON.parse(String(init?.body)));
+
+      return Response.json({
+        id: "chatcmpl-generation-defined",
+        choices: [{ message: { content: "reply" } }],
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runPrompt({
+      input: "keep configured defaults",
+      rootDir,
+      generation: { temperature: undefined, maxTokens: undefined },
+    });
+
+    if (result.kind !== "complete") throw new Error("expected complete");
+    expect(requestBodies[0]).toMatchObject({
+      temperature: 0.2,
+      max_tokens: 1234,
+    });
+  });
+
   test("emits streamed reasoning deltas from the provider", async () => {
     const rootDir = await createPromptRoot();
     const events: AgentLoopEvent[] = [];

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -107,6 +107,40 @@ describe("agent loop sessions", () => {
     });
   });
 
+  test("passes configured model generation defaults to the provider request", async () => {
+    await cleanupProviderConfigDirs();
+    await configureTestProviderEnv({
+      models: [
+        "      - id: test-model",
+        "        generation:",
+        "          temperature: 0.2",
+        "          maxTokens: 1234",
+      ],
+    });
+    const rootDir = await createPromptRoot();
+    const requestBodies: Array<{ temperature?: number; max_tokens?: number }> = [];
+
+    globalThis.fetch = (async (_input: unknown, init: RequestInit & { body?: unknown }) => {
+      requestBodies.push(JSON.parse(String(init?.body)));
+
+      return Response.json({
+        id: "chatcmpl-generation-defaults",
+        choices: [{ message: { content: "reply" } }],
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runPrompt({
+      input: "use configured defaults",
+      rootDir,
+    });
+
+    if (result.kind !== "complete") throw new Error("expected complete");
+    expect(requestBodies[0]).toMatchObject({
+      temperature: 0.2,
+      max_tokens: 1234,
+    });
+  });
+
   test("emits streamed reasoning deltas from the provider", async () => {
     const rootDir = await createPromptRoot();
     const events: AgentLoopEvent[] = [];
@@ -528,7 +562,7 @@ async function createPromptRoot(options: { stopGates?: string[]; validators?: st
   return rootDir;
 }
 
-async function configureTestProviderEnv(): Promise<void> {
+async function configureTestProviderEnv(options: { models?: string[] } = {}): Promise<void> {
   const configDir = await mkdtemp(join(tmpdir(), "vesicle-agent-provider-"));
   providerConfigDirs.push(configDir);
   const configPath = join(configDir, "providers.yaml");
@@ -542,7 +576,7 @@ async function configureTestProviderEnv(): Promise<void> {
     "    baseUrl: https://provider.test/v1",
     "    apiKeyEnv: TEST_PROVIDER_API_KEY",
     "    models:",
-    "      - test-model",
+    ...(options.models ?? ["      - test-model"]),
     "",
   ].join("\n"), "utf8");
   await writeFile(join(configDir, ".env"), "TEST_PROVIDER_API_KEY=test-key\n", "utf8");

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -68,6 +68,62 @@ describe("config loading", () => {
     expect(config.apiKey).toBe("secret");
   });
 
+  test("loads object model generation defaults and capabilities", async () => {
+    const { env } = await writeProvidersFile([
+      "default:",
+      "  provider: deepseek",
+      "  model: deepseek-reasoner",
+      "providers:",
+      "  deepseek:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: https://api.deepseek.com/v1",
+      "    apiKeyEnv: DEEPSEEK_API_KEY",
+      "    models:",
+      "      - deepseek-v4-flash",
+      "      - id: deepseek-reasoner",
+      "        generation:",
+      "          temperature: 0.4",
+      "          maxTokens: 8192",
+      "        capabilities:",
+      "          streaming: true",
+      "          tools: true",
+      "          reasoningTier: true",
+      "          reasoningContent: true",
+      "",
+    ], ["DEEPSEEK_API_KEY=secret"]);
+
+    const registry = await loadProviderRegistry(env);
+    const config = await loadConfigForSelection(undefined, env);
+
+    expect(registry.providers[0].models.map((model) => model.id)).toEqual(["deepseek-v4-flash", "deepseek-reasoner"]);
+    expect(config.generation).toEqual({ temperature: 0.4, maxTokens: 8192 });
+    expect(config.capabilities).toMatchObject({
+      streaming: true,
+      tools: true,
+      reasoningTier: true,
+      reasoningContent: true,
+    });
+  });
+
+  test("rejects duplicate model ids across string and object entries", async () => {
+    const { env } = await writeProvidersFile([
+      "default:",
+      "  provider: local",
+      "  model: qwen3",
+      "providers:",
+      "  local:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: http://127.0.0.1:11434/v1",
+      "    apiKeyEnv: LOCAL_OPENAI_COMPAT_API_KEY",
+      "    models:",
+      "      - qwen3",
+      "      - id: qwen3",
+      "",
+    ]);
+
+    await expect(loadProviderRegistry(env)).rejects.toThrow('Provider "local" declares duplicate model "qwen3".');
+  });
+
   test("prefers the user-level provider .env over inherited process variables", async () => {
     const { env } = await writeProvidersFile([
       "default:",

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -124,6 +124,26 @@ describe("config loading", () => {
     await expect(loadProviderRegistry(env)).rejects.toThrow('Provider "local" declares duplicate model "qwen3".');
   });
 
+  test("preserves colon-bearing string model ids", async () => {
+    const { env } = await writeProvidersFile([
+      "default:",
+      "  provider: local",
+      "  model: anthropic:claude-3-opus",
+      "providers:",
+      "  local:",
+      "    protocol: openai-chat-compatible",
+      "    baseUrl: http://127.0.0.1:11434/v1",
+      "    apiKeyEnv: LOCAL_OPENAI_COMPAT_API_KEY",
+      "    models:",
+      "      - anthropic:claude-3-opus",
+      "",
+    ]);
+
+    const registry = await loadProviderRegistry(env);
+
+    expect(registry.providers[0].models[0].id).toBe("anthropic:claude-3-opus");
+  });
+
   test("prefers the user-level provider .env over inherited process variables", async () => {
     const { env } = await writeProvidersFile([
       "default:",

--- a/tests/provider-backend.test.ts
+++ b/tests/provider-backend.test.ts
@@ -25,6 +25,7 @@ describe("OpenAI-compatible request shaping", () => {
     expect(body.tool_choice).toBeUndefined();
     expect(body.thinking).toBeUndefined();
     expect(body.reasoning_effort).toBeUndefined();
+    expect(body.temperature).toBeUndefined();
   });
 
   test("maps normalized thinking tiers to OpenAI-compatible reasoning controls", () => {


### PR DESCRIPTION
## Summary

- allow `providers.yaml` models to be either string entries or object entries with `id`, `generation`, and `capabilities`
- merge selected model generation defaults in the agent loop while keeping high-frequency thinking control as the TUI override
- remove the OpenAI Chat adapter's hardcoded temperature default and show model defaults/capabilities in `/models`
- move the provider secret template beside the provider registry template under `docs/examples/`

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run doctor`

## Notes / Follow-ups

- Existing user-level string model lists remain compatible; the current local `%APPDATA%\prism-vesicle\providers.yaml` shape does not require migration.