### PR TITLE
feat(providers): stream Anthropic Messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ project follows Semantic Versioning once releases begin.
 - Anthropic Messages provider protocol for non-streaming text responses,
   `tool_use` / `tool_result` loops, and `thinking` / `redacted_thinking` block
   preservation.
+- Anthropic Messages SSE streaming for text deltas, thinking deltas,
+  streamed tool-use JSON, and final response reconstruction.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ return to an unresolved gate.
 ## Current Capabilities
 
 - OpenAI-compatible Chat Completions provider path
-- Anthropic Messages provider path for non-streaming text, tool calls, and
+- Anthropic Messages provider path for text, streaming, tool calls, and
   thinking block preservation
 - Streaming OpenAI-compatible Chat Completions responses when the provider
   supports SSE, including streamed tool-call reconstruction

--- a/STATUS.md
+++ b/STATUS.md
@@ -29,8 +29,8 @@ Chat wrapper:
 - Run a terminal UI with provider status, markdown-rendered message stream,
   responsive workspace/artifact sidebar, wide-screen activity/artifact pane,
   slash hints, prompt history recall, and input bar.
-- Call OpenAI-compatible Chat Completions endpoints and non-streaming
-  Anthropic Messages endpoints.
+- Call OpenAI-compatible Chat Completions endpoints and Anthropic Messages
+  endpoints, including SSE streaming on both protocols.
 - Load multiple OpenAI-compatible provider/model profiles from the user-level
   provider config (`%APPDATA%\prism-vesicle\providers.yaml` on Windows,
   `$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` or
@@ -144,8 +144,8 @@ never abort a turn. Validators run only on artifact-shaped assistant content
 
 ## Known Limits
 
-- OpenAI-compatible Chat Completions and non-streaming Anthropic Messages are
-  implemented. OpenAI Responses and Gemini are deferred.
+- OpenAI-compatible Chat Completions and Anthropic Messages are implemented.
+  OpenAI Responses and Gemini are deferred.
 - The provider registry supports multiple configured providers using
   `openai-chat-compatible` or `anthropic-messages`.
 - OpenAI-compatible SSE streaming is implemented on the 0.2 branch for

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -62,7 +62,9 @@ Anthropic Messages adapters map Vesicle messages to Anthropic content blocks:
 assistant thinking blocks must be emitted before text/tool_use blocks, and
 tool results are user messages containing `tool_result` blocks. The agent loop
 and session store must not interpret these native blocks beyond preserving
-their typed metadata.
+their typed metadata. Anthropic streaming must reconstruct text, thinking, and
+tool_use blocks by provider content-block index before emitting the final
+`VesicleResponse`.
 High-frequency thinking controls may be interactive TUI state. Lower-frequency
 generation defaults such as `temperature` and `maxTokens` belong in the
 user-level provider model config and are merged by `core/agent-loop` before

--- a/src/providers/anthropic-messages/adapter.ts
+++ b/src/providers/anthropic-messages/adapter.ts
@@ -388,6 +388,7 @@ function absorbAnthropicStreamEvent(
     }
     if (delta.type === "thinking_delta" && delta.thinking) {
       const current = state.thinkingBlocks.get(index);
+      if (current && !("thinking" in current)) return events;
       const next = current && "thinking" in current
         ? { ...current, thinking: `${current.thinking}${delta.thinking}` }
         : { thinking: delta.thinking };

--- a/src/providers/anthropic-messages/adapter.ts
+++ b/src/providers/anthropic-messages/adapter.ts
@@ -1,7 +1,7 @@
 import type { VesicleConfig } from "../../config/env";
 import { ProviderError } from "../shared/errors";
 import { displayTextFromThinkingBlocks } from "../shared/thinking";
-import type { ProviderAdapter, ProviderThinkingBlock, ReasoningTier, VesicleRequest, VesicleResponse } from "../shared/types";
+import type { ProviderAdapter, ProviderStreamEvent, ProviderThinkingBlock, ReasoningTier, VesicleRequest, VesicleResponse } from "../shared/types";
 import type { ToolCall } from "../../core/tools";
 
 type AnthropicContentBlock =
@@ -30,6 +30,40 @@ type AnthropicResponse = {
   };
 };
 
+type AnthropicStreamEvent = {
+  type?: string;
+  index?: number;
+  message?: {
+    id?: string;
+    model?: string;
+    usage?: AnthropicResponse["usage"];
+  };
+  content_block?: AnthropicContentBlock;
+  delta?: {
+    type?: string;
+    text?: string;
+    thinking?: string;
+    signature?: string;
+    partial_json?: string;
+    stop_reason?: string;
+  };
+  usage?: AnthropicResponse["usage"];
+  error?: {
+    message?: string;
+  };
+};
+
+type AnthropicStreamState = {
+  id: string;
+  model: string;
+  textParts: string[];
+  thinkingBlocks: Map<number, { thinking: string; signature?: string } | { redactedData: string }>;
+  toolCalls: Map<number, { id: string; name: string; inputJson: string }>;
+  finishReason?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+};
+
 const defaultMaxTokens = 4096;
 
 export class AnthropicMessagesAdapter implements ProviderAdapter {
@@ -56,6 +90,27 @@ export class AnthropicMessagesAdapter implements ProviderAdapter {
     }
 
     return responseFromAnthropicBody(body, request.id, this.config.providerId);
+  }
+
+  async *stream(request: VesicleRequest): AsyncIterable<ProviderStreamEvent> {
+    this.requireApiKey();
+
+    const response = await fetch(`${this.config.baseUrl}/messages`, {
+      method: "POST",
+      headers: { ...this.headers(), "Accept": "text/event-stream" },
+      body: JSON.stringify({ ...toAnthropicMessagesBody(request), stream: true }),
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => undefined) as AnthropicResponse | undefined;
+      const providerMessage = body?.error?.message ?? response.statusText;
+      throw new ProviderError(`Provider request failed (${response.status}): ${providerMessage}`, {
+        kind: "http_error",
+        providerId: this.config.providerId,
+        status: response.status,
+      });
+    }
+
+    yield* readAnthropicMessagesStream(response, request.id, request.model.model, this.config.providerId);
   }
 
   private headers(): Record<string, string> {
@@ -232,6 +287,227 @@ function responseFromAnthropicBody(
         : undefined,
     },
   };
+}
+
+async function* readAnthropicMessagesStream(
+  response: Response,
+  fallbackId: string,
+  fallbackModel: string,
+  providerId?: string,
+): AsyncIterable<ProviderStreamEvent> {
+  if (!response.body) {
+    throw new ProviderError("Provider streaming response did not include a body.", { kind: "stream_error", providerId });
+  }
+
+  const state: AnthropicStreamState = {
+    id: fallbackId,
+    model: fallbackModel,
+    textParts: [],
+    thinkingBlocks: new Map(),
+    toolCalls: new Map(),
+  };
+  let sawStop = false;
+
+  for await (const event of readSseEvents(response.body)) {
+    const data = parseStreamEvent(event.data, providerId);
+    if (event.event === "error" || data.error?.message) {
+      throw new ProviderError(`Provider stream failed: ${data.error?.message ?? event.data}`, {
+        kind: "stream_error",
+        providerId,
+      });
+    }
+    for (const emitted of absorbAnthropicStreamEvent(state, event.event, data, providerId)) {
+      yield emitted;
+    }
+    if (event.event === "message_stop") sawStop = true;
+  }
+
+  if (!sawStop) {
+    throw new ProviderError("Provider stream ended before message_stop.", { kind: "stream_error", providerId });
+  }
+
+  yield { type: "complete", response: finalizeAnthropicStream(state, providerId) };
+}
+
+function absorbAnthropicStreamEvent(
+  state: AnthropicStreamState,
+  eventName: string,
+  data: AnthropicStreamEvent,
+  providerId?: string,
+): ProviderStreamEvent[] {
+  const events: ProviderStreamEvent[] = [];
+
+  if (eventName === "message_start") {
+    if (data.message?.id) state.id = data.message.id;
+    if (data.message?.model) state.model = data.message.model;
+    if (data.message?.usage?.input_tokens !== undefined) state.inputTokens = data.message.usage.input_tokens;
+    return events;
+  }
+
+  if (eventName === "content_block_start") {
+    const index = data.index ?? 0;
+    const block = data.content_block;
+    if (!block) return events;
+    if (block.type === "tool_use") {
+      if (!block.id || !block.name) {
+        throw new ProviderError("Provider stream included a tool_use block without id or name.", {
+          kind: "malformed_response",
+          providerId,
+        });
+      }
+      state.toolCalls.set(index, { id: block.id, name: block.name, inputJson: "" });
+      events.push({ type: "tool_call_delta", index, id: block.id, name: block.name });
+      return events;
+    }
+    if (block.type === "thinking") {
+      state.thinkingBlocks.set(index, { thinking: block.thinking ?? "", ...(block.signature ? { signature: block.signature } : {}) });
+      return events;
+    }
+    if (block.type === "redacted_thinking") {
+      state.thinkingBlocks.set(index, { redactedData: block.data });
+    }
+    return events;
+  }
+
+  if (eventName === "content_block_delta") {
+    const index = data.index ?? 0;
+    const delta = data.delta;
+    if (!delta) return events;
+    if (delta.type === "text_delta" && delta.text) {
+      state.textParts.push(delta.text);
+      events.push({ type: "content_delta", delta: delta.text });
+      return events;
+    }
+    if (delta.type === "input_json_delta" && delta.partial_json) {
+      const current = state.toolCalls.get(index);
+      if (current) {
+        current.inputJson += delta.partial_json;
+        events.push({ type: "tool_call_delta", index, argumentsDelta: delta.partial_json });
+      }
+      return events;
+    }
+    if (delta.type === "thinking_delta" && delta.thinking) {
+      const current = state.thinkingBlocks.get(index);
+      const next = current && "thinking" in current
+        ? { ...current, thinking: `${current.thinking}${delta.thinking}` }
+        : { thinking: delta.thinking };
+      state.thinkingBlocks.set(index, next);
+      events.push({ type: "reasoning_delta", delta: delta.thinking });
+      return events;
+    }
+    if (delta.type === "signature_delta" && delta.signature) {
+      const current = state.thinkingBlocks.get(index);
+      if (current && "thinking" in current) {
+        state.thinkingBlocks.set(index, { ...current, signature: delta.signature });
+      }
+    }
+    return events;
+  }
+
+  if (eventName === "message_delta") {
+    if (data.delta?.stop_reason) state.finishReason = data.delta.stop_reason;
+    if (data.usage?.output_tokens !== undefined) state.outputTokens = data.usage.output_tokens;
+  }
+
+  return events;
+}
+
+function finalizeAnthropicStream(state: AnthropicStreamState, providerId?: string): VesicleResponse {
+  const content = state.textParts.join("");
+  const thinkingBlocks: ProviderThinkingBlock[] = [...state.thinkingBlocks.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, block]) => (
+      "thinking" in block
+        ? { type: "thinking", thinking: block.thinking, ...(block.signature ? { signature: block.signature } : {}) }
+        : { type: "redacted_thinking", data: block.redactedData }
+    ));
+  const toolCalls: ToolCall[] = [...state.toolCalls.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, call]) => ({
+      id: call.id,
+      name: call.name,
+      arguments: call.inputJson || "{}",
+    }));
+  const reasoningContent = displayTextFromThinkingBlocks(thinkingBlocks);
+
+  if (!content && toolCalls.length === 0) {
+    throw new ProviderError("Provider response did not include assistant content or tool calls.", {
+      kind: "malformed_response",
+      providerId,
+    });
+  }
+
+  return {
+    id: state.id,
+    content,
+    ...(reasoningContent ? { reasoningContent } : {}),
+    ...(thinkingBlocks.length > 0 ? { thinkingBlocks } : {}),
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    finishReason: state.finishReason,
+    usage: {
+      inputTokens: state.inputTokens,
+      outputTokens: state.outputTokens,
+      totalTokens: state.inputTokens !== undefined && state.outputTokens !== undefined
+        ? state.inputTokens + state.outputTokens
+        : undefined,
+    },
+  };
+}
+
+async function* readSseEvents(body: ReadableStream<Uint8Array>): AsyncIterable<{ event: string; data: string }> {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const parts = buffer.split(/\r?\n\r?\n/);
+      buffer = parts.pop() ?? "";
+      for (const part of parts) {
+        const event = parseSseBlock(part);
+        if (event) yield event;
+      }
+    }
+
+    buffer += decoder.decode();
+    const trailing = parseSseBlock(buffer);
+    if (trailing) yield trailing;
+  } finally {
+    try {
+      reader.releaseLock();
+    } catch {
+      // Preserve original stream errors if the reader lock was already released.
+    }
+  }
+}
+
+function parseSseBlock(block: string): { event: string; data: string } | undefined {
+  const lines = block.split(/\r?\n/);
+  let event = "message";
+  const dataLines: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trimEnd();
+    if (trimmed.startsWith("event:")) event = trimmed.slice("event:".length).trimStart();
+    if (trimmed.startsWith("data:")) dataLines.push(trimmed.slice("data:".length).trimStart());
+  }
+  if (dataLines.length === 0) return undefined;
+  return { event, data: dataLines.join("\n") };
+}
+
+function parseStreamEvent(data: string, providerId?: string): AnthropicStreamEvent {
+  try {
+    return JSON.parse(data) as AnthropicStreamEvent;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ProviderError(`Provider stream delivered unparseable data: ${detail}`, {
+      kind: "malformed_response",
+      providerId,
+      cause: error,
+    });
+  }
 }
 
 function anthropicThinkingControl(tier: ReasoningTier | undefined, maxTokens: number): Record<string, unknown> | undefined {

--- a/tests/anthropic-provider.test.ts
+++ b/tests/anthropic-provider.test.ts
@@ -259,6 +259,35 @@ describe("Anthropic Messages adapter", () => {
       providerId: "anthropic",
     });
   });
+
+  test("streams redacted thinking blocks into the final response", async () => {
+    globalThis.fetch = (async () => new Response(rawSse([
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_redacted","model":"claude-test"}}',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"redacted_thinking","data":"opaque"}}',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"done"}}',
+      'event: message_stop\ndata: {"type":"message_stop"}',
+    ]))) as unknown as typeof fetch;
+
+    const adapter = new AnthropicMessagesAdapter({
+      provider: "anthropic-messages",
+      providerId: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+      model: "claude-test",
+      apiKey: "test-key",
+    });
+
+    const events = await collect(adapter.stream!(request()));
+
+    expect(events.at(-1)).toMatchObject({
+      type: "complete",
+      response: {
+        content: "done",
+        reasoningContent: "[redacted thinking]",
+        thinkingBlocks: [{ type: "redacted_thinking", data: "opaque" }],
+      },
+    });
+  });
 });
 
 function request(): VesicleRequest {

--- a/tests/anthropic-provider.test.ts
+++ b/tests/anthropic-provider.test.ts
@@ -191,6 +191,74 @@ describe("Anthropic Messages adapter", () => {
       providerId: "anthropic",
     });
   });
+
+  test("streams text, thinking, tool deltas, and a final response", async () => {
+    globalThis.fetch = (async (_input: unknown, init: RequestInit & { body?: unknown }) => {
+      expect(JSON.parse(String(init.body))).toMatchObject({ stream: true });
+      return new Response(rawSse([
+        'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stream","model":"claude-test","usage":{"input_tokens":11}}}',
+        'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"think"}}',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig"}}',
+        'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"hello"}}',
+        'event: content_block_start\ndata: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_1","name":"read_file","input":{}}}',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":"}}',
+        'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\\"workspace/a.md\\"}"}}',
+        'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":22}}',
+        'event: message_stop\ndata: {"type":"message_stop"}',
+      ]), {
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as unknown as typeof fetch;
+
+    const adapter = new AnthropicMessagesAdapter({
+      provider: "anthropic-messages",
+      providerId: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+      model: "claude-test",
+      apiKey: "test-key",
+    });
+
+    const events = await collect(adapter.stream!(request()));
+
+    expect(events).toContainEqual({ type: "reasoning_delta", delta: "think" });
+    expect(events).toContainEqual({ type: "content_delta", delta: "hello" });
+    expect(events).toContainEqual({ type: "tool_call_delta", index: 2, id: "toolu_1", name: "read_file" });
+    expect(events).toContainEqual({ type: "tool_call_delta", index: 2, argumentsDelta: "{\"path\":" });
+    expect(events.at(-1)).toEqual({
+      type: "complete",
+      response: {
+        id: "msg_stream",
+        content: "hello",
+        reasoningContent: "think",
+        thinkingBlocks: [{ type: "thinking", thinking: "think", signature: "sig" }],
+        toolCalls: [{ id: "toolu_1", name: "read_file", arguments: "{\"path\":\"workspace/a.md\"}" }],
+        finishReason: "tool_use",
+        usage: { inputTokens: 11, outputTokens: 22, totalTokens: 33 },
+      },
+    });
+  });
+
+  test("rejects streams that end before message_stop", async () => {
+    globalThis.fetch = (async () => new Response(rawSse([
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_stream"}}',
+    ]))) as unknown as typeof fetch;
+
+    const adapter = new AnthropicMessagesAdapter({
+      provider: "anthropic-messages",
+      providerId: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+      model: "claude-test",
+      apiKey: "test-key",
+    });
+
+    await expect(collect(adapter.stream!(request()))).rejects.toMatchObject({
+      name: "ProviderError",
+      kind: "stream_error",
+      providerId: "anthropic",
+    });
+  });
 });
 
 function request(): VesicleRequest {
@@ -200,4 +268,20 @@ function request(): VesicleRequest {
     system: ["system"],
     messages: [{ role: "user", content: "hello" }],
   };
+}
+
+async function collect<T>(events: AsyncIterable<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const event of events) result.push(event);
+  return result;
+}
+
+function rawSse(blocks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const block of blocks) controller.enqueue(encoder.encode(`${block}\n\n`));
+      controller.close();
+    },
+  });
 }


### PR DESCRIPTION
## Summary

- add Anthropic Messages SSE streaming support
- stream text, thinking, and tool-use JSON deltas into Vesicle provider events
- reconstruct final `VesicleResponse` with thinking blocks, reasoning bridge text, tool calls, finish reason, and usage
- report premature Anthropic stream EOF before `message_stop` as a stream error
- update docs/status/changelog/style for Anthropic streaming support

## Test Plan

- [x] `bun run typecheck`
- [x] `bun test tests\anthropic-provider.test.ts tests\agent-loop.test.ts tests\provider-backend.test.ts tests\tui.test.tsx`
- [x] `bun test`
- [x] `bun run doctor`
- [x] manual Anthropic streaming smoke by user

## Notes / Follow-ups

- Waiting for Bot Review.