### PR TITLE
feat(tools): record file operation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ project follows Semantic Versioning once releases begin.
   `create_file`, `replace_in_file`, `append_file`, `delete_file`, `copy_file`,
   and `move_file`, all behind the existing project-relative path guards and
   artifact-root write boundaries.
+- File tool operation ledger: successful filesystem tools now emit structured
+  `fileEvent` metadata through agent-loop activity events and session JSONL
+  tool records.
 - OpenAI-compatible Chat Completions streaming path: provider responses now use
   SSE when available, emitting assistant content deltas and reconstructing
   streamed `tool_calls` into the same final `VesicleResponse` shape used by

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ return to an unresolved gate.
   `assets/engines/*.yaml`
 - JSONL session persistence under `.vesicle/sessions/` with `/resume` picker
   support and interactive pending-gate recovery
+- Structured `fileEvent` metadata in session tool records for successful
+  filesystem operations, enabling artifact/file-operation audit views without
+  parsing prose
 - Tool-calling loop for guarded filesystem CRUD/search tools (`stat_path`,
   `list_files`, `grep_files`, `read_file`, `create_file`, `write_file`,
   `replace_in_file`, `append_file`, `delete_file`, `copy_file`, `move_file`)

--- a/STATUS.md
+++ b/STATUS.md
@@ -56,6 +56,9 @@ Chat wrapper:
   natively.
 - Persist sessions as JSONL under `.vesicle/sessions/`; resume them through a
   TUI picker, including unresolved `request_confirmation` gates.
+- Persist successful filesystem tool operations as structured `fileEvent`
+  metadata on session tool records, so generated file changes can be replayed
+  or audited without scraping prose.
 - Execute a guarded filesystem tool loop (`stat_path`, `list_files`,
   `grep_files`, `read_file`, `create_file`, `write_file`, `replace_in_file`,
   `append_file`, `delete_file`, `copy_file`, `move_file`) with a high ceiling

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -158,6 +158,9 @@ Prompts are runtime assets, not hardcoded source literals.
 - Provider requests must include prior user/assistant turns when continuing a
   session.
 - Tool calls and tool results should be persisted for replay/debugging.
+- Successful filesystem tool results should persist structured `fileEvent`
+  metadata on the session tool record. Callers may use this for artifact
+  audit/ledger views without parsing natural-language tool result text.
 - User-selected reasoning tiers should be persisted as session metadata so
   interactive resume restores runtime generation behavior. Provider
   thinking state is preserved as thinking blocks for protocol continuity and

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -161,6 +161,10 @@ Prompts are runtime assets, not hardcoded source literals.
 - Successful filesystem tool results should persist structured `fileEvent`
   metadata on the session tool record. Callers may use this for artifact
   audit/ledger views without parsing natural-language tool result text.
+  In `fileEvent`, `bytes` means the resulting or observed file size, and for
+  `delete_file` it means the deleted file size. `append_file` may also report
+  `deltaBytes`; `list_files` reports `entryCount`; `grep_files` reports
+  `matches`.
 - User-selected reasoning tiers should be persisted as session metadata so
   interactive resume restores runtime generation behavior. Provider
   thinking state is preserved as thinking blocks for protocol continuity and

--- a/src/core/agent-loop/run.ts
+++ b/src/core/agent-loop/run.ts
@@ -4,7 +4,7 @@ import type { ProviderSelection } from "../../config/providers";
 import { createProvider } from "../../providers";
 import type { ProviderAdapter, ProviderThinkingBlock, VesicleMessage, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
 import { executeFileTool, fileToolDefinitions } from "../tools";
-import type { ToolCall, ToolDefinition } from "../tools";
+import type { FileToolEvent, ToolCall, ToolDefinition } from "../tools";
 import { composeSystemPrompt, loadPromptBundle } from "../prompt/loader";
 import type { EngineId } from "../engine/profile";
 import { loadEngineProfile } from "../engine/profile";
@@ -44,7 +44,7 @@ export type AgentLoopEvent =
       toolCalls: Array<{ id: string; name: string; arguments: string }>;
     }
   | { type: "tool_call"; name: string; callId: string; arguments: string }
-  | { type: "tool_result"; name: string; callId: string; ok: boolean; content: string }
+  | { type: "tool_result"; name: string; callId: string; ok: boolean; content: string; fileEvent?: FileToolEvent }
   | { type: "gate_pending"; gate: string }
   | { type: "validation"; ok: boolean };
 
@@ -307,6 +307,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
           name: toolResult.name,
           ok: toolResult.ok,
           toolCallId: toolResult.callId,
+          ...(toolResult.fileEvent ? { fileEvent: toolResult.fileEvent } : {}),
         },
       });
 
@@ -319,6 +320,7 @@ async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
         callId: toolResult.callId,
         ok: toolResult.ok,
         content: toolResult.content,
+        ...(toolResult.fileEvent ? { fileEvent: toolResult.fileEvent } : {}),
       });
     }
 

--- a/src/core/tools/fs.ts
+++ b/src/core/tools/fs.ts
@@ -7,11 +7,37 @@ export type ToolCall = {
   arguments: string;
 };
 
+export type FileToolEvent = {
+  kind: "file_operation";
+  operation:
+    | "stat"
+    | "list"
+    | "grep"
+    | "read"
+    | "create"
+    | "write"
+    | "replace"
+    | "append"
+    | "delete"
+    | "copy"
+    | "move";
+  path?: string;
+  sourcePath?: string;
+  targetPath?: string;
+  changed: boolean;
+  bytes?: number;
+  lines?: number;
+  matches?: number;
+  occurrences?: number;
+  truncated?: boolean;
+};
+
 export type ToolResult = {
   callId: string;
   name: string;
   ok: boolean;
   content: string;
+  fileEvent?: FileToolEvent;
 };
 
 export type ToolDefinition = {
@@ -315,14 +341,26 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
           type: info.isDirectory() ? "directory" : info.isFile() ? "file" : "other",
           size: info.size,
           modifiedAt: info.mtime.toISOString(),
-        }));
+        }), {
+          kind: "file_operation",
+          operation: "stat",
+          path: toProjectPath(rootDir, resolved),
+          changed: false,
+          bytes: info.size,
+        });
       }
 
       case "list_files": {
         const args = parseArgs<{ path: string; recursive?: boolean }>(call.arguments);
         const dir = resolveAllowed(rootDir, args.path, readableRoots);
         const entries = await listFiles(dir, Boolean(args.recursive));
-        return ok(call, entries.map((entry) => toProjectPath(rootDir, entry)).join("\n") || "(empty)");
+        return ok(call, entries.map((entry) => toProjectPath(rootDir, entry)).join("\n") || "(empty)", {
+          kind: "file_operation",
+          operation: "list",
+          path: toProjectPath(rootDir, dir),
+          changed: false,
+          matches: entries.length,
+        });
       }
 
       case "grep_files": {
@@ -336,13 +374,28 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         }>(call.arguments);
         const resolved = resolveAllowed(rootDir, args.path, readableRoots);
         const result = await grepFiles(rootDir, resolved, args);
-        return ok(call, JSON.stringify(result));
+        return ok(call, JSON.stringify(result), {
+          kind: "file_operation",
+          operation: "grep",
+          path: toProjectPath(rootDir, resolved),
+          changed: false,
+          matches: result.matches.length,
+          truncated: result.truncated,
+        });
       }
 
       case "read_file": {
         const args = parseArgs<{ path: string; startLine?: number; endLine?: number }>(call.arguments);
         const filePath = resolveAllowed(rootDir, args.path, readableRoots);
-        return ok(call, sliceLines(await readFile(filePath, "utf8"), args.startLine, args.endLine));
+        const content = sliceLines(await readFile(filePath, "utf8"), args.startLine, args.endLine);
+        return ok(call, content, {
+          kind: "file_operation",
+          operation: "read",
+          path: toProjectPath(rootDir, filePath),
+          changed: false,
+          bytes: textByteLength(content),
+          lines: content ? content.split(/\r?\n/).length : 0,
+        });
       }
 
       case "create_file": {
@@ -350,7 +403,13 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         const filePath = resolveAllowed(rootDir, args.path, writableRoots);
         await mkdir(dirname(filePath), { recursive: true });
         await writeFile(filePath, args.content, { encoding: "utf8", flag: "wx" });
-        return ok(call, `Created ${toProjectPath(rootDir, filePath)}`);
+        return ok(call, `Created ${toProjectPath(rootDir, filePath)}`, {
+          kind: "file_operation",
+          operation: "create",
+          path: toProjectPath(rootDir, filePath),
+          changed: true,
+          bytes: textByteLength(args.content),
+        });
       }
 
       case "write_file": {
@@ -358,7 +417,13 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         const filePath = resolveAllowed(rootDir, args.path, writableRoots);
         await mkdir(dirname(filePath), { recursive: true });
         await writeFile(filePath, args.content, "utf8");
-        return ok(call, `Wrote ${toProjectPath(rootDir, filePath)}`);
+        return ok(call, `Wrote ${toProjectPath(rootDir, filePath)}`, {
+          kind: "file_operation",
+          operation: "write",
+          path: toProjectPath(rootDir, filePath),
+          changed: true,
+          bytes: textByteLength(args.content),
+        });
       }
 
       case "replace_in_file": {
@@ -375,7 +440,14 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         // designed for concurrent external writers.
         const next = original.split(args.oldText).join(args.newText);
         await writeFile(filePath, next, "utf8");
-        return ok(call, `Replaced ${args.replaceAll ? count : 1} occurrence(s) in ${toProjectPath(rootDir, filePath)}`);
+        return ok(call, `Replaced ${args.replaceAll ? count : 1} occurrence(s) in ${toProjectPath(rootDir, filePath)}`, {
+          kind: "file_operation",
+          operation: "replace",
+          path: toProjectPath(rootDir, filePath),
+          changed: true,
+          bytes: textByteLength(next),
+          occurrences: args.replaceAll ? count : 1,
+        });
       }
 
       case "append_file": {
@@ -384,7 +456,13 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         await mkdir(dirname(filePath), { recursive: true });
         if (!args.createIfMissing) await assertFile(filePath);
         await appendFile(filePath, args.content, { encoding: "utf8", flag: "a" });
-        return ok(call, `Appended ${args.content.length} char(s) to ${toProjectPath(rootDir, filePath)}`);
+        return ok(call, `Appended ${args.content.length} char(s) to ${toProjectPath(rootDir, filePath)}`, {
+          kind: "file_operation",
+          operation: "append",
+          path: toProjectPath(rootDir, filePath),
+          changed: true,
+          bytes: textByteLength(args.content),
+        });
       }
 
       case "delete_file": {
@@ -394,7 +472,12 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         // Single-user TUI contract: the path is expected not to change between
         // the file check and unlink.
         await unlink(filePath);
-        return ok(call, `Deleted ${toProjectPath(rootDir, filePath)}`);
+        return ok(call, `Deleted ${toProjectPath(rootDir, filePath)}`, {
+          kind: "file_operation",
+          operation: "delete",
+          path: toProjectPath(rootDir, filePath),
+          changed: true,
+        });
       }
 
       case "copy_file": {
@@ -404,7 +487,15 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         await assertFile(sourcePath);
         await prepareTarget(targetPath, Boolean(args.overwrite));
         await copyFile(sourcePath, targetPath);
-        return ok(call, `Copied ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`);
+        const copied = await stat(targetPath);
+        return ok(call, `Copied ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`, {
+          kind: "file_operation",
+          operation: "copy",
+          sourcePath: toProjectPath(rootDir, sourcePath),
+          targetPath: toProjectPath(rootDir, targetPath),
+          changed: true,
+          bytes: copied.size,
+        });
       }
 
       case "move_file": {
@@ -414,7 +505,15 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         await assertFile(sourcePath);
         await prepareTarget(targetPath, Boolean(args.overwrite));
         await rename(sourcePath, targetPath);
-        return ok(call, `Moved ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`);
+        const moved = await stat(targetPath);
+        return ok(call, `Moved ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`, {
+          kind: "file_operation",
+          operation: "move",
+          sourcePath: toProjectPath(rootDir, sourcePath),
+          targetPath: toProjectPath(rootDir, targetPath),
+          changed: true,
+          bytes: moved.size,
+        });
       }
 
       default:
@@ -576,12 +675,17 @@ function toProjectPath(rootDir: string, filePath: string): string {
   return relative(rootDir, filePath).split(sep).join("/");
 }
 
-function ok(call: ToolCall, content: string): ToolResult {
+function textByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}
+
+function ok(call: ToolCall, content: string, fileEvent?: FileToolEvent): ToolResult {
   return {
     callId: call.id,
     name: call.name,
     ok: true,
     content,
+    ...(fileEvent ? { fileEvent } : {}),
   };
 }
 

--- a/src/core/tools/fs.ts
+++ b/src/core/tools/fs.ts
@@ -1,3 +1,4 @@
+import type { Stats } from "node:fs";
 import { appendFile, copyFile, mkdir, readdir, readFile, rename, stat, unlink, writeFile } from "node:fs/promises";
 import { dirname, relative, resolve, sep } from "node:path";
 
@@ -25,9 +26,15 @@ export type FileToolEvent = {
   sourcePath?: string;
   targetPath?: string;
   changed: boolean;
+  /** Size of the resulting or observed file, or the deleted file for delete_file. */
   bytes?: number;
+  /** Bytes added by append_file. */
+  deltaBytes?: number;
   lines?: number;
+  /** grep_files hit count. */
   matches?: number;
+  /** list_files entry count. */
+  entryCount?: number;
   occurrences?: number;
   truncated?: boolean;
 };
@@ -359,7 +366,7 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
           operation: "list",
           path: toProjectPath(rootDir, dir),
           changed: false,
-          matches: entries.length,
+          entryCount: entries.length,
         });
       }
 
@@ -456,19 +463,21 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         await mkdir(dirname(filePath), { recursive: true });
         if (!args.createIfMissing) await assertFile(filePath);
         await appendFile(filePath, args.content, { encoding: "utf8", flag: "a" });
+        const appended = await stat(filePath);
         return ok(call, `Appended ${args.content.length} char(s) to ${toProjectPath(rootDir, filePath)}`, {
           kind: "file_operation",
           operation: "append",
           path: toProjectPath(rootDir, filePath),
           changed: true,
-          bytes: textByteLength(args.content),
+          bytes: appended.size,
+          deltaBytes: textByteLength(args.content),
         });
       }
 
       case "delete_file": {
         const args = parseArgs<{ path: string }>(call.arguments);
         const filePath = resolveAllowed(rootDir, args.path, writableRoots);
-        await assertFile(filePath);
+        const deleted = await assertFile(filePath);
         // Single-user TUI contract: the path is expected not to change between
         // the file check and unlink.
         await unlink(filePath);
@@ -477,6 +486,7 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
           operation: "delete",
           path: toProjectPath(rootDir, filePath),
           changed: true,
+          bytes: deleted.size,
         });
       }
 
@@ -484,17 +494,16 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         const args = parseArgs<{ sourcePath: string; targetPath: string; overwrite?: boolean }>(call.arguments);
         const sourcePath = resolveAllowed(rootDir, args.sourcePath, readableRoots);
         const targetPath = resolveAllowed(rootDir, args.targetPath, writableRoots);
-        await assertFile(sourcePath);
+        const source = await assertFile(sourcePath);
         await prepareTarget(targetPath, Boolean(args.overwrite));
         await copyFile(sourcePath, targetPath);
-        const copied = await stat(targetPath);
         return ok(call, `Copied ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`, {
           kind: "file_operation",
           operation: "copy",
           sourcePath: toProjectPath(rootDir, sourcePath),
           targetPath: toProjectPath(rootDir, targetPath),
           changed: true,
-          bytes: copied.size,
+          bytes: source.size,
         });
       }
 
@@ -502,17 +511,16 @@ export async function executeFileTool(rootDir: string, call: ToolCall): Promise<
         const args = parseArgs<{ sourcePath: string; targetPath: string; overwrite?: boolean }>(call.arguments);
         const sourcePath = resolveAllowed(rootDir, args.sourcePath, writableRoots);
         const targetPath = resolveAllowed(rootDir, args.targetPath, writableRoots);
-        await assertFile(sourcePath);
+        const source = await assertFile(sourcePath);
         await prepareTarget(targetPath, Boolean(args.overwrite));
         await rename(sourcePath, targetPath);
-        const moved = await stat(targetPath);
         return ok(call, `Moved ${toProjectPath(rootDir, sourcePath)} to ${toProjectPath(rootDir, targetPath)}`, {
           kind: "file_operation",
           operation: "move",
           sourcePath: toProjectPath(rootDir, sourcePath),
           targetPath: toProjectPath(rootDir, targetPath),
           changed: true,
-          bytes: moved.size,
+          bytes: source.size,
         });
       }
 
@@ -622,9 +630,10 @@ function countOccurrences(content: string, needle: string): number {
   }
 }
 
-async function assertFile(filePath: string): Promise<void> {
+async function assertFile(filePath: string): Promise<Stats> {
   const info = await stat(filePath);
   if (!info.isFile()) throw new Error("Path must be a file.");
+  return info;
 }
 
 async function prepareTarget(targetPath: string, overwrite: boolean): Promise<void> {

--- a/src/core/tools/index.ts
+++ b/src/core/tools/index.ts
@@ -14,7 +14,7 @@ export type BuiltInToolName =
   | "copy_file"
   | "move_file";
 export { executeFileTool, fileToolDefinitions } from "./fs";
-export type { ToolCall, ToolDefinition, ToolResult } from "./fs";
+export type { FileToolEvent, ToolCall, ToolDefinition, ToolResult } from "./fs";
 
 export type ToolContract = {
   name: BuiltInToolName;

--- a/tests/agent-loop.test.ts
+++ b/tests/agent-loop.test.ts
@@ -212,6 +212,7 @@ describe("agent loop sessions", () => {
   test("executes model-requested write_file calls", async () => {
     const rootDir = await createPromptRoot();
     const requestBodies: Array<{ messages: Array<{ role: string; content: string; reasoning_content?: string }> }> = [];
+    const events: AgentLoopEvent[] = [];
 
     globalThis.fetch = (async (_input: unknown, init: RequestInit & { body?: unknown }) => {
       requestBodies.push(JSON.parse(String(init?.body)));
@@ -261,10 +262,13 @@ describe("agent loop sessions", () => {
       input: "write a file",
       rootDir,
       messages: [{ role: "user", content: "write a file" }],
+      onEvent: (event) => events.push(event),
     });
     if (result.kind !== "complete") throw new Error("expected complete");
 
     const written = await readFile(join(rootDir, "workspace", "tool-test.md"), "utf8");
+    const records = (await readFile(result.sessionPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    const toolRecord = records.find((record) => record.role === "tool");
 
     expect(result.response.content).toBe("File written.");
     expect(written).toBe("# Tool Test\n\nwritten");
@@ -273,6 +277,20 @@ describe("agent loop sessions", () => {
       message.role === "assistant" &&
       message.reasoning_content === "Need to write the requested artifact before answering."
     ))).toBe(true);
+    expect(toolRecord?.metadata.fileEvent).toMatchObject({
+      kind: "file_operation",
+      operation: "write",
+      path: "workspace/tool-test.md",
+      changed: true,
+    });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "tool_result",
+      name: "write_file",
+      fileEvent: expect.objectContaining({
+        operation: "write",
+        path: "workspace/tool-test.md",
+      }),
+    }));
   });
 
   test("does not run artifact validators on ordinary assistant prose", async () => {

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { executeFileTool } from "../src/core/tools";
+import type { ToolResult } from "../src/core/tools";
 
 let rootDir = "";
 
@@ -20,21 +21,34 @@ afterEach(async () => {
 
 describe("file tools v2", () => {
   test("supports create, ranged read, exact replace, append, grep, stat, copy, move, and delete", async () => {
-    await expectTool("create_file", {
+    const createResult = await expectTool("create_file", {
       path: "workspace/a.md",
       content: "alpha\nbeta\nalpha",
     }, "Created workspace/a.md");
+    expect(createResult.fileEvent).toMatchObject({
+      operation: "create",
+      path: "workspace/a.md",
+      changed: true,
+      bytes: 16,
+    });
 
     await expectToolFailure("create_file", {
       path: "workspace/a.md",
       content: "duplicate",
     }, "EEXIST");
 
-    await expectTool("read_file", {
+    const readResult = await expectTool("read_file", {
       path: "workspace/a.md",
       startLine: 2,
       endLine: 2,
     }, "beta");
+    expect(readResult.fileEvent).toMatchObject({
+      operation: "read",
+      path: "workspace/a.md",
+      changed: false,
+      bytes: 4,
+      lines: 1,
+    });
 
     await expectToolFailure("replace_in_file", {
       path: "workspace/a.md",
@@ -42,17 +56,31 @@ describe("file tools v2", () => {
       newText: "gamma",
     }, "matched 2 times");
 
-    await expectTool("replace_in_file", {
+    const replaceResult = await expectTool("replace_in_file", {
       path: "workspace/a.md",
       oldText: "alpha",
       newText: "gamma",
       replaceAll: true,
     }, "Replaced 2 occurrence(s) in workspace/a.md");
+    expect(replaceResult.fileEvent).toMatchObject({
+      operation: "replace",
+      path: "workspace/a.md",
+      changed: true,
+      bytes: 16,
+      occurrences: 2,
+    });
 
-    await expectTool("append_file", {
+    const appendResult = await expectTool("append_file", {
       path: "workspace/a.md",
       content: "\nend",
     }, "Appended 4 char(s) to workspace/a.md");
+    expect(appendResult.fileEvent).toMatchObject({
+      operation: "append",
+      path: "workspace/a.md",
+      changed: true,
+      bytes: 20,
+      deltaBytes: 4,
+    });
 
     const statResult = await executeFileTool(rootDir, call("stat_path", { path: "workspace/a.md" }));
     expect(statResult.ok).toBe(true);
@@ -65,6 +93,16 @@ describe("file tools v2", () => {
     expect(JSON.parse(statResult.content)).toMatchObject({
       path: "workspace/a.md",
       type: "file",
+    });
+
+    const listResult = await executeFileTool(rootDir, call("list_files", { path: "workspace" }));
+    expect(listResult.ok).toBe(true);
+    expect(listResult.fileEvent).toMatchObject({
+      kind: "file_operation",
+      operation: "list",
+      path: "workspace",
+      changed: false,
+      entryCount: 1,
     });
 
     const grepResult = await executeFileTool(rootDir, call("grep_files", {
@@ -88,20 +126,40 @@ describe("file tools v2", () => {
       truncated: false,
     });
 
-    await expectTool("copy_file", {
+    const copyResult = await expectTool("copy_file", {
       sourcePath: "workspace/a.md",
       targetPath: "reports/b.md",
     }, "Copied workspace/a.md to reports/b.md");
+    expect(copyResult.fileEvent).toMatchObject({
+      operation: "copy",
+      sourcePath: "workspace/a.md",
+      targetPath: "reports/b.md",
+      changed: true,
+      bytes: 20,
+    });
     expect(await readFile(join(rootDir, "reports", "b.md"), "utf8")).toContain("gamma");
 
-    await expectTool("move_file", {
+    const moveResult = await expectTool("move_file", {
       sourcePath: "reports/b.md",
       targetPath: "workspace/c.md",
     }, "Moved reports/b.md to workspace/c.md");
+    expect(moveResult.fileEvent).toMatchObject({
+      operation: "move",
+      sourcePath: "reports/b.md",
+      targetPath: "workspace/c.md",
+      changed: true,
+      bytes: 20,
+    });
 
-    await expectTool("delete_file", {
+    const deleteResult = await expectTool("delete_file", {
       path: "workspace/c.md",
     }, "Deleted workspace/c.md");
+    expect(deleteResult.fileEvent).toMatchObject({
+      operation: "delete",
+      path: "workspace/c.md",
+      changed: true,
+      bytes: 20,
+    });
   });
 
   test("keeps write operations inside artifact roots and refuses risky deletes", async () => {
@@ -224,11 +282,12 @@ describe("file tools v2", () => {
   });
 });
 
-async function expectTool(name: string, args: Record<string, unknown>, content: string): Promise<void> {
+async function expectTool(name: string, args: Record<string, unknown>, content: string): Promise<ToolResult> {
   const result = await executeFileTool(rootDir, call(name, args));
   expect(result.ok).toBe(true);
   expect(result.content).toBe(content);
   expect(result.fileEvent).toMatchObject({ kind: "file_operation" });
+  return result;
 }
 
 async function expectToolFailure(name: string, args: Record<string, unknown>, content: string): Promise<void> {

--- a/tests/file-tools.test.ts
+++ b/tests/file-tools.test.ts
@@ -56,6 +56,12 @@ describe("file tools v2", () => {
 
     const statResult = await executeFileTool(rootDir, call("stat_path", { path: "workspace/a.md" }));
     expect(statResult.ok).toBe(true);
+    expect(statResult.fileEvent).toMatchObject({
+      kind: "file_operation",
+      operation: "stat",
+      path: "workspace/a.md",
+      changed: false,
+    });
     expect(JSON.parse(statResult.content)).toMatchObject({
       path: "workspace/a.md",
       type: "file",
@@ -67,6 +73,13 @@ describe("file tools v2", () => {
       maxMatches: 10,
     }));
     expect(grepResult.ok).toBe(true);
+    expect(grepResult.fileEvent).toMatchObject({
+      kind: "file_operation",
+      operation: "grep",
+      path: "workspace",
+      matches: 2,
+      changed: false,
+    });
     expect(JSON.parse(grepResult.content)).toMatchObject({
       matches: [
         { path: "workspace/a.md", line: 1, text: "gamma" },
@@ -215,6 +228,7 @@ async function expectTool(name: string, args: Record<string, unknown>, content: 
   const result = await executeFileTool(rootDir, call(name, args));
   expect(result.ok).toBe(true);
   expect(result.content).toBe(content);
+  expect(result.fileEvent).toMatchObject({ kind: "file_operation" });
 }
 
 async function expectToolFailure(name: string, args: Record<string, unknown>, content: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Add structured fileEvent metadata to successful filesystem tool results.
- Persist fileEvent metadata on agent-loop tool records in session JSONL and emit it through tool_result activity events.
- Update docs and tests for the file-operation ledger contract.

## Test Plan

- [x] bun run typecheck
- [x] bun test tests\\file-tools.test.ts tests\\agent-loop.test.ts tests\\session.test.ts
- [x] bun test
- [x] bun run doctor

## Notes / Follow-ups

- This PR records the backend ledger data only; TUI artifact/history views can consume fileEvent metadata in a later UI-focused pass.
