### PR TITLE
feat(providers): preserve thinking blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ project follows Semantic Versioning once releases begin.
 
 ### Changed
 
+- Reasoning preservation now uses provider-neutral thinking blocks internally,
+  while keeping OpenAI-compatible `reasoningContent` as a compatibility bridge.
+  Agent-loop events, session replay, and TUI display can now carry provider
+  thinking state without flattening it into assistant prose.
 - Expanded `AGENTS.md` and `CLAUDE.md` into full AI-collaborator entry points
   that link the repo's workflow, style, status, contribution, provider config,
   verification, and documentation-sweep rules.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ return to an unresolved gate.
 - Reasoning visibility for models that return `reasoning_content`: the TUI
   renders reasoning as a separate bounded block, defaults to collapsed preview,
   and offers `/reasoning hidden|collapsed|expanded`
+- Provider thinking state is preserved as replayable thinking blocks in
+  sessions, with OpenAI-compatible `reasoning_content` mapped into that shape
+  for future native protocol adapters
 - Engine profiles drive systemPrompt, tools, validators, and stop gates from
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker

--- a/STATUS.md
+++ b/STATUS.md
@@ -48,6 +48,9 @@ Chat wrapper:
 - Show provider `reasoning_content` as a separate TUI thinking block before
   assistant text, with `/reasoning hidden|collapsed|expanded`; the default
   collapsed mode keeps long reasoning bounded to a short tail preview.
+- Preserve provider thinking state as session-replayed thinking blocks, with
+  OpenAI-compatible `reasoning_content` mapped into that structure as a bridge
+  for future Anthropic Messages and Gemini adapters.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
 - Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a
@@ -150,9 +153,8 @@ never abort a turn. Validators run only on artifact-shaped assistant content
   provider protocols are still deferred.
 - Thinking-tier control maps to OpenAI-compatible `thinking` and
   `reasoning_effort` request fields. User-visible reasoning is currently a TUI
-  display feature for preserved OpenAI-compatible `reasoning_content`; native
-  Anthropic, Gemini, and OpenAI Responses thinking surfaces are deferred with
-  their provider adapters.
+  display feature for preserved provider thinking blocks; native Anthropic,
+  Gemini, and OpenAI Responses adapters are deferred.
 - TUI engine switching is hardcoded to ETL (runtime/evaluate profiles exist
   and load, but the TUI does not yet offer a selector).
 - Gate UI is Select-style for ETL blueprint and phase checkpoints, with a

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -140,8 +140,10 @@ Prompts are runtime assets, not hardcoded source literals.
 - Tool calls and tool results should be persisted for replay/debugging.
 - User-selected reasoning tiers should be persisted as session metadata so
   interactive resume restores runtime generation behavior. Provider
-  `reasoning_content` is preserved for protocol continuity and TUI display,
-  but it is metadata and must not be merged into normal assistant prose.
+  thinking state is preserved as thinking blocks for protocol continuity and
+  TUI display, but it is metadata and must not be merged into normal assistant
+  prose. OpenAI-compatible `reasoning_content` is a compatibility bridge into
+  that block structure.
 - Session lists should mark unresolved gates so the user can distinguish a
   normal transcript from a workflow waiting for confirmation.
 - Long-running turns should emit host-visible activity events before and after

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -2,7 +2,7 @@ import type { VesicleConfig } from "../../config/env";
 import { loadConfigForSelection } from "../../config/providers";
 import type { ProviderSelection } from "../../config/providers";
 import { createProvider } from "../../providers";
-import type { ProviderAdapter, VesicleMessage, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
+import type { ProviderAdapter, ProviderThinkingBlock, VesicleMessage, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
 import { executeFileTool, fileToolDefinitions } from "../tools";
 import type { ToolCall, ToolDefinition } from "../tools";
 import { composeSystemPrompt, loadPromptBundle } from "../prompt/loader";
@@ -40,6 +40,7 @@ export type AgentLoopEvent =
       type: "assistant_response";
       content: string;
       reasoningContent?: string;
+      thinkingBlocks?: ProviderThinkingBlock[];
       toolCalls: Array<{ id: string; name: string; arguments: string }>;
     }
   | { type: "tool_call"; name: string; callId: string; arguments: string }
@@ -240,6 +241,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
       type: "assistant_response",
       content: response.content,
       ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
+      ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks } : {}),
       toolCalls: toolCalls.map((call) => ({ id: call.id, name: call.name, arguments: call.arguments })),
     });
     if (toolCalls.length === 0) {
@@ -268,6 +270,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
       role: "assistant",
       content: response.content,
       ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
+      ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks } : {}),
       toolCalls,
     });
     await session.append({
@@ -277,6 +280,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
         providerResponseId: response.id,
         finishReason: response.finishReason,
         ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
+        ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks } : {}),
         toolCalls,
       },
     });
@@ -392,6 +396,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
       role: "assistant",
       content: response.content,
       ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
+      ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks } : {}),
     });
     await session.append({
       role: "assistant",
@@ -399,6 +404,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
       metadata: {
         providerResponseId: response.id,
         ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
+        ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks } : {}),
         usage: response.usage,
       },
     });

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -4,7 +4,7 @@ import { parseGateRequest } from "../gate/types";
 import type { GateRequest } from "../gate/types";
 import type { ProviderSelection } from "../../config/providers";
 import { reasoningTiers } from "../../providers/shared/types";
-import type { ReasoningTier } from "../../providers/shared/types";
+import type { ProviderThinkingBlock, ReasoningTier } from "../../providers/shared/types";
 
 export type ReasoningDisplayMode = "hidden" | "collapsed" | "expanded";
 
@@ -153,6 +153,7 @@ export type ResumedMessage = {
   role: "user" | "assistant" | "tool";
   content: string;
   reasoningContent?: string;
+  thinkingBlocks?: ProviderThinkingBlock[];
   toolCallId?: string;
   toolCalls?: ResumedToolCall[];
 };
@@ -220,10 +221,12 @@ export async function loadSessionSnapshot(
     if (record.role === "assistant") {
       const toolCalls = record.metadata?.toolCalls as ResumedToolCall[] | undefined;
       const reasoningContent = record.metadata?.reasoningContent as string | undefined;
+      const thinkingBlocks = readThinkingBlocks(record.metadata?.thinkingBlocks);
       messages.push({
         role: "assistant",
         content: record.content,
         ...(reasoningContent ? { reasoningContent } : {}),
+        ...(thinkingBlocks ? { thinkingBlocks } : {}),
         ...(toolCalls ? { toolCalls } : {}),
       });
       continue;
@@ -312,6 +315,16 @@ function findPendingGate(records: SessionRecord[]): { gate: GateRequest; toolCal
   }
 
   return undefined;
+}
+
+function readThinkingBlocks(value: unknown): ProviderThinkingBlock[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const blocks = value.filter((item): item is ProviderThinkingBlock => (
+    Boolean(item) &&
+    typeof item === "object" &&
+    typeof (item as { type?: unknown }).type === "string"
+  ));
+  return blocks.length > 0 ? blocks : undefined;
 }
 
 /**

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -319,12 +319,25 @@ function findPendingGate(records: SessionRecord[]): { gate: GateRequest; toolCal
 
 function readThinkingBlocks(value: unknown): ProviderThinkingBlock[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const blocks = value.filter((item): item is ProviderThinkingBlock => (
-    Boolean(item) &&
-    typeof item === "object" &&
-    typeof (item as { type?: unknown }).type === "string"
-  ));
+  const blocks = value.filter(isKnownThinkingBlock);
   return blocks.length > 0 ? blocks : undefined;
+}
+
+function isKnownThinkingBlock(value: unknown): value is ProviderThinkingBlock {
+  if (!value || typeof value !== "object") return false;
+  const block = value as ProviderThinkingBlock;
+  switch (block.type) {
+    case "reasoning":
+      return typeof block.reasoningContent === "string";
+    case "thinking":
+      return typeof block.thinking === "string";
+    case "redacted_thinking":
+      return typeof block.data === "string";
+    case "thought_summary":
+      return typeof block.text === "string" || typeof block.summary === "string";
+    default:
+      return false;
+  }
 }
 
 /**

--- a/src/providers/openai-chat/request.ts
+++ b/src/providers/openai-chat/request.ts
@@ -1,4 +1,5 @@
 import type { ReasoningTier, VesicleRequest } from "../shared/types";
+import { reasoningContentFromThinkingBlocks } from "../shared/thinking";
 
 export function toChatCompletionBody(request: VesicleRequest, stream: boolean, includeUsage = false): Record<string, unknown> {
   const hasTools = Boolean(request.tools && request.tools.length > 0);
@@ -16,10 +17,11 @@ export function toChatCompletionBody(request: VesicleRequest, stream: boolean, i
         }
 
         if (message.role === "assistant" && message.toolCalls && message.toolCalls.length > 0) {
+          const reasoningContent = assistantReasoningContent(message);
           return {
             role: "assistant",
             content: message.content || null,
-            ...(message.reasoningContent ? { reasoning_content: message.reasoningContent } : {}),
+            ...(reasoningContent ? { reasoning_content: reasoningContent } : {}),
             tool_calls: message.toolCalls.map((call) => ({
               id: call.id,
               type: "function",
@@ -35,8 +37,9 @@ export function toChatCompletionBody(request: VesicleRequest, stream: boolean, i
           role: message.role,
           content: message.content,
         };
-        if (message.role === "assistant" && message.reasoningContent) {
-          body.reasoning_content = message.reasoningContent;
+        if (message.role === "assistant") {
+          const reasoningContent = assistantReasoningContent(message);
+          if (reasoningContent) body.reasoning_content = reasoningContent;
         }
         return body;
       }),
@@ -49,6 +52,10 @@ export function toChatCompletionBody(request: VesicleRequest, stream: boolean, i
     stream,
     stream_options: stream && includeUsage ? { include_usage: true } : undefined,
   };
+}
+
+function assistantReasoningContent(message: VesicleRequest["messages"][number]): string | undefined {
+  return reasoningContentFromThinkingBlocks(message.thinkingBlocks) ?? message.reasoningContent;
 }
 
 function reasoningControls(tier: ReasoningTier | undefined): Record<string, unknown> {

--- a/src/providers/openai-chat/response.ts
+++ b/src/providers/openai-chat/response.ts
@@ -1,4 +1,5 @@
 import { ProviderError } from "../shared/errors";
+import { thinkingBlocksFromReasoningContent } from "../shared/thinking";
 import type { VesicleResponse } from "../shared/types";
 import type { ChatCompletionResponse } from "./types";
 
@@ -27,6 +28,7 @@ export function responseFromChatCompletionBody(
     id: body?.id ?? fallbackId,
     content,
     ...(reasoningContent ? { reasoningContent } : {}),
+    ...(reasoningContent ? { thinkingBlocks: thinkingBlocksFromReasoningContent(reasoningContent) } : {}),
     toolCalls,
     finishReason: choice?.finish_reason ?? undefined,
     raw: body,

--- a/src/providers/openai-chat/stream.ts
+++ b/src/providers/openai-chat/stream.ts
@@ -1,4 +1,5 @@
 import { ProviderError } from "../shared/errors";
+import { thinkingBlocksFromReasoningContent } from "../shared/thinking";
 import type { ProviderStreamEvent, VesicleResponse } from "../shared/types";
 import type { ChatCompletionStreamChunk } from "./types";
 
@@ -121,6 +122,7 @@ function finalizeStream(state: StreamAccumulator, providerId?: string): VesicleR
     id: state.id,
     content: state.content,
     ...(state.reasoningContent ? { reasoningContent: state.reasoningContent } : {}),
+    ...(state.reasoningContent ? { thinkingBlocks: thinkingBlocksFromReasoningContent(state.reasoningContent) } : {}),
     toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
     finishReason: state.finishReason,
     usage: state.usage,

--- a/src/providers/shared/thinking.ts
+++ b/src/providers/shared/thinking.ts
@@ -1,0 +1,41 @@
+import type { ProviderThinkingBlock } from "./types";
+
+export function thinkingBlocksFromReasoningContent(reasoningContent: string | undefined): ProviderThinkingBlock[] | undefined {
+  if (!reasoningContent) return undefined;
+  return [{ type: "reasoning", reasoningContent }];
+}
+
+export function reasoningContentFromThinkingBlocks(blocks: ProviderThinkingBlock[] | undefined): string | undefined {
+  for (const block of blocks ?? []) {
+    if (block.type !== "reasoning") continue;
+    const reasoningContent = block.reasoningContent;
+    if (typeof reasoningContent === "string" && reasoningContent) return reasoningContent;
+  }
+  return undefined;
+}
+
+export function displayTextFromThinkingBlocks(blocks: ProviderThinkingBlock[] | undefined): string | undefined {
+  const parts: string[] = [];
+  for (const block of blocks ?? []) {
+    if (block.type === "reasoning") {
+      const reasoningContent = block.reasoningContent;
+      if (typeof reasoningContent === "string" && reasoningContent) parts.push(reasoningContent);
+      continue;
+    }
+    if (block.type === "thinking") {
+      const thinking = block.thinking;
+      if (typeof thinking === "string" && thinking) parts.push(thinking);
+      continue;
+    }
+    if (block.type === "redacted_thinking") {
+      parts.push("[redacted thinking]");
+      continue;
+    }
+    if (block.type === "thought_summary") {
+      const text = block.text ?? block.summary;
+      if (typeof text === "string" && text) parts.push(text);
+    }
+  }
+  const text = parts.join("\n").trim();
+  return text || undefined;
+}

--- a/src/providers/shared/thinking.ts
+++ b/src/providers/shared/thinking.ts
@@ -6,12 +6,14 @@ export function thinkingBlocksFromReasoningContent(reasoningContent: string | un
 }
 
 export function reasoningContentFromThinkingBlocks(blocks: ProviderThinkingBlock[] | undefined): string | undefined {
+  const parts: string[] = [];
   for (const block of blocks ?? []) {
     if (block.type !== "reasoning") continue;
     const reasoningContent = block.reasoningContent;
-    if (typeof reasoningContent === "string" && reasoningContent) return reasoningContent;
+    if (typeof reasoningContent === "string" && reasoningContent) parts.push(reasoningContent);
   }
-  return undefined;
+  const text = parts.join("\n").trim();
+  return text || undefined;
 }
 
 export function displayTextFromThinkingBlocks(blocks: ProviderThinkingBlock[] | undefined): string | undefined {
@@ -34,6 +36,7 @@ export function displayTextFromThinkingBlocks(blocks: ProviderThinkingBlock[] | 
     if (block.type === "thought_summary") {
       const text = block.text ?? block.summary;
       if (typeof text === "string" && text) parts.push(text);
+      continue;
     }
   }
   const text = parts.join("\n").trim();

--- a/src/providers/shared/types.ts
+++ b/src/providers/shared/types.ts
@@ -8,10 +8,16 @@ export type ModelRef = {
   model: string;
 };
 
+export type ProviderThinkingBlock = {
+  type: string;
+  [key: string]: unknown;
+};
+
 export type VesicleMessage = {
   role: "system" | "user" | "assistant" | "tool";
   content: string;
   reasoningContent?: string;
+  thinkingBlocks?: ProviderThinkingBlock[];
   toolCallId?: string;
   toolCalls?: ToolCall[];
 };
@@ -34,6 +40,7 @@ export type VesicleResponse = {
   id: string;
   content: string;
   reasoningContent?: string;
+  thinkingBlocks?: ProviderThinkingBlock[];
   toolCalls?: ToolCall[];
   finishReason?: string;
   raw?: unknown;

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -10,6 +10,7 @@ import type { AgentLoopEvent } from "../core/agent-loop/run";
 import type { VesicleMessage } from "../providers/shared/types";
 import { reasoningTiers } from "../providers/shared/types";
 import type { ReasoningTier } from "../providers/shared/types";
+import { displayTextFromThinkingBlocks } from "../providers/shared/thinking";
 import type { GateResolution } from "../core/gate/types";
 import { copySelectionToClipboard } from "./clipboard";
 import { sharedSyntaxStyle, palette } from "./theme";
@@ -389,8 +390,9 @@ export function App() {
     void refreshArtifacts();
 
     const appended: Message[] = [];
-    if (!result.response.toolCalls?.length && result.response.reasoningContent?.trim()) {
-      appended.push({ role: "system", content: result.response.reasoningContent, kind: "reasoning" });
+    const reasoningText = displayTextFromThinkingBlocks(result.response.thinkingBlocks) ?? result.response.reasoningContent;
+    if (!result.response.toolCalls?.length && reasoningText?.trim()) {
+      appended.push({ role: "system", content: reasoningText, kind: "reasoning" });
     }
     if (!result.response.toolCalls?.length && result.response.content.trim()) {
       appended.push({ role: "assistant", content: result.response.content });
@@ -433,8 +435,9 @@ export function App() {
       case "assistant_response":
         setStreamingAssistant("");
         setStreamingReasoning("");
-        if (event.reasoningContent && event.toolCalls.length > 0) {
-          appendReasoningMessage(event.reasoningContent);
+        if (event.toolCalls.length > 0) {
+          const reasoningText = displayTextFromThinkingBlocks(event.thinkingBlocks) ?? event.reasoningContent;
+          if (reasoningText) appendReasoningMessage(reasoningText);
         }
         if (event.toolCalls.length > 0) {
           const content = renderAssistantToolTurn(event.content, event.toolCalls);
@@ -1229,6 +1232,7 @@ function vesicleMessagesFromResumed(messages: ResumedMessage[]): VesicleMessage[
     role: message.role,
     content: message.content,
     ...(message.reasoningContent ? { reasoningContent: message.reasoningContent } : {}),
+    ...(message.thinkingBlocks ? { thinkingBlocks: message.thinkingBlocks.map((block) => ({ ...block })) } : {}),
     ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
     ...(message.toolCalls ? { toolCalls: message.toolCalls.map((call) => ({ ...call })) } : {}),
   }));
@@ -1236,11 +1240,12 @@ function vesicleMessagesFromResumed(messages: ResumedMessage[]): VesicleMessage[
 
 function displayMessagesFromResumed(message: ResumedMessage): Message[] {
   if (message.role === "assistant") {
+    const reasoningText = displayTextFromThinkingBlocks(message.thinkingBlocks) ?? message.reasoningContent;
     const content = message.toolCalls && message.toolCalls.length > 0
       ? renderAssistantToolTurn(message.content, message.toolCalls)
       : message.content;
     return [
-      ...(message.reasoningContent?.trim() ? [{ role: "system" as const, content: message.reasoningContent, kind: "reasoning" as const }] : []),
+      ...(reasoningText?.trim() ? [{ role: "system" as const, content: reasoningText, kind: "reasoning" as const }] : []),
       { role: "assistant", content },
     ];
   }

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -198,11 +198,13 @@ describe("agent loop sessions", () => {
 
     if (result.kind !== "complete") throw new Error("expected complete");
     expect(result.response.reasoningContent).toBe("considering context");
+    expect(result.response.thinkingBlocks).toEqual([{ type: "reasoning", reasoningContent: "considering context" }]);
     expect(events).toContainEqual({ type: "assistant_reasoning_delta", delta: "considering context" });
     expect(events).toContainEqual({
       type: "assistant_response",
       content: "answer",
       reasoningContent: "considering context",
+      thinkingBlocks: [{ type: "reasoning", reasoningContent: "considering context" }],
       toolCalls: [],
     });
   });

--- a/tests/provider-backend.test.ts
+++ b/tests/provider-backend.test.ts
@@ -53,7 +53,7 @@ describe("OpenAI-compatible request shaping", () => {
         {
           role: "assistant",
           content: "",
-          reasoningContent: "Need to read the file first.",
+          thinkingBlocks: [{ type: "reasoning", reasoningContent: "Need to read the file first." }],
           toolCalls: [{ id: "call-read", name: "read_file", arguments: "{\"path\":\"workspace/a.md\"}" }],
         },
         { role: "tool", toolCallId: "call-read", content: "{\"ok\":true}" },
@@ -131,6 +131,7 @@ describe("OpenAI-compatible response parsing", () => {
       id: "chatcmpl-reasoning",
       content: "final answer",
       reasoningContent: "Think before answering.",
+      thinkingBlocks: [{ type: "reasoning", reasoningContent: "Think before answering." }],
     });
   });
 });
@@ -174,6 +175,7 @@ describe("Chat Completions stream integration", () => {
         id: "chatcmpl-stream",
         content: "hello",
         reasoningContent: "think",
+        thinkingBlocks: [{ type: "reasoning", reasoningContent: "think" }],
         finishReason: "stop",
         toolCalls: undefined,
         usage: undefined,

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -42,6 +42,7 @@ describe("session resume", () => {
       content: "here is the blueprint",
       metadata: {
         reasoningContent: "I should pause before proceeding.",
+        thinkingBlocks: [{ type: "reasoning", reasoningContent: "I should pause before proceeding." }],
         toolCalls: [{ id: "call-1", name: "request_confirmation", arguments: "{}" }],
       },
     });
@@ -69,6 +70,7 @@ describe("session resume", () => {
     ]);
     expect(messages[1].toolCalls?.[0]?.id).toBe("call-1");
     expect(messages[1].reasoningContent).toBe("I should pause before proceeding.");
+    expect(messages[1].thinkingBlocks).toEqual([{ type: "reasoning", reasoningContent: "I should pause before proceeding." }]);
     expect(messages[2].toolCallId).toBe("call-1");
     // The composed system prompt must not leak into the resumed message list.
     expect(messages.some((m) => m.content.includes("composed prompt"))).toBe(false);

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -81,6 +81,28 @@ describe("session resume", () => {
     await expect(loadSessionMessages(rootDir, "does-not-exist")).rejects.toThrow();
   });
 
+  test("loadSessionMessages filters malformed thinking blocks", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-thinking-blocks-"));
+    const store = await createSessionStore(rootDir, "2026-03-02T00-00-00-000Z-blocks");
+
+    await store.append({ role: "system", content: "prompt" });
+    await store.append({
+      role: "assistant",
+      content: "answer",
+      metadata: {
+        thinkingBlocks: [
+          { type: "reasoning", reasoningContent: "valid" },
+          { type: "reasoning", reasoningContent: 42 },
+          { type: "unknown", value: "ignored" },
+        ],
+      },
+    });
+
+    const messages = await loadSessionMessages(rootDir, "2026-03-02T00-00-00-000Z-blocks");
+
+    expect(messages[0].thinkingBlocks).toEqual([{ type: "reasoning", reasoningContent: "valid" }]);
+  });
+
   test("loadSessionMessages synthesizes tool results for an unresolved gate (CR B1)", async () => {
     // A session that paused at a gate ends with an assistant message
     // carrying a request_confirmation tool call but no tool result (the

--- a/tests/thinking.test.ts
+++ b/tests/thinking.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { displayTextFromThinkingBlocks, reasoningContentFromThinkingBlocks } from "../src/providers/shared/thinking";
+
+describe("provider thinking block helpers", () => {
+  test("concatenates multiple OpenAI-compatible reasoning blocks", () => {
+    expect(reasoningContentFromThinkingBlocks([
+      { type: "reasoning", reasoningContent: "first" },
+      { type: "thinking", thinking: "native thinking" },
+      { type: "reasoning", reasoningContent: "second" },
+    ])).toBe("first\nsecond");
+  });
+
+  test("extracts display text from supported thinking block types", () => {
+    expect(displayTextFromThinkingBlocks([
+      { type: "reasoning", reasoningContent: "openai reasoning" },
+      { type: "thinking", thinking: "anthropic thinking" },
+      { type: "redacted_thinking", data: "opaque" },
+      { type: "thought_summary", summary: "gemini summary" },
+    ])).toBe([
+      "openai reasoning",
+      "anthropic thinking",
+      "[redacted thinking]",
+      "gemini summary",
+    ].join("\n"));
+  });
+});


### PR DESCRIPTION
## Summary

- introduce provider-neutral `thinkingBlocks` on Vesicle messages and responses while keeping `reasoningContent` as an OpenAI-compatible bridge
- map OpenAI Chat `reasoning_content` into replayable thinking blocks and back into follow-up Chat Completions requests
- persist/reload thinking blocks through the agent loop, session JSONL metadata, and resumed TUI transcript display
- document the protocol-state boundary as groundwork for native Anthropic Messages and Gemini adapters

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test tests\provider-backend.test.ts tests\agent-loop.test.ts tests\session.test.ts tests\tui.test.tsx`
- [x] `bun test`
- [x] `bun run doctor`

## Notes / Follow-ups

- This PR does not add a new protocol adapter; it prepares the internal state shape so Anthropic/Gemini thinking blocks can be preserved without flattening them into assistant prose.