### PR TITLE
feat(tools): expand guarded filesystem operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ project follows Semantic Versioning once releases begin.
   `/models`, `/use`, and `/model`.
 - Artifact workbench commands for `/artifacts`, `/artifact`, `/validate`, and
   `/revise`, including validation against the selected artifact file on disk.
+- Filesystem tool v2 surface: `stat_path`, `grep_files`, ranged `read_file`,
+  `create_file`, `replace_in_file`, `append_file`, `delete_file`, `copy_file`,
+  and `move_file`, all behind the existing project-relative path guards and
+  artifact-root write boundaries.
 - OpenAI-compatible Chat Completions streaming path: provider responses now use
   SSE when available, emitting assistant content deltas and reconstructing
   streamed `tool_calls` into the same final `VesicleResponse` shape used by

--- a/README.md
+++ b/README.md
@@ -97,8 +97,11 @@ return to an unresolved gate.
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker
   support and interactive pending-gate recovery
-- Tool-calling loop for `list_files`, `read_file`, and `write_file` with a
-  high ceiling and no-progress circuit breaker (not a coding-agent hard cap)
+- Tool-calling loop for guarded filesystem CRUD/search tools (`stat_path`,
+  `list_files`, `grep_files`, `read_file`, `create_file`, `write_file`,
+  `replace_in_file`, `append_file`, `delete_file`, `copy_file`, `move_file`)
+  with a high ceiling and no-progress circuit breaker (not a coding-agent hard
+  cap)
 - `request_confirmation` gate runtime: the model pauses for user confirmation
   at declared stop gates (ETL blueprint and phase checkpoints wired)
 - Module A (character card) and Module B (scenario card) v9 schema validators;

--- a/STATUS.md
+++ b/STATUS.md
@@ -56,9 +56,10 @@ Chat wrapper:
   natively.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
-- Execute a file-tool loop (`list_files` / `read_file` / `write_file`) with a
-  high ceiling and a no-progress circuit breaker instead of a coding-agent
-  hard cap.
+- Execute a guarded filesystem tool loop (`stat_path`, `list_files`,
+  `grep_files`, `read_file`, `create_file`, `write_file`, `replace_in_file`,
+  `append_file`, `delete_file`, `copy_file`, `move_file`) with a high ceiling
+  and a no-progress circuit breaker instead of a coding-agent hard cap.
 - Pause the workflow on `request_confirmation` gates; the user confirms,
   revises, or retreats to chat, then the loop continues.
 - Validate artifact-shaped ETL output against Module A (character card) and
@@ -109,9 +110,17 @@ prism-vesicle/
 
 | Tool | Status | Write scope |
 |------|--------|-------------|
+| `stat_path` | Implemented | Read-only |
 | `list_files` | Implemented | Read-only |
-| `read_file` | Implemented | Read-only |
-| `write_file` | Implemented | `workspace/`, `test_runs/`, `novels/`, `reports/` |
+| `grep_files` | Implemented | Read-only |
+| `read_file` | Implemented, with optional line ranges | Read-only |
+| `create_file` | Implemented, no overwrite | `workspace/`, `test_runs/`, `novels/`, `reports/` |
+| `write_file` | Implemented, full overwrite | `workspace/`, `test_runs/`, `novels/`, `reports/` |
+| `replace_in_file` | Implemented, exact text replacement | `workspace/`, `test_runs/`, `novels/`, `reports/` |
+| `append_file` | Implemented | `workspace/`, `test_runs/`, `novels/`, `reports/` |
+| `delete_file` | Implemented, files only | `workspace/`, `test_runs/`, `novels/`, `reports/` |
+| `copy_file` | Implemented | Source: read roots; target: artifact roots |
+| `move_file` | Implemented | `workspace/`, `test_runs/`, `novels/`, `reports/` |
 | `request_confirmation` | Implemented (gate) | No filesystem access |
 | `config.load` | Internal contract | N/A |
 | `prompt.load` | Internal contract | N/A |

--- a/assets/engines/dyad.profile.yaml
+++ b/assets/engines/dyad.profile.yaml
@@ -8,9 +8,17 @@ defaultTools:
   - config.load
   - prompt.load
   - session.write
+  - stat_path
   - list_files
+  - grep_files
   - read_file
+  - create_file
   - write_file
+  - replace_in_file
+  - append_file
+  - delete_file
+  - copy_file
+  - move_file
 validators: []
 stopGates: []
 stateRoots:

--- a/assets/engines/etl.profile.yaml
+++ b/assets/engines/etl.profile.yaml
@@ -8,9 +8,17 @@ defaultTools:
   - config.load
   - prompt.load
   - session.write
+  - stat_path
   - list_files
+  - grep_files
   - read_file
+  - create_file
   - write_file
+  - replace_in_file
+  - append_file
+  - delete_file
+  - copy_file
+  - move_file
 validators:
   - character-card
   - scenario-card

--- a/assets/engines/evaluate.profile.yaml
+++ b/assets/engines/evaluate.profile.yaml
@@ -8,9 +8,17 @@ defaultTools:
   - config.load
   - prompt.load
   - session.write
+  - stat_path
   - list_files
+  - grep_files
   - read_file
+  - create_file
   - write_file
+  - replace_in_file
+  - append_file
+  - delete_file
+  - copy_file
+  - move_file
 validators: []
 stopGates: []
 stateRoots:

--- a/assets/engines/runtime.profile.yaml
+++ b/assets/engines/runtime.profile.yaml
@@ -8,9 +8,17 @@ defaultTools:
   - config.load
   - prompt.load
   - session.write
+  - stat_path
   - list_files
+  - grep_files
   - read_file
+  - create_file
   - write_file
+  - replace_in_file
+  - append_file
+  - delete_file
+  - copy_file
+  - move_file
 validators: []
 stopGates:
   - runtime-turn

--- a/assets/engines/weaver-orch.profile.yaml
+++ b/assets/engines/weaver-orch.profile.yaml
@@ -8,9 +8,17 @@ defaultTools:
   - config.load
   - prompt.load
   - session.write
+  - stat_path
   - list_files
+  - grep_files
   - read_file
+  - create_file
   - write_file
+  - replace_in_file
+  - append_file
+  - delete_file
+  - copy_file
+  - move_file
 validators: []
 stopGates: []
 stateRoots:

--- a/assets/engines/weaver.profile.yaml
+++ b/assets/engines/weaver.profile.yaml
@@ -8,9 +8,17 @@ defaultTools:
   - config.load
   - prompt.load
   - session.write
+  - stat_path
   - list_files
+  - grep_files
   - read_file
+  - create_file
   - write_file
+  - replace_in_file
+  - append_file
+  - delete_file
+  - copy_file
+  - move_file
 validators: []
 stopGates: []
 stateRoots:

--- a/assets/prompts/shared/vesicle-base.md
+++ b/assets/prompts/shared/vesicle-base.md
@@ -6,14 +6,14 @@ You are running inside Prism Vesicle, a direct TUI/API harness for Prism Engine.
 
 - Do not claim to be Codex, Claude Code, RooCode, VSCode, or a coding-agent extension.
 - Do not assume host-specific tools such as `ask_followup_question`, `new_task`, `AGENTS.md`, `CLAUDE.md`, or Roo custom modes.
-- M0 exposes these Vesicle host contracts: `config.load`, `prompt.load`, `session.write`, `list_files`, `read_file`, and `write_file`.
-- When a workflow requires filesystem action, use the Vesicle file tools. Do not claim that a file was written unless `write_file` has returned a successful tool result.
+- Vesicle exposes these host contracts and file tools: `config.load`, `prompt.load`, `session.write`, `stat_path`, `list_files`, `grep_files`, `read_file`, `create_file`, `write_file`, `replace_in_file`, `append_file`, `delete_file`, `copy_file`, and `move_file`.
+- When a workflow requires filesystem action, use the Vesicle file tools. Do not claim that a file was created, written, edited, deleted, copied, or moved unless the corresponding tool has returned a successful result.
 
 ## Runtime Scope
 
 - Treat `assets/specs/` and `assets/templates/` as read-only reference assets.
 - Treat `source_materials/`, `workspace/`, `test_runs/`, `novels/`, and `reports/` as durable project state roots.
-- Use `write_file` for generated artifacts under `workspace/`, `test_runs/`, `novels/`, or `reports/`.
+- Generated or edited artifacts must stay under `workspace/`, `test_runs/`, `novels/`, or `reports/`.
 - Keep Prism v9 output-layer constraints intact: no L-System tags in deployed character or scenario artifacts, and no runtime-mutable state in static YAML unless the schema explicitly allows it.
 
 ## M0 Interaction

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -102,6 +102,9 @@ Model-visible tools are a security boundary.
 - Create/write/replace/append/delete/copy-target/move roots: `workspace/`,
   `test_runs/`, `novels/`, `reports/`.
 - `delete_file` must delete only files, never directories or directory trees.
+- `grep_files` regex mode is for trusted single-user model input. If Vesicle
+  ever exposes untrusted model/plugin input, regex matching needs a timeout
+  boundary such as RE2 or a worker-thread sandbox.
 - A model must not claim a file was created, written, edited, deleted, copied,
   or moved unless the corresponding file tool returned success.
 - The `request_confirmation` gate tool is attached only when the active engine

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -97,10 +97,13 @@ Model-visible tools are a security boundary.
 
 - Only project-relative paths are allowed.
 - Absolute paths and traversal outside the project root are rejected.
-- Read/list roots: `assets/`, `source_materials/`, `workspace/`, `test_runs/`,
-  `novels/`, `reports/`.
-- Write roots: `workspace/`, `test_runs/`, `novels/`, `reports/`.
-- A model must not claim a file was written unless `write_file` returned success.
+- Read/list/stat/grep roots: `assets/`, `source_materials/`, `workspace/`,
+  `test_runs/`, `novels/`, `reports/`.
+- Create/write/replace/append/delete/copy-target/move roots: `workspace/`,
+  `test_runs/`, `novels/`, `reports/`.
+- `delete_file` must delete only files, never directories or directory trees.
+- A model must not claim a file was created, written, edited, deleted, copied,
+  or moved unless the corresponding file tool returned success.
 - The `request_confirmation` gate tool is attached only when the active engine
   profile declares at least one stop gate. Undeclared gates are refused with a
   tool result, not paused — the model self-corrects on the next turn.

--- a/src/core/tools/fs.ts
+++ b/src/core/tools/fs.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { appendFile, copyFile, mkdir, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 
 export type ToolCall = {
@@ -30,6 +30,24 @@ export const fileToolDefinitions: ToolDefinition[] = [
   {
     type: "function",
     function: {
+      name: "stat_path",
+      description: "Inspect an allowed project-relative file or directory path.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Project-relative path under an allowed read root.",
+          },
+        },
+        required: ["path"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
       name: "list_files",
       description: "List files under an allowed Vesicle project directory.",
       parameters: {
@@ -52,6 +70,44 @@ export const fileToolDefinitions: ToolDefinition[] = [
   {
     type: "function",
     function: {
+      name: "grep_files",
+      description: "Search allowed UTF-8 project files for literal text or a JavaScript regular expression.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Project-relative file or directory path under an allowed read root.",
+          },
+          pattern: {
+            type: "string",
+            description: "Search pattern. Interpreted literally unless regex is true.",
+          },
+          regex: {
+            type: "boolean",
+            description: "Treat pattern as a JavaScript regular expression. Defaults to false.",
+          },
+          caseSensitive: {
+            type: "boolean",
+            description: "Whether matching is case-sensitive. Defaults to false.",
+          },
+          recursive: {
+            type: "boolean",
+            description: "Whether to search directories recursively. Defaults to true.",
+          },
+          maxMatches: {
+            type: "number",
+            description: "Maximum matches to return. Defaults to 50 and is capped at 200.",
+          },
+        },
+        required: ["path", "pattern"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
       name: "read_file",
       description: "Read a UTF-8 text file from an allowed Vesicle project directory.",
       parameters: {
@@ -61,8 +117,38 @@ export const fileToolDefinitions: ToolDefinition[] = [
             type: "string",
             description: "Project-relative file path.",
           },
+          startLine: {
+            type: "number",
+            description: "Optional 1-based first line to read.",
+          },
+          endLine: {
+            type: "number",
+            description: "Optional 1-based last line to read, inclusive.",
+          },
         },
         required: ["path"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "create_file",
+      description: "Create a new UTF-8 artifact file. Fails if the file already exists.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Project-relative output path under workspace, test_runs, novels, or reports.",
+          },
+          content: {
+            type: "string",
+            description: "Full UTF-8 file content to write.",
+          },
+        },
+        required: ["path", "content"],
         additionalProperties: false,
       },
     },
@@ -89,11 +175,149 @@ export const fileToolDefinitions: ToolDefinition[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "replace_in_file",
+      description: "Replace exact text inside an existing UTF-8 artifact file.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Project-relative file path under workspace, test_runs, novels, or reports.",
+          },
+          oldText: {
+            type: "string",
+            description: "Exact text to replace.",
+          },
+          newText: {
+            type: "string",
+            description: "Replacement text.",
+          },
+          replaceAll: {
+            type: "boolean",
+            description: "Replace every occurrence. Defaults to false; without it, exactly one occurrence must match.",
+          },
+        },
+        required: ["path", "oldText", "newText"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "append_file",
+      description: "Append UTF-8 text to an existing artifact file.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Project-relative file path under workspace, test_runs, novels, or reports.",
+          },
+          content: {
+            type: "string",
+            description: "UTF-8 content to append.",
+          },
+          createIfMissing: {
+            type: "boolean",
+            description: "Create the file if it does not exist. Defaults to false.",
+          },
+        },
+        required: ["path", "content"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "delete_file",
+      description: "Delete a single artifact file. Directories are not deleted.",
+      parameters: {
+        type: "object",
+        properties: {
+          path: {
+            type: "string",
+            description: "Project-relative file path under workspace, test_runs, novels, or reports.",
+          },
+        },
+        required: ["path"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "copy_file",
+      description: "Copy an allowed file to an artifact root.",
+      parameters: {
+        type: "object",
+        properties: {
+          sourcePath: {
+            type: "string",
+            description: "Project-relative source file path under an allowed read root.",
+          },
+          targetPath: {
+            type: "string",
+            description: "Project-relative target path under workspace, test_runs, novels, or reports.",
+          },
+          overwrite: {
+            type: "boolean",
+            description: "Overwrite an existing target file. Defaults to false.",
+          },
+        },
+        required: ["sourcePath", "targetPath"],
+        additionalProperties: false,
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "move_file",
+      description: "Move or rename an artifact file inside artifact roots.",
+      parameters: {
+        type: "object",
+        properties: {
+          sourcePath: {
+            type: "string",
+            description: "Project-relative source file path under workspace, test_runs, novels, or reports.",
+          },
+          targetPath: {
+            type: "string",
+            description: "Project-relative target path under workspace, test_runs, novels, or reports.",
+          },
+          overwrite: {
+            type: "boolean",
+            description: "Overwrite an existing target file. Defaults to false.",
+          },
+        },
+        required: ["sourcePath", "targetPath"],
+        additionalProperties: false,
+      },
+    },
+  },
 ];
 
 export async function executeFileTool(rootDir: string, call: ToolCall): Promise<ToolResult> {
   try {
     switch (call.name) {
+      case "stat_path": {
+        const args = parseArgs<{ path: string }>(call.arguments);
+        const resolved = resolveAllowed(rootDir, args.path, readableRoots);
+        const info = await stat(resolved);
+        return ok(call, JSON.stringify({
+          path: toProjectPath(rootDir, resolved),
+          type: info.isDirectory() ? "directory" : info.isFile() ? "file" : "other",
+          size: info.size,
+          modifiedAt: info.mtime.toISOString(),
+        }));
+      }
+
       case "list_files": {
         const args = parseArgs<{ path: string; recursive?: boolean }>(call.arguments);
         const dir = resolveAllowed(rootDir, args.path, readableRoots);
@@ -101,10 +325,32 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         return ok(call, entries.map((entry) => toProjectPath(rootDir, entry)).join("\n") || "(empty)");
       }
 
+      case "grep_files": {
+        const args = parseArgs<{
+          path: string;
+          pattern: string;
+          regex?: boolean;
+          caseSensitive?: boolean;
+          recursive?: boolean;
+          maxMatches?: number;
+        }>(call.arguments);
+        const resolved = resolveAllowed(rootDir, args.path, readableRoots);
+        const result = await grepFiles(rootDir, resolved, args);
+        return ok(call, JSON.stringify(result));
+      }
+
       case "read_file": {
-        const args = parseArgs<{ path: string }>(call.arguments);
+        const args = parseArgs<{ path: string; startLine?: number; endLine?: number }>(call.arguments);
         const filePath = resolveAllowed(rootDir, args.path, readableRoots);
-        return ok(call, await readFile(filePath, "utf8"));
+        return ok(call, sliceLines(await readFile(filePath, "utf8"), args.startLine, args.endLine));
+      }
+
+      case "create_file": {
+        const args = parseArgs<{ path: string; content: string }>(call.arguments);
+        const filePath = resolveAllowed(rootDir, args.path, writableRoots);
+        await mkdir(dirname(filePath), { recursive: true });
+        await writeFile(filePath, args.content, { encoding: "utf8", flag: "wx" });
+        return ok(call, `Created ${toProjectPath(rootDir, filePath)}`);
       }
 
       case "write_file": {
@@ -113,6 +359,60 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         await mkdir(dirname(filePath), { recursive: true });
         await writeFile(filePath, args.content, "utf8");
         return ok(call, `Wrote ${toProjectPath(rootDir, filePath)}`);
+      }
+
+      case "replace_in_file": {
+        const args = parseArgs<{ path: string; oldText: string; newText: string; replaceAll?: boolean }>(call.arguments);
+        const filePath = resolveAllowed(rootDir, args.path, writableRoots);
+        const original = await readFile(filePath, "utf8");
+        if (!args.oldText) throw new Error("oldText must not be empty.");
+        const count = countOccurrences(original, args.oldText);
+        if (count === 0) throw new Error("oldText was not found.");
+        if (!args.replaceAll && count !== 1) {
+          throw new Error(`oldText matched ${count} times. Set replaceAll=true or provide a more specific oldText.`);
+        }
+        const next = args.replaceAll
+          ? original.split(args.oldText).join(args.newText)
+          : original.replace(args.oldText, args.newText);
+        await writeFile(filePath, next, "utf8");
+        return ok(call, `Replaced ${args.replaceAll ? count : 1} occurrence(s) in ${toProjectPath(rootDir, filePath)}`);
+      }
+
+      case "append_file": {
+        const args = parseArgs<{ path: string; content: string; createIfMissing?: boolean }>(call.arguments);
+        const filePath = resolveAllowed(rootDir, args.path, writableRoots);
+        await mkdir(dirname(filePath), { recursive: true });
+        if (!args.createIfMissing) await assertFile(filePath);
+        await appendFile(filePath, args.content, { encoding: "utf8", flag: "a" });
+        return ok(call, `Appended ${args.content.length} char(s) to ${toProjectPath(rootDir, filePath)}`);
+      }
+
+      case "delete_file": {
+        const args = parseArgs<{ path: string }>(call.arguments);
+        const filePath = resolveAllowed(rootDir, args.path, writableRoots);
+        await assertFile(filePath);
+        await unlink(filePath);
+        return ok(call, `Deleted ${toProjectPath(rootDir, filePath)}`);
+      }
+
+      case "copy_file": {
+        const args = parseArgs<{ sourcePath: string; targetPath: string; overwrite?: boolean }>(call.arguments);
+        const sourcePath = resolveAllowed(rootDir, args.sourcePath, readableRoots);
+        const targetPath = resolveAllowed(rootDir, args.targetPath, writableRoots);
+        await assertFile(sourcePath);
+        await prepareTarget(targetPath, Boolean(args.overwrite));
+        await copyFile(sourcePath, targetPath);
+        return ok(call, `Copied ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`);
+      }
+
+      case "move_file": {
+        const args = parseArgs<{ sourcePath: string; targetPath: string; overwrite?: boolean }>(call.arguments);
+        const sourcePath = resolveAllowed(rootDir, args.sourcePath, writableRoots);
+        const targetPath = resolveAllowed(rootDir, args.targetPath, writableRoots);
+        await assertFile(sourcePath);
+        await prepareTarget(targetPath, Boolean(args.overwrite));
+        await rename(sourcePath, targetPath);
+        return ok(call, `Moved ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`);
       }
 
       default:
@@ -151,6 +451,86 @@ function resolveAllowed(rootDir: string, requestedPath: string, roots: string[])
   }
 
   return resolved;
+}
+
+function sliceLines(content: string, startLine: number | undefined, endLine: number | undefined): string {
+  if (startLine === undefined && endLine === undefined) return content;
+  const start = startLine ?? 1;
+  const end = endLine ?? Number.POSITIVE_INFINITY;
+  if (!Number.isInteger(start) || start <= 0) throw new Error("startLine must be a positive integer.");
+  if (!Number.isInteger(end) && end !== Number.POSITIVE_INFINITY) throw new Error("endLine must be a positive integer.");
+  if (end < start) throw new Error("endLine must be greater than or equal to startLine.");
+  return content.split(/\r?\n/).slice(start - 1, end).join("\n");
+}
+
+async function grepFiles(
+  rootDir: string,
+  targetPath: string,
+  args: { pattern: string; regex?: boolean; caseSensitive?: boolean; recursive?: boolean; maxMatches?: number },
+): Promise<{ matches: Array<{ path: string; line: number; text: string }>; truncated: boolean }> {
+  if (!args.pattern) throw new Error("pattern must not be empty.");
+  const limit = clampPositiveInteger(args.maxMatches ?? 50, "maxMatches", 200);
+  const matcher = createMatcher(args.pattern, Boolean(args.regex), Boolean(args.caseSensitive));
+  const info = await stat(targetPath);
+  const files = info.isFile()
+    ? [targetPath]
+    : info.isDirectory()
+      ? await listFiles(targetPath, args.recursive ?? true)
+      : [];
+  const matches: Array<{ path: string; line: number; text: string }> = [];
+
+  for (const file of files) {
+    const lines = (await readFile(file, "utf8")).split(/\r?\n/);
+    for (let index = 0; index < lines.length; index++) {
+      if (!matcher(lines[index])) continue;
+      matches.push({ path: toProjectPath(rootDir, file), line: index + 1, text: lines[index] });
+      if (matches.length >= limit) return { matches, truncated: true };
+    }
+  }
+
+  return { matches, truncated: false };
+}
+
+function createMatcher(pattern: string, regex: boolean, caseSensitive: boolean): (line: string) => boolean {
+  if (regex) {
+    const expression = new RegExp(pattern, caseSensitive ? "" : "i");
+    return (line) => expression.test(line);
+  }
+  const needle = caseSensitive ? pattern : pattern.toLocaleLowerCase();
+  return (line) => (caseSensitive ? line : line.toLocaleLowerCase()).includes(needle);
+}
+
+function clampPositiveInteger(value: number, name: string, max: number): number {
+  if (!Number.isInteger(value) || value <= 0) throw new Error(`${name} must be a positive integer.`);
+  return Math.min(value, max);
+}
+
+function countOccurrences(content: string, needle: string): number {
+  let count = 0;
+  let index = 0;
+  while (true) {
+    const next = content.indexOf(needle, index);
+    if (next === -1) return count;
+    count += 1;
+    index = next + needle.length;
+  }
+}
+
+async function assertFile(filePath: string): Promise<void> {
+  const info = await stat(filePath);
+  if (!info.isFile()) throw new Error("Path must be a file.");
+}
+
+async function prepareTarget(targetPath: string, overwrite: boolean): Promise<void> {
+  await mkdir(dirname(targetPath), { recursive: true });
+  const existing = await stat(targetPath).catch((error: unknown) => {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") return undefined;
+    throw error;
+  });
+  if (!existing) return;
+  if (!existing.isFile()) throw new Error("Target path exists and is not a file.");
+  if (!overwrite) throw new Error("Target file already exists. Set overwrite=true to replace it.");
+  await unlink(targetPath);
 }
 
 async function listFiles(dir: string, recursive: boolean): Promise<string[]> {

--- a/src/core/tools/fs.ts
+++ b/src/core/tools/fs.ts
@@ -371,9 +371,9 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         if (!args.replaceAll && count !== 1) {
           throw new Error(`oldText matched ${count} times. Set replaceAll=true or provide a more specific oldText.`);
         }
-        const next = args.replaceAll
-          ? original.split(args.oldText).join(args.newText)
-          : original.replace(args.oldText, args.newText);
+        // Single-user TUI contract: this read/count/write sequence is not
+        // designed for concurrent external writers.
+        const next = original.split(args.oldText).join(args.newText);
         await writeFile(filePath, next, "utf8");
         return ok(call, `Replaced ${args.replaceAll ? count : 1} occurrence(s) in ${toProjectPath(rootDir, filePath)}`);
       }
@@ -391,6 +391,8 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         const args = parseArgs<{ path: string }>(call.arguments);
         const filePath = resolveAllowed(rootDir, args.path, writableRoots);
         await assertFile(filePath);
+        // Single-user TUI contract: the path is expected not to change between
+        // the file check and unlink.
         await unlink(filePath);
         return ok(call, `Deleted ${toProjectPath(rootDir, filePath)}`);
       }
@@ -457,6 +459,8 @@ function sliceLines(content: string, startLine: number | undefined, endLine: num
   if (startLine === undefined && endLine === undefined) return content;
   const start = startLine ?? 1;
   const end = endLine ?? Number.POSITIVE_INFINITY;
+  if (typeof start !== "number") throw new Error("startLine must be a number.");
+  if (typeof end !== "number") throw new Error("endLine must be a number.");
   if (!Number.isInteger(start) || start <= 0) throw new Error("startLine must be a positive integer.");
   if (!Number.isInteger(end) && end !== Number.POSITIVE_INFINITY) throw new Error("endLine must be a positive integer.");
   if (end < start) throw new Error("endLine must be greater than or equal to startLine.");
@@ -493,6 +497,9 @@ async function grepFiles(
 
 function createMatcher(pattern: string, regex: boolean, caseSensitive: boolean): (line: string) => boolean {
   if (regex) {
+    // Regex patterns are model-provided but currently trusted inside the
+    // single-user TUI. If Vesicle exposes untrusted providers, move regex
+    // matching behind a timeout-capable engine such as RE2 or a worker.
     const expression = new RegExp(pattern, caseSensitive ? "" : "i");
     return (line) => expression.test(line);
   }
@@ -530,6 +537,8 @@ async function prepareTarget(targetPath: string, overwrite: boolean): Promise<vo
   if (!existing) return;
   if (!existing.isFile()) throw new Error("Target path exists and is not a file.");
   if (!overwrite) throw new Error("Target file already exists. Set overwrite=true to replace it.");
+  // Single-user TUI contract: overwrite is a stat/unlink/write sequence, not
+  // a cross-process atomic replacement protocol.
   await unlink(targetPath);
 }
 
@@ -549,7 +558,13 @@ async function listFiles(dir: string, recursive: boolean): Promise<string[]> {
       continue;
     }
 
-    if ((await stat(fullPath)).isFile()) {
+    if (entry.isFile()) {
+      result.push(fullPath);
+      continue;
+    }
+
+    const info = await stat(fullPath).catch(() => undefined);
+    if (info?.isFile()) {
       result.push(fullPath);
     }
   }

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -2,9 +2,17 @@ export type BuiltInToolName =
   | "config.load"
   | "session.write"
   | "prompt.load"
+  | "stat_path"
   | "list_files"
+  | "grep_files"
   | "read_file"
-  | "write_file";
+  | "create_file"
+  | "write_file"
+  | "replace_in_file"
+  | "append_file"
+  | "delete_file"
+  | "copy_file"
+  | "move_file";
 export { executeFileTool, fileToolDefinitions } from "./fs";
 export type { ToolCall, ToolDefinition, ToolResult } from "./fs";
 
@@ -27,15 +35,47 @@ export const m0Tools: ToolContract[] = [
     description: "Load Prism prompt assets from the assets directory.",
   },
   {
+    name: "stat_path",
+    description: "Inspect an allowed project path.",
+  },
+  {
     name: "list_files",
     description: "List allowed project files.",
+  },
+  {
+    name: "grep_files",
+    description: "Search text in allowed project files.",
   },
   {
     name: "read_file",
     description: "Read allowed UTF-8 project files.",
   },
   {
+    name: "create_file",
+    description: "Create a new UTF-8 artifact file without overwriting an existing file.",
+  },
+  {
     name: "write_file",
     description: "Write UTF-8 artifacts under workspace, test_runs, novels, or reports.",
+  },
+  {
+    name: "replace_in_file",
+    description: "Replace exact text inside an existing artifact file.",
+  },
+  {
+    name: "append_file",
+    description: "Append UTF-8 text to an existing artifact file.",
+  },
+  {
+    name: "delete_file",
+    description: "Delete an artifact file.",
+  },
+  {
+    name: "copy_file",
+    description: "Copy an allowed file into an artifact root.",
+  },
+  {
+    name: "move_file",
+    description: "Move or rename an artifact file inside artifact roots.",
   },
 ];

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -110,6 +110,10 @@ describe("file tools v2", () => {
       sourcePath: "source_materials/seed.md",
       targetPath: "workspace/seed.md",
     }, "Copied source_materials/seed.md to workspace/seed.md");
+
+    await expectToolFailure("delete_file", {
+      path: "workspace/nope.md",
+    }, "ENOENT");
   });
 
   test("append_file requires an existing file unless createIfMissing is set", async () => {
@@ -125,6 +129,85 @@ describe("file tools v2", () => {
     }, "Appended 4 char(s) to workspace/missing.md");
 
     expect(await readFile(join(rootDir, "workspace", "missing.md"), "utf8")).toBe("tail");
+
+    await expectTool("append_file", {
+      path: "workspace/nested/new.md",
+      content: "nested",
+      createIfMissing: true,
+    }, "Appended 6 char(s) to workspace/nested/new.md");
+    expect(await readFile(join(rootDir, "workspace", "nested", "new.md"), "utf8")).toBe("nested");
+  });
+
+  test("handles literal replacement text, regex grep, overwrite paths, and validation edges", async () => {
+    await expectTool("create_file", {
+      path: "workspace/edge.md",
+      content: "PRICE\nAlpha\nalpha\nBeta42",
+    }, "Created workspace/edge.md");
+
+    await expectTool("replace_in_file", {
+      path: "workspace/edge.md",
+      oldText: "PRICE",
+      newText: "Price: $50 and $&",
+    }, "Replaced 1 occurrence(s) in workspace/edge.md");
+    expect(await readFile(join(rootDir, "workspace", "edge.md"), "utf8")).toContain("Price: $50 and $&");
+
+    await expectToolFailure("replace_in_file", {
+      path: "workspace/edge.md",
+      oldText: "",
+      newText: "x",
+    }, "oldText must not be empty");
+
+    const regexResult = await executeFileTool(rootDir, call("grep_files", {
+      path: "workspace/edge.md",
+      pattern: "^Alpha$",
+      regex: true,
+      caseSensitive: true,
+    }));
+    expect(regexResult.ok).toBe(true);
+    expect(JSON.parse(regexResult.content)).toMatchObject({
+      matches: [{ path: "workspace/edge.md", line: 2, text: "Alpha" }],
+      truncated: false,
+    });
+
+    const dirStat = await executeFileTool(rootDir, call("stat_path", { path: "workspace" }));
+    expect(dirStat.ok).toBe(true);
+    expect(JSON.parse(dirStat.content)).toMatchObject({ path: "workspace", type: "directory" });
+
+    await expectToolFailure("read_file", {
+      path: "workspace/edge.md",
+      startLine: 0,
+    }, "startLine must be a positive integer");
+    await expectToolFailure("read_file", {
+      path: "workspace/edge.md",
+      startLine: 3,
+      endLine: 2,
+    }, "endLine must be greater than or equal to startLine");
+    await expectToolFailure("read_file", {
+      path: "workspace/edge.md",
+      startLine: "1",
+    }, "startLine must be a number");
+
+    await expectTool("create_file", {
+      path: "workspace/target.md",
+      content: "old",
+    }, "Created workspace/target.md");
+    await expectTool("copy_file", {
+      sourcePath: "workspace/edge.md",
+      targetPath: "workspace/target.md",
+      overwrite: true,
+    }, "Copied workspace/edge.md to workspace/target.md");
+    expect(await readFile(join(rootDir, "workspace", "target.md"), "utf8")).toContain("Beta42");
+
+    await expectTool("create_file", {
+      path: "reports/move-target.md",
+      content: "old move",
+    }, "Created reports/move-target.md");
+    await expectTool("move_file", {
+      sourcePath: "workspace/target.md",
+      targetPath: "reports/move-target.md",
+      overwrite: true,
+    }, "Moved workspace/target.md to reports/move-target.md");
+    expect(await readFile(join(rootDir, "reports", "move-target.md"), "utf8")).toContain("Beta42");
   });
 });
 

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { executeFileTool } from "../src/core/tools";
+
+let rootDir = "";
+
+beforeEach(async () => {
+  rootDir = await mkdtemp(join(tmpdir(), "vesicle-file-tools-"));
+  await mkdir(join(rootDir, "workspace"), { recursive: true });
+  await mkdir(join(rootDir, "reports"), { recursive: true });
+  await mkdir(join(rootDir, "source_materials"), { recursive: true });
+  await writeFile(join(rootDir, "source_materials", "seed.md"), "Alpha seed\nBeta seed\n", "utf8");
+});
+
+afterEach(async () => {
+  await rm(rootDir, { recursive: true, force: true });
+});
+
+describe("file tools v2", () => {
+  test("supports create, ranged read, exact replace, append, grep, stat, copy, move, and delete", async () => {
+    await expectTool("create_file", {
+      path: "workspace/a.md",
+      content: "alpha\nbeta\nalpha",
+    }, "Created workspace/a.md");
+
+    await expectToolFailure("create_file", {
+      path: "workspace/a.md",
+      content: "duplicate",
+    }, "EEXIST");
+
+    await expectTool("read_file", {
+      path: "workspace/a.md",
+      startLine: 2,
+      endLine: 2,
+    }, "beta");
+
+    await expectToolFailure("replace_in_file", {
+      path: "workspace/a.md",
+      oldText: "alpha",
+      newText: "gamma",
+    }, "matched 2 times");
+
+    await expectTool("replace_in_file", {
+      path: "workspace/a.md",
+      oldText: "alpha",
+      newText: "gamma",
+      replaceAll: true,
+    }, "Replaced 2 occurrence(s) in workspace/a.md");
+
+    await expectTool("append_file", {
+      path: "workspace/a.md",
+      content: "\nend",
+    }, "Appended 4 char(s) to workspace/a.md");
+
+    const statResult = await executeFileTool(rootDir, call("stat_path", { path: "workspace/a.md" }));
+    expect(statResult.ok).toBe(true);
+    expect(JSON.parse(statResult.content)).toMatchObject({
+      path: "workspace/a.md",
+      type: "file",
+    });
+
+    const grepResult = await executeFileTool(rootDir, call("grep_files", {
+      path: "workspace",
+      pattern: "gamma",
+      maxMatches: 10,
+    }));
+    expect(grepResult.ok).toBe(true);
+    expect(JSON.parse(grepResult.content)).toMatchObject({
+      matches: [
+        { path: "workspace/a.md", line: 1, text: "gamma" },
+        { path: "workspace/a.md", line: 3, text: "gamma" },
+      ],
+      truncated: false,
+    });
+
+    await expectTool("copy_file", {
+      sourcePath: "workspace/a.md",
+      targetPath: "reports/b.md",
+    }, "Copied workspace/a.md to reports/b.md");
+    expect(await readFile(join(rootDir, "reports", "b.md"), "utf8")).toContain("gamma");
+
+    await expectTool("move_file", {
+      sourcePath: "reports/b.md",
+      targetPath: "workspace/c.md",
+    }, "Moved reports/b.md to workspace/c.md");
+
+    await expectTool("delete_file", {
+      path: "workspace/c.md",
+    }, "Deleted workspace/c.md");
+  });
+
+  test("keeps write operations inside artifact roots and refuses risky deletes", async () => {
+    await expectToolFailure("write_file", {
+      path: "assets/leak.md",
+      content: "nope",
+    }, "Path must be under one of");
+
+    await expectToolFailure("delete_file", {
+      path: "workspace",
+    }, "Path must be a file");
+
+    await expectToolFailure("move_file", {
+      sourcePath: "source_materials/seed.md",
+      targetPath: "workspace/seed.md",
+    }, "Path must be under one of");
+
+    await expectTool("copy_file", {
+      sourcePath: "source_materials/seed.md",
+      targetPath: "workspace/seed.md",
+    }, "Copied source_materials/seed.md to workspace/seed.md");
+  });
+
+  test("append_file requires an existing file unless createIfMissing is set", async () => {
+    await expectToolFailure("append_file", {
+      path: "workspace/missing.md",
+      content: "tail",
+    }, "ENOENT");
+
+    await expectTool("append_file", {
+      path: "workspace/missing.md",
+      content: "tail",
+      createIfMissing: true,
+    }, "Appended 4 char(s) to workspace/missing.md");
+
+    expect(await readFile(join(rootDir, "workspace", "missing.md"), "utf8")).toBe("tail");
+  });
+});
+
+async function expectTool(name: string, args: Record<string, unknown>, content: string): Promise<void> {
+  const result = await executeFileTool(rootDir, call(name, args));
+  expect(result.ok).toBe(true);
+  expect(result.content).toBe(content);
+}
+
+async function expectToolFailure(name: string, args: Record<string, unknown>, content: string): Promise<void> {
+  const result = await executeFileTool(rootDir, call(name, args));
+  expect(result.ok).toBe(false);
+  expect(result.content).toContain(content);
+}
+
+function call(name: string, args: Record<string, unknown>) {
+  return {
+    id: `call-${name}`,
+    name,
+    arguments: JSON.stringify(args),
+  };
+}


### PR DESCRIPTION
## Summary

- Expand the model-visible filesystem tool surface with stat_path, grep_files, ranged read_file, create_file, replace_in_file, append_file, delete_file, copy_file, and move_file.
- Keep all operations behind project-relative path guards; write/edit/delete/move targets stay limited to workspace, test_runs, novels, and reports.
- Update engine profiles, the Vesicle base prompt, docs, and focused file-tool tests.

## Test Plan

- [x] bun run typecheck
- [x] bun test tests\\file-tools.test.ts tests\\profile.test.ts tests\\agent-loop.test.ts
- [x] bun test
- [x] bun run doctor

## Notes / Follow-ups

- delete_file intentionally refuses directories and recursive deletion.
- replace_in_file uses exact text replacement and requires replaceAll=true when oldText matches multiple locations.
