### PR TITLE
refactor: split TUI and Anthropic runtime hotspots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ project follows Semantic Versioning once releases begin.
 
 ### Fixed
 
+- Permission pauses no longer render empty assistant bubbles, and the active TUI bottom surface now owns keyboard and paste input through the same modal priority used for rendering.
 - The Workspace sidebar now keeps a fixed two-row Shell summary, preventing multiple background tasks from overwriting the Effort, session, and MCP rows in OpenTUI.
 - Provider-returned tool calls are now checked against the current effective tool surface before permission evaluation or execution, so YOLO cannot execute a hallucinated `shell_exec` when the host-shell capability is disabled.
 - Shell process deadlines now remain active until inherited stdout/stderr pipes close, and successful shell exit also cleans up surviving in-group descendants instead of leaving ordinary child work behind.

--- a/src/providers/anthropic-messages/adapter.ts
+++ b/src/providers/anthropic-messages/adapter.ts
@@ -2,78 +2,13 @@ import type { VesicleConfig } from "../../config/env";
 import { ProviderError } from "../shared/errors";
 import { fetchProvider } from "../shared/fetch";
 import { anthropicMessagesHeaders } from "../shared/headers";
-import { readSseEvents } from "../shared/sse";
-import { displayTextFromThinkingBlocks } from "../shared/thinking";
-import { normalizeResponseUsage } from "../shared/usage";
-import type { ProviderAdapter, ProviderStreamEvent, ProviderThinkingBlock, ReasoningTier, VesicleRequest, VesicleResponse } from "../shared/types";
-import type { ToolCall } from "../../core/tools";
+import type { ProviderAdapter, ProviderStreamEvent, VesicleRequest, VesicleResponse } from "../shared/types";
+import { toAnthropicMessagesBody } from "./request";
+import { responseFromAnthropicBody } from "./response";
+import { readAnthropicMessagesStream } from "./stream";
+import type { AnthropicResponse } from "./types";
 
-type AnthropicContentBlock =
-  | { type: "text"; text: string }
-  | { type: "image"; source: { type: "base64"; media_type: string; data: string } }
-  | { type: "thinking"; thinking: string; signature?: string }
-  | { type: "redacted_thinking"; data: string }
-  | { type: "tool_use"; id: string; name: string; input: unknown }
-  | { type: "tool_result"; tool_use_id: string; content: string | AnthropicContentBlock[]; is_error?: boolean };
-
-type AnthropicMessage = {
-  role: "user" | "assistant";
-  content: string | AnthropicContentBlock[];
-};
-
-type AnthropicResponse = {
-  id?: string;
-  model?: string;
-  content?: AnthropicContentBlock[];
-  stop_reason?: string;
-  usage?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    cache_creation_input_tokens?: number;
-    cache_read_input_tokens?: number;
-  };
-  error?: {
-    message?: string;
-  };
-};
-
-type AnthropicStreamEvent = {
-  type?: string;
-  index?: number;
-  message?: {
-    id?: string;
-    model?: string;
-    usage?: AnthropicResponse["usage"];
-  };
-  content_block?: AnthropicContentBlock;
-  delta?: {
-    type?: string;
-    text?: string;
-    thinking?: string;
-    signature?: string;
-    partial_json?: string;
-    stop_reason?: string;
-  };
-  usage?: AnthropicResponse["usage"];
-  error?: {
-    message?: string;
-  };
-};
-
-type AnthropicStreamState = {
-  id: string;
-  model: string;
-  textParts: string[];
-  thinkingBlocks: Map<number, { thinking: string; signature?: string } | { redactedData: string }>;
-  toolCalls: Map<number, { id: string; name: string; inputJson: string }>;
-  finishReason?: string;
-  inputTokens?: number;
-  outputTokens?: number;
-  cacheCreationInputTokens?: number;
-  cacheReadInputTokens?: number;
-};
-
-const defaultMaxTokens = 4096;
+export { toAnthropicMessagesBody } from "./request";
 
 export class AnthropicMessagesAdapter implements ProviderAdapter {
   readonly id = "anthropic-messages";
@@ -83,25 +18,9 @@ export class AnthropicMessagesAdapter implements ProviderAdapter {
   async complete(request: VesicleRequest): Promise<VesicleResponse> {
     this.requireApiKey();
 
-    const response = await fetchProvider(`${this.config.baseUrl}/messages?beta=true`, {
-      method: "POST",
-      headers: this.headers(),
-      body: JSON.stringify(toAnthropicMessagesBody(request)),
-      signal: request.signal,
-    }, {
-      providerId: this.config.providerId,
-      signal: request.signal,
-      attemptHeaders: (retryCount) => ({ "x-stainless-retry-count": String(retryCount) }),
-    });
+    const response = await this.fetchMessages(request, false);
     const body = await response.json().catch(() => undefined) as AnthropicResponse | undefined;
-    if (!response.ok) {
-      const providerMessage = body?.error?.message ?? response.statusText;
-      throw new ProviderError(`Provider request failed (${response.status}): ${providerMessage}`, {
-        kind: "http_error",
-        providerId: this.config.providerId,
-        status: response.status,
-      });
-    }
+    if (!response.ok) this.throwHttpError(response, body);
 
     return responseFromAnthropicBody(body, request.id, this.config.providerId);
   }
@@ -109,27 +28,26 @@ export class AnthropicMessagesAdapter implements ProviderAdapter {
   async *stream(request: VesicleRequest): AsyncIterable<ProviderStreamEvent> {
     this.requireApiKey();
 
-    const response = await fetchProvider(`${this.config.baseUrl}/messages?beta=true`, {
+    const response = await this.fetchMessages(request, true);
+    if (!response.ok) {
+      const body = await response.json().catch(() => undefined) as AnthropicResponse | undefined;
+      this.throwHttpError(response, body);
+    }
+
+    yield* readAnthropicMessagesStream(response, request.id, request.model.model, this.config.providerId);
+  }
+
+  private fetchMessages(request: VesicleRequest, stream: boolean): Promise<Response> {
+    return fetchProvider(`${this.config.baseUrl}/messages?beta=true`, {
       method: "POST",
       headers: this.headers(),
-      body: JSON.stringify({ ...toAnthropicMessagesBody(request), stream: true }),
+      body: JSON.stringify({ ...toAnthropicMessagesBody(request), ...(stream ? { stream: true } : {}) }),
       signal: request.signal,
     }, {
       providerId: this.config.providerId,
       signal: request.signal,
       attemptHeaders: (retryCount) => ({ "x-stainless-retry-count": String(retryCount) }),
     });
-    if (!response.ok) {
-      const body = await response.json().catch(() => undefined) as AnthropicResponse | undefined;
-      const providerMessage = body?.error?.message ?? response.statusText;
-      throw new ProviderError(`Provider request failed (${response.status}): ${providerMessage}`, {
-        kind: "http_error",
-        providerId: this.config.providerId,
-        status: response.status,
-      });
-    }
-
-    yield* readAnthropicMessagesStream(response, request.id, request.model.model, this.config.providerId);
   }
 
   private headers(): Record<string, string> {
@@ -148,450 +66,13 @@ export class AnthropicMessagesAdapter implements ProviderAdapter {
       providerId: this.config.providerId,
     });
   }
-}
 
-export function toAnthropicMessagesBody(request: VesicleRequest): Record<string, unknown> {
-  const hasTools = Boolean(request.tools && request.tools.length > 0);
-  const maxTokens = request.generation?.maxTokens ?? defaultMaxTokens;
-  return {
-    model: request.model.model,
-    system: request.system.join("\n\n"),
-    messages: toAnthropicMessages(request.messages),
-    max_tokens: maxTokens,
-    temperature: request.generation?.temperature,
-    thinking: anthropicThinkingControl(request.generation?.reasoningTier, maxTokens),
-    tools: hasTools ? request.tools?.map((tool) => ({
-      name: tool.function.name,
-      description: tool.function.description,
-      input_schema: tool.function.parameters,
-    })) : undefined,
-    tool_choice: hasTools ? { type: "auto" } : undefined,
-  };
-}
-
-function toAnthropicMessages(messages: VesicleRequest["messages"]): AnthropicMessage[] {
-  const serialized: AnthropicMessage[] = [];
-  let pendingToolResults: AnthropicContentBlock[] = [];
-
-  const flushToolResults = (): AnthropicMessage | undefined => {
-    if (pendingToolResults.length === 0) return undefined;
-    const message: AnthropicMessage = { role: "user", content: pendingToolResults };
-    serialized.push(message);
-    pendingToolResults = [];
-    return message;
-  };
-
-  for (const message of messages) {
-    if (message.role === "system") continue;
-    if (message.role === "tool") {
-      pendingToolResults.push({
-        type: "tool_result",
-        tool_use_id: message.toolCallId ?? "",
-        content: message.images?.length
-          ? anthropicUserBlocks(message.content, message.images)
-          : message.content,
-      });
-      continue;
-    }
-
-    const flushedToolResults = flushToolResults();
-    if (message.role === "assistant") {
-      const content: AnthropicContentBlock[] = [
-        ...anthropicThinkingBlocks(message.thinkingBlocks),
-        ...(message.content ? [{ type: "text" as const, text: message.content }] : []),
-        ...(message.toolCalls ?? []).map((call) => ({
-          type: "tool_use" as const,
-          id: call.id,
-          name: call.name,
-          input: parseToolArguments(call.arguments),
-        })),
-      ];
-      serialized.push({ role: "assistant", content: content.length > 0 ? content : [{ type: "text", text: "" }] });
-      continue;
-    }
-
-    if (flushedToolResults && Array.isArray(flushedToolResults.content)) {
-      if (message.images?.length) {
-        flushedToolResults.content.push(...anthropicUserBlocks(message.content, message.images));
-      } else if (message.content) {
-        flushedToolResults.content.push({ type: "text", text: message.content });
-      }
-      continue;
-    }
-    serialized.push({
-      role: "user",
-      content: message.images?.length ? anthropicUserBlocks(message.content, message.images) : message.content,
+  private throwHttpError(response: Response, body: AnthropicResponse | undefined): never {
+    const providerMessage = body?.error?.message ?? response.statusText;
+    throw new ProviderError(`Provider request failed (${response.status}): ${providerMessage}`, {
+      kind: "http_error",
+      providerId: this.config.providerId,
+      status: response.status,
     });
-  }
-
-  flushToolResults();
-  return serialized;
-}
-
-function anthropicUserBlocks(
-  text: string,
-  images: NonNullable<VesicleRequest["messages"][number]["images"]>,
-): AnthropicContentBlock[] {
-  return [
-    ...(text ? [{ type: "text" as const, text }] : []),
-    ...images.flatMap((image, index) => [
-      { type: "text" as const, text: `[Image #${index + 1}: ${image.sourcePath ?? image.filename ?? image.source}]` },
-      {
-        type: "image" as const,
-        source: {
-          type: "base64" as const,
-          media_type: image.mediaType,
-          data: requireImageData(image.data, image.id),
-        },
-      },
-    ]),
-  ];
-}
-
-function requireImageData(data: string | undefined, id: string): string {
-  if (!data) throw new Error(`Image attachment was not materialized before provider serialization: ${id}.`);
-  return data;
-}
-
-function anthropicThinkingBlocks(blocks: ProviderThinkingBlock[] | undefined): AnthropicContentBlock[] {
-  const result: AnthropicContentBlock[] = [];
-  for (const block of blocks ?? []) {
-    if (block.type === "thinking" && typeof block.thinking === "string") {
-      result.push({
-        type: "thinking",
-        thinking: block.thinking,
-        ...(typeof block.signature === "string" ? { signature: block.signature } : {}),
-      });
-    }
-    if (block.type === "redacted_thinking" && typeof block.data === "string") {
-      result.push({ type: "redacted_thinking", data: block.data });
-    }
-  }
-  return result;
-}
-
-function responseFromAnthropicBody(
-  body: AnthropicResponse | undefined,
-  fallbackId: string,
-  providerId?: string,
-): VesicleResponse {
-  const blocks = body?.content ?? [];
-  const textParts: string[] = [];
-  const thinkingBlocks: ProviderThinkingBlock[] = [];
-  const toolCalls: ToolCall[] = [];
-
-  for (let index = 0; index < blocks.length; index++) {
-    const block = blocks[index];
-    if (!block || typeof block !== "object") continue;
-    if (block.type === "text") {
-      textParts.push(block.text);
-      continue;
-    }
-    if (block.type === "thinking") {
-      thinkingBlocks.push({
-        type: "thinking",
-        thinking: block.thinking,
-        ...(typeof block.signature === "string" ? { signature: block.signature } : {}),
-      });
-      continue;
-    }
-    if (block.type === "redacted_thinking") {
-      thinkingBlocks.push({ type: "redacted_thinking", data: block.data });
-      continue;
-    }
-    if (block.type === "tool_use") {
-      if (!block.id || !block.name) {
-        throw new ProviderError("Provider response included a tool_use block without id or name.", {
-          kind: "malformed_response",
-          providerId,
-        });
-      }
-      toolCalls.push({
-        id: block.id,
-        name: block.name,
-        arguments: jsonString(block.input),
-      });
-    }
-  }
-
-  const content = textParts.join("");
-  const reasoningContent = displayTextFromThinkingBlocks(thinkingBlocks);
-  if (!content && toolCalls.length === 0) {
-    throw new ProviderError("Provider response did not include assistant content or tool calls.", {
-      kind: "malformed_response",
-      providerId,
-    });
-  }
-
-  return {
-    id: body?.id ?? fallbackId,
-    content,
-    ...(reasoningContent ? { reasoningContent } : {}),
-    ...(thinkingBlocks.length > 0 ? { thinkingBlocks } : {}),
-    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    finishReason: body?.stop_reason,
-    raw: body,
-    usage: usageFromAnthropicUsage(body?.usage),
-  };
-}
-
-async function* readAnthropicMessagesStream(
-  response: Response,
-  fallbackId: string,
-  fallbackModel: string,
-  providerId?: string,
-): AsyncIterable<ProviderStreamEvent> {
-  if (!response.body) {
-    throw new ProviderError("Provider streaming response did not include a body.", { kind: "stream_error", providerId });
-  }
-
-  const state: AnthropicStreamState = {
-    id: fallbackId,
-    model: fallbackModel,
-    textParts: [],
-    thinkingBlocks: new Map(),
-    toolCalls: new Map(),
-  };
-  let sawStop = false;
-
-  for await (const event of readSseEvents(response.body)) {
-    const data = parseStreamEvent(event.data, providerId);
-    if (event.event === "error" || data.error?.message) {
-      throw new ProviderError(`Provider stream failed: ${data.error?.message ?? event.data}`, {
-        kind: "stream_error",
-        providerId,
-      });
-    }
-    for (const emitted of absorbAnthropicStreamEvent(state, event.event, data, providerId)) {
-      yield emitted;
-    }
-    if (event.event === "message_stop") sawStop = true;
-  }
-
-  if (!sawStop) {
-    throw new ProviderError("Provider stream ended before message_stop.", { kind: "stream_error", providerId });
-  }
-
-  yield { type: "complete", response: finalizeAnthropicStream(state, providerId) };
-}
-
-function absorbAnthropicStreamEvent(
-  state: AnthropicStreamState,
-  eventName: string,
-  data: AnthropicStreamEvent,
-  providerId?: string,
-): ProviderStreamEvent[] {
-  const events: ProviderStreamEvent[] = [];
-
-  if (eventName === "message_start") {
-    if (data.message?.id) state.id = data.message.id;
-    if (data.message?.model) state.model = data.message.model;
-    if (data.message?.usage?.input_tokens !== undefined) state.inputTokens = data.message.usage.input_tokens;
-    if (data.message?.usage?.cache_creation_input_tokens !== undefined) state.cacheCreationInputTokens = data.message.usage.cache_creation_input_tokens;
-    if (data.message?.usage?.cache_read_input_tokens !== undefined) state.cacheReadInputTokens = data.message.usage.cache_read_input_tokens;
-    return events;
-  }
-
-  if (eventName === "content_block_start") {
-    const index = data.index ?? 0;
-    const block = data.content_block;
-    if (!block) return events;
-    if (block.type === "tool_use") {
-      if (!block.id || !block.name) {
-        throw new ProviderError("Provider stream included a tool_use block without id or name.", {
-          kind: "malformed_response",
-          providerId,
-        });
-      }
-      state.toolCalls.set(index, { id: block.id, name: block.name, inputJson: "" });
-      events.push({ type: "tool_call_delta", index, id: block.id, name: block.name });
-      return events;
-    }
-    if (block.type === "thinking") {
-      state.thinkingBlocks.set(index, { thinking: block.thinking ?? "", ...(block.signature ? { signature: block.signature } : {}) });
-      return events;
-    }
-    if (block.type === "redacted_thinking") {
-      state.thinkingBlocks.set(index, { redactedData: block.data });
-    }
-    return events;
-  }
-
-  if (eventName === "content_block_delta") {
-    const index = data.index ?? 0;
-    const delta = data.delta;
-    if (!delta) return events;
-    if (delta.type === "text_delta" && delta.text) {
-      state.textParts.push(delta.text);
-      events.push({ type: "content_delta", delta: delta.text });
-      return events;
-    }
-    if (delta.type === "input_json_delta" && delta.partial_json) {
-      const current = state.toolCalls.get(index);
-      if (current) {
-        current.inputJson += delta.partial_json;
-        events.push({ type: "tool_call_delta", index, argumentsDelta: delta.partial_json });
-      }
-      return events;
-    }
-    if (delta.type === "thinking_delta" && delta.thinking) {
-      const current = state.thinkingBlocks.get(index);
-      if (current && !("thinking" in current)) return events;
-      const next = current && "thinking" in current
-        ? { ...current, thinking: `${current.thinking}${delta.thinking}` }
-        : { thinking: delta.thinking };
-      state.thinkingBlocks.set(index, next);
-      events.push({ type: "reasoning_delta", delta: delta.thinking });
-      return events;
-    }
-    if (delta.type === "signature_delta" && delta.signature) {
-      const current = state.thinkingBlocks.get(index);
-      if (current && "thinking" in current) {
-        state.thinkingBlocks.set(index, { ...current, signature: delta.signature });
-      }
-    }
-    return events;
-  }
-
-  if (eventName === "message_delta") {
-    if (data.delta?.stop_reason) state.finishReason = data.delta.stop_reason;
-    if (data.usage?.output_tokens !== undefined) state.outputTokens = data.usage.output_tokens;
-    if (data.usage?.input_tokens !== undefined) state.inputTokens = data.usage.input_tokens;
-    if (data.usage?.cache_creation_input_tokens !== undefined) state.cacheCreationInputTokens = data.usage.cache_creation_input_tokens;
-    if (data.usage?.cache_read_input_tokens !== undefined) state.cacheReadInputTokens = data.usage.cache_read_input_tokens;
-  }
-
-  return events;
-}
-
-function finalizeAnthropicStream(state: AnthropicStreamState, providerId?: string): VesicleResponse {
-  const content = state.textParts.join("");
-  const thinkingBlocks: ProviderThinkingBlock[] = [...state.thinkingBlocks.entries()]
-    .sort(([a], [b]) => a - b)
-    .map(([, block]) => (
-      "thinking" in block
-        ? { type: "thinking", thinking: block.thinking, ...(block.signature ? { signature: block.signature } : {}) }
-        : { type: "redacted_thinking", data: block.redactedData }
-    ));
-  const toolCalls: ToolCall[] = [...state.toolCalls.entries()]
-    .sort(([a], [b]) => a - b)
-    .map(([, call]) => ({
-      id: call.id,
-      name: call.name,
-      arguments: call.inputJson || "{}",
-    }));
-  const reasoningContent = displayTextFromThinkingBlocks(thinkingBlocks);
-
-  if (!content && toolCalls.length === 0) {
-    throw new ProviderError("Provider response did not include assistant content or tool calls.", {
-      kind: "malformed_response",
-      providerId,
-    });
-  }
-
-  return {
-    id: state.id,
-    content,
-    ...(reasoningContent ? { reasoningContent } : {}),
-    ...(thinkingBlocks.length > 0 ? { thinkingBlocks } : {}),
-    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-    finishReason: state.finishReason,
-    usage: normalizeResponseUsage({
-      contextInputTokens: sumDefined(state.inputTokens, state.cacheCreationInputTokens, state.cacheReadInputTokens),
-      inputTokens: state.inputTokens,
-      outputTokens: state.outputTokens,
-      cacheReadInputTokens: state.cacheReadInputTokens,
-      cacheHitInputTokens: state.cacheReadInputTokens,
-      cacheWriteInputTokens: state.cacheCreationInputTokens,
-      cacheMissInputTokens: state.cacheCreationInputTokens,
-      providerDetails: {
-        ...(state.cacheCreationInputTokens !== undefined ? { cacheCreationInputTokens: state.cacheCreationInputTokens } : {}),
-        ...(state.cacheReadInputTokens !== undefined ? { cacheReadInputTokens: state.cacheReadInputTokens } : {}),
-      },
-    }),
-  };
-}
-
-function usageFromAnthropicUsage(usage: AnthropicResponse["usage"] | undefined): VesicleResponse["usage"] {
-  if (!usage) return undefined;
-  return normalizeResponseUsage({
-    contextInputTokens: sumDefined(usage.input_tokens, usage.cache_creation_input_tokens, usage.cache_read_input_tokens),
-    inputTokens: usage.input_tokens,
-    outputTokens: usage.output_tokens,
-    cacheReadInputTokens: usage.cache_read_input_tokens,
-    cacheHitInputTokens: usage.cache_read_input_tokens,
-    cacheWriteInputTokens: usage.cache_creation_input_tokens,
-    cacheMissInputTokens: usage.cache_creation_input_tokens,
-    providerDetails: {
-      ...(usage.cache_creation_input_tokens !== undefined ? { cacheCreationInputTokens: usage.cache_creation_input_tokens } : {}),
-      ...(usage.cache_read_input_tokens !== undefined ? { cacheReadInputTokens: usage.cache_read_input_tokens } : {}),
-    },
-  });
-}
-
-function sumDefined(...values: Array<number | undefined>): number | undefined {
-  let total = 0;
-  let seen = false;
-  for (const value of values) {
-    if (typeof value !== "number" || !Number.isFinite(value)) continue;
-    total += value;
-    seen = true;
-  }
-  return seen ? total : undefined;
-}
-
-function parseStreamEvent(data: string, providerId?: string): AnthropicStreamEvent {
-  try {
-    return JSON.parse(data) as AnthropicStreamEvent;
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : String(error);
-    throw new ProviderError(`Provider stream delivered unparseable data: ${detail}`, {
-      kind: "malformed_response",
-      providerId,
-      cause: error,
-    });
-  }
-}
-
-function anthropicThinkingControl(tier: ReasoningTier | undefined, maxTokens: number): Record<string, unknown> | undefined {
-  if (!tier) return undefined;
-  if (tier === "off") return { type: "disabled" };
-  if (maxTokens <= 1024) {
-    throw new ProviderError("Anthropic thinking requires maxTokens greater than 1024.", { kind: "malformed_response" });
-  }
-  const budget = Math.min(thinkingBudgetForTier(tier), maxTokens - 1024);
-  return { type: "enabled", budget_tokens: budget };
-}
-
-function thinkingBudgetForTier(tier: "low" | "medium" | "high" | "xhigh" | "max"): number {
-  switch (tier) {
-    case "low":
-      return 1024;
-    case "medium":
-      return 2048;
-    case "high":
-      return 4096;
-    case "xhigh":
-      return 8192;
-    case "max":
-      return 16000;
-  }
-}
-
-function parseToolArguments(value: string): unknown {
-  try {
-    return JSON.parse(value || "{}");
-  } catch {
-    throw new ProviderError("Cannot serialize malformed tool-call arguments for Anthropic Messages.", {
-      kind: "malformed_response",
-    });
-  }
-}
-
-function jsonString(value: unknown): string {
-  try {
-    return JSON.stringify(value ?? {});
-  } catch {
-    return "{}";
   }
 }

--- a/src/providers/anthropic-messages/request.ts
+++ b/src/providers/anthropic-messages/request.ts
@@ -1,0 +1,172 @@
+import { ProviderError } from "../shared/errors";
+import type { ProviderThinkingBlock, ReasoningTier, VesicleRequest } from "../shared/types";
+import type { AnthropicContentBlock, AnthropicMessage } from "./types";
+
+const defaultMaxTokens = 4096;
+
+export function toAnthropicMessagesBody(request: VesicleRequest): Record<string, unknown> {
+  const hasTools = Boolean(request.tools && request.tools.length > 0);
+  const maxTokens = request.generation?.maxTokens ?? defaultMaxTokens;
+  return {
+    model: request.model.model,
+    system: request.system.join("\n\n"),
+    messages: toAnthropicMessages(request.messages),
+    max_tokens: maxTokens,
+    temperature: request.generation?.temperature,
+    thinking: anthropicThinkingControl(request.generation?.reasoningTier, maxTokens),
+    tools: hasTools ? request.tools?.map((tool) => ({
+      name: tool.function.name,
+      description: tool.function.description,
+      input_schema: tool.function.parameters,
+    })) : undefined,
+    tool_choice: hasTools ? { type: "auto" } : undefined,
+  };
+}
+
+function toAnthropicMessages(messages: VesicleRequest["messages"]): AnthropicMessage[] {
+  const serialized: AnthropicMessage[] = [];
+  let pendingToolResults: AnthropicContentBlock[] = [];
+
+  const flushToolResults = (): AnthropicMessage | undefined => {
+    if (pendingToolResults.length === 0) return undefined;
+    const message: AnthropicMessage = { role: "user", content: pendingToolResults };
+    serialized.push(message);
+    pendingToolResults = [];
+    return message;
+  };
+
+  for (const message of messages) {
+    if (message.role === "system") continue;
+    if (message.role === "tool") {
+      pendingToolResults.push({
+        type: "tool_result",
+        tool_use_id: message.toolCallId ?? "",
+        content: message.images?.length
+          ? anthropicUserBlocks(message.content, message.images)
+          : message.content,
+      });
+      continue;
+    }
+
+    const flushedToolResults = flushToolResults();
+    if (message.role === "assistant") {
+      serialized.push(anthropicAssistantMessage(message));
+      continue;
+    }
+
+    if (appendUserMessageToToolResults(flushedToolResults, message)) continue;
+    serialized.push({
+      role: "user",
+      content: message.images?.length ? anthropicUserBlocks(message.content, message.images) : message.content,
+    });
+  }
+
+  flushToolResults();
+  return serialized;
+}
+
+function anthropicAssistantMessage(message: VesicleRequest["messages"][number]): AnthropicMessage {
+  const content: AnthropicContentBlock[] = [
+    ...anthropicThinkingBlocks(message.thinkingBlocks),
+    ...(message.content ? [{ type: "text" as const, text: message.content }] : []),
+    ...(message.toolCalls ?? []).map((call) => ({
+      type: "tool_use" as const,
+      id: call.id,
+      name: call.name,
+      input: parseToolArguments(call.arguments),
+    })),
+  ];
+  return {
+    role: "assistant",
+    content: content.length > 0 ? content : [{ type: "text", text: "" }],
+  };
+}
+
+function appendUserMessageToToolResults(
+  toolResultMessage: AnthropicMessage | undefined,
+  message: VesicleRequest["messages"][number],
+): boolean {
+  if (!toolResultMessage || !Array.isArray(toolResultMessage.content)) return false;
+  if (message.images?.length) {
+    toolResultMessage.content.push(...anthropicUserBlocks(message.content, message.images));
+  } else if (message.content) {
+    toolResultMessage.content.push({ type: "text", text: message.content });
+  }
+  return true;
+}
+
+function anthropicUserBlocks(
+  text: string,
+  images: NonNullable<VesicleRequest["messages"][number]["images"]>,
+): AnthropicContentBlock[] {
+  return [
+    ...(text ? [{ type: "text" as const, text }] : []),
+    ...images.flatMap((image, index) => [
+      { type: "text" as const, text: `[Image #${index + 1}: ${image.sourcePath ?? image.filename ?? image.source}]` },
+      {
+        type: "image" as const,
+        source: {
+          type: "base64" as const,
+          media_type: image.mediaType,
+          data: requireImageData(image.data, image.id),
+        },
+      },
+    ]),
+  ];
+}
+
+function anthropicThinkingBlocks(blocks: ProviderThinkingBlock[] | undefined): AnthropicContentBlock[] {
+  const result: AnthropicContentBlock[] = [];
+  for (const block of blocks ?? []) {
+    if (block.type === "thinking" && typeof block.thinking === "string") {
+      result.push({
+        type: "thinking",
+        thinking: block.thinking,
+        ...(typeof block.signature === "string" ? { signature: block.signature } : {}),
+      });
+    }
+    if (block.type === "redacted_thinking" && typeof block.data === "string") {
+      result.push({ type: "redacted_thinking", data: block.data });
+    }
+  }
+  return result;
+}
+
+function requireImageData(data: string | undefined, id: string): string {
+  if (!data) throw new Error(`Image attachment was not materialized before provider serialization: ${id}.`);
+  return data;
+}
+
+function anthropicThinkingControl(tier: ReasoningTier | undefined, maxTokens: number): Record<string, unknown> | undefined {
+  if (!tier) return undefined;
+  if (tier === "off") return { type: "disabled" };
+  if (maxTokens <= 1024) {
+    throw new ProviderError("Anthropic thinking requires maxTokens greater than 1024.", { kind: "malformed_response" });
+  }
+  return { type: "enabled", budget_tokens: Math.min(thinkingBudgetForTier(tier), maxTokens - 1024) };
+}
+
+function thinkingBudgetForTier(tier: Exclude<ReasoningTier, "off">): number {
+  switch (tier) {
+    case "low":
+      return 1024;
+    case "medium":
+      return 2048;
+    case "high":
+      return 4096;
+    case "xhigh":
+      return 8192;
+    case "max":
+      return 16000;
+  }
+}
+
+function parseToolArguments(value: string): unknown {
+  try {
+    return JSON.parse(value || "{}");
+  } catch {
+    throw new ProviderError("Cannot serialize malformed tool-call arguments for Anthropic Messages.", {
+      kind: "malformed_response",
+    });
+  }
+}

--- a/src/providers/anthropic-messages/response.ts
+++ b/src/providers/anthropic-messages/response.ts
@@ -1,0 +1,81 @@
+import { ProviderError } from "../shared/errors";
+import { displayTextFromThinkingBlocks } from "../shared/thinking";
+import type { ProviderThinkingBlock, VesicleResponse } from "../shared/types";
+import type { AnthropicResponse } from "./types";
+import { usageFromAnthropicUsage } from "./usage";
+
+export function responseFromAnthropicBody(
+  body: AnthropicResponse | undefined,
+  fallbackId: string,
+  providerId?: string,
+): VesicleResponse {
+  const textParts: string[] = [];
+  const thinkingBlocks: ProviderThinkingBlock[] = [];
+  const toolCalls: NonNullable<VesicleResponse["toolCalls"]> = [];
+
+  for (const block of body?.content ?? []) {
+    if (!block || typeof block !== "object") continue;
+    if (block.type === "text") {
+      textParts.push(block.text);
+      continue;
+    }
+    if (block.type === "thinking") {
+      thinkingBlocks.push({
+        type: "thinking",
+        thinking: block.thinking,
+        ...(typeof block.signature === "string" ? { signature: block.signature } : {}),
+      });
+      continue;
+    }
+    if (block.type === "redacted_thinking") {
+      thinkingBlocks.push({ type: "redacted_thinking", data: block.data });
+      continue;
+    }
+    if (block.type === "tool_use") toolCalls.push(toolCallFromBlock(block, providerId));
+  }
+
+  const content = textParts.join("");
+  const reasoningContent = displayTextFromThinkingBlocks(thinkingBlocks);
+  if (!content && toolCalls.length === 0) {
+    throw new ProviderError("Provider response did not include assistant content or tool calls.", {
+      kind: "malformed_response",
+      providerId,
+    });
+  }
+
+  return {
+    id: body?.id ?? fallbackId,
+    content,
+    ...(reasoningContent ? { reasoningContent } : {}),
+    ...(thinkingBlocks.length > 0 ? { thinkingBlocks } : {}),
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    finishReason: body?.stop_reason,
+    raw: body,
+    usage: usageFromAnthropicUsage(body?.usage),
+  };
+}
+
+function toolCallFromBlock(
+  block: Extract<NonNullable<AnthropicResponse["content"]>[number], { type: "tool_use" }>,
+  providerId?: string,
+): NonNullable<VesicleResponse["toolCalls"]>[number] {
+  if (!block.id || !block.name) {
+    throw new ProviderError("Provider response included a tool_use block without id or name.", {
+      kind: "malformed_response",
+      providerId,
+    });
+  }
+  return {
+    id: block.id,
+    name: block.name,
+    arguments: jsonString(block.input),
+  };
+}
+
+function jsonString(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? {});
+  } catch {
+    return "{}";
+  }
+}

--- a/src/providers/anthropic-messages/stream.ts
+++ b/src/providers/anthropic-messages/stream.ts
@@ -1,0 +1,242 @@
+import { ProviderError } from "../shared/errors";
+import { readSseEvents } from "../shared/sse";
+import { displayTextFromThinkingBlocks } from "../shared/thinking";
+import type { ProviderStreamEvent, ProviderThinkingBlock, VesicleResponse } from "../shared/types";
+import type { AnthropicStreamEvent, AnthropicStreamState, AnthropicUsage } from "./types";
+import { usageFromAnthropicUsage } from "./usage";
+
+export async function* readAnthropicMessagesStream(
+  response: Response,
+  fallbackId: string,
+  fallbackModel: string,
+  providerId?: string,
+): AsyncIterable<ProviderStreamEvent> {
+  if (!response.body) {
+    throw new ProviderError("Provider streaming response did not include a body.", { kind: "stream_error", providerId });
+  }
+
+  const state = createAnthropicStreamState(fallbackId, fallbackModel);
+  let sawStop = false;
+
+  for await (const event of readSseEvents(response.body)) {
+    const data = parseStreamEvent(event.data, providerId);
+    if (event.event === "error" || data.error?.message) {
+      throw new ProviderError(`Provider stream failed: ${data.error?.message ?? event.data}`, {
+        kind: "stream_error",
+        providerId,
+      });
+    }
+    for (const emitted of absorbAnthropicStreamEvent(state, event.event, data, providerId)) {
+      yield emitted;
+    }
+    if (event.event === "message_stop") sawStop = true;
+  }
+
+  if (!sawStop) {
+    throw new ProviderError("Provider stream ended before message_stop.", { kind: "stream_error", providerId });
+  }
+
+  yield { type: "complete", response: finalizeAnthropicStream(state, providerId) };
+}
+
+function createAnthropicStreamState(fallbackId: string, fallbackModel: string): AnthropicStreamState {
+  return {
+    id: fallbackId,
+    model: fallbackModel,
+    textParts: [],
+    thinkingBlocks: new Map(),
+    toolCalls: new Map(),
+    usage: {},
+  };
+}
+
+function absorbAnthropicStreamEvent(
+  state: AnthropicStreamState,
+  eventName: string,
+  data: AnthropicStreamEvent,
+  providerId?: string,
+): ProviderStreamEvent[] {
+  switch (eventName) {
+    case "message_start":
+      absorbMessageStart(state, data);
+      return [];
+    case "content_block_start":
+      return absorbContentBlockStart(state, data, providerId);
+    case "content_block_delta":
+      return absorbContentBlockDelta(state, data);
+    case "message_delta":
+      absorbMessageDelta(state, data);
+      return [];
+    default:
+      return [];
+  }
+}
+
+function absorbMessageStart(state: AnthropicStreamState, data: AnthropicStreamEvent): void {
+  if (data.message?.id) state.id = data.message.id;
+  if (data.message?.model) state.model = data.message.model;
+  applyInputUsage(state.usage, data.message?.usage);
+}
+
+function absorbContentBlockStart(
+  state: AnthropicStreamState,
+  data: AnthropicStreamEvent,
+  providerId?: string,
+): ProviderStreamEvent[] {
+  const index = data.index ?? 0;
+  const block = data.content_block;
+  if (!block) return [];
+  if (block.type === "tool_use") {
+    if (!block.id || !block.name) {
+      throw new ProviderError("Provider stream included a tool_use block without id or name.", {
+        kind: "malformed_response",
+        providerId,
+      });
+    }
+    state.toolCalls.set(index, { id: block.id, name: block.name, inputJson: "" });
+    return [{ type: "tool_call_delta", index, id: block.id, name: block.name }];
+  }
+  if (block.type === "thinking") {
+    state.thinkingBlocks.set(index, {
+      thinking: block.thinking ?? "",
+      ...(block.signature ? { signature: block.signature } : {}),
+    });
+  } else if (block.type === "redacted_thinking") {
+    state.thinkingBlocks.set(index, { redactedData: block.data });
+  }
+  return [];
+}
+
+function absorbContentBlockDelta(
+  state: AnthropicStreamState,
+  data: AnthropicStreamEvent,
+): ProviderStreamEvent[] {
+  const index = data.index ?? 0;
+  const delta = data.delta;
+  if (!delta) return [];
+  if (delta.type === "text_delta" && delta.text) return absorbTextDelta(state, delta.text);
+  if (delta.type === "input_json_delta" && delta.partial_json) {
+    return absorbToolArgumentsDelta(state, index, delta.partial_json);
+  }
+  if (delta.type === "thinking_delta" && delta.thinking) {
+    return absorbThinkingDelta(state, index, delta.thinking);
+  }
+  if (delta.type === "signature_delta" && delta.signature) {
+    absorbSignatureDelta(state, index, delta.signature);
+  }
+  return [];
+}
+
+function absorbTextDelta(state: AnthropicStreamState, delta: string): ProviderStreamEvent[] {
+  state.textParts.push(delta);
+  return [{ type: "content_delta", delta }];
+}
+
+function absorbToolArgumentsDelta(
+  state: AnthropicStreamState,
+  index: number,
+  delta: string,
+): ProviderStreamEvent[] {
+  const current = state.toolCalls.get(index);
+  if (!current) return [];
+  current.inputJson += delta;
+  return [{ type: "tool_call_delta", index, argumentsDelta: delta }];
+}
+
+function absorbThinkingDelta(
+  state: AnthropicStreamState,
+  index: number,
+  delta: string,
+): ProviderStreamEvent[] {
+  const current = state.thinkingBlocks.get(index);
+  if (current && !("thinking" in current)) return [];
+  const next = current && "thinking" in current
+    ? { ...current, thinking: `${current.thinking}${delta}` }
+    : { thinking: delta };
+  state.thinkingBlocks.set(index, next);
+  return [{ type: "reasoning_delta", delta }];
+}
+
+function absorbSignatureDelta(state: AnthropicStreamState, index: number, signature: string): void {
+  const current = state.thinkingBlocks.get(index);
+  if (current && "thinking" in current) {
+    state.thinkingBlocks.set(index, { ...current, signature });
+  }
+}
+
+function absorbMessageDelta(state: AnthropicStreamState, data: AnthropicStreamEvent): void {
+  if (data.delta?.stop_reason) state.finishReason = data.delta.stop_reason;
+  applyUsage(state.usage, data.usage);
+}
+
+function applyUsage(target: AnthropicUsage, source: AnthropicUsage | undefined): void {
+  if (!source) return;
+  applyInputUsage(target, source);
+  if (source.output_tokens !== undefined) target.output_tokens = source.output_tokens;
+}
+
+function applyInputUsage(target: AnthropicUsage, source: AnthropicUsage | undefined): void {
+  if (!source) return;
+  if (source.input_tokens !== undefined) target.input_tokens = source.input_tokens;
+  if (source.cache_creation_input_tokens !== undefined) {
+    target.cache_creation_input_tokens = source.cache_creation_input_tokens;
+  }
+  if (source.cache_read_input_tokens !== undefined) target.cache_read_input_tokens = source.cache_read_input_tokens;
+}
+
+function finalizeAnthropicStream(state: AnthropicStreamState, providerId?: string): VesicleResponse {
+  const content = state.textParts.join("");
+  const thinkingBlocks = orderedThinkingBlocks(state);
+  const toolCalls = orderedToolCalls(state);
+  const reasoningContent = displayTextFromThinkingBlocks(thinkingBlocks);
+
+  if (!content && toolCalls.length === 0) {
+    throw new ProviderError("Provider response did not include assistant content or tool calls.", {
+      kind: "malformed_response",
+      providerId,
+    });
+  }
+
+  return {
+    id: state.id,
+    content,
+    ...(reasoningContent ? { reasoningContent } : {}),
+    ...(thinkingBlocks.length > 0 ? { thinkingBlocks } : {}),
+    toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+    finishReason: state.finishReason,
+    usage: usageFromAnthropicUsage(state.usage),
+  };
+}
+
+function orderedThinkingBlocks(state: AnthropicStreamState): ProviderThinkingBlock[] {
+  return [...state.thinkingBlocks.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, block]) => (
+      "thinking" in block
+        ? { type: "thinking", thinking: block.thinking, ...(block.signature ? { signature: block.signature } : {}) }
+        : { type: "redacted_thinking", data: block.redactedData }
+    ));
+}
+
+function orderedToolCalls(state: AnthropicStreamState): NonNullable<VesicleResponse["toolCalls"]> {
+  return [...state.toolCalls.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([, call]) => ({
+      id: call.id,
+      name: call.name,
+      arguments: call.inputJson || "{}",
+    }));
+}
+
+function parseStreamEvent(data: string, providerId?: string): AnthropicStreamEvent {
+  try {
+    return JSON.parse(data) as AnthropicStreamEvent;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new ProviderError(`Provider stream delivered unparseable data: ${detail}`, {
+      kind: "malformed_response",
+      providerId,
+      cause: error,
+    });
+  }
+}

--- a/src/providers/anthropic-messages/types.ts
+++ b/src/providers/anthropic-messages/types.ts
@@ -1,0 +1,67 @@
+export type AnthropicContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; source: { type: "base64"; media_type: string; data: string } }
+  | { type: "thinking"; thinking: string; signature?: string }
+  | { type: "redacted_thinking"; data: string }
+  | { type: "tool_use"; id: string; name: string; input: unknown }
+  | { type: "tool_result"; tool_use_id: string; content: string | AnthropicContentBlock[]; is_error?: boolean };
+
+export type AnthropicMessage = {
+  role: "user" | "assistant";
+  content: string | AnthropicContentBlock[];
+};
+
+export type AnthropicUsage = {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+};
+
+export type AnthropicResponse = {
+  id?: string;
+  model?: string;
+  content?: AnthropicContentBlock[];
+  stop_reason?: string;
+  usage?: AnthropicUsage;
+  error?: {
+    message?: string;
+  };
+};
+
+export type AnthropicStreamEvent = {
+  type?: string;
+  index?: number;
+  message?: {
+    id?: string;
+    model?: string;
+    usage?: AnthropicUsage;
+  };
+  content_block?: AnthropicContentBlock;
+  delta?: {
+    type?: string;
+    text?: string;
+    thinking?: string;
+    signature?: string;
+    partial_json?: string;
+    stop_reason?: string;
+  };
+  usage?: AnthropicUsage;
+  error?: {
+    message?: string;
+  };
+};
+
+export type AnthropicThinkingStreamBlock =
+  | { thinking: string; signature?: string }
+  | { redactedData: string };
+
+export type AnthropicStreamState = {
+  id: string;
+  model: string;
+  textParts: string[];
+  thinkingBlocks: Map<number, AnthropicThinkingStreamBlock>;
+  toolCalls: Map<number, { id: string; name: string; inputJson: string }>;
+  finishReason?: string;
+  usage: AnthropicUsage;
+};

--- a/src/providers/anthropic-messages/usage.ts
+++ b/src/providers/anthropic-messages/usage.ts
@@ -1,0 +1,39 @@
+import type { ResponseUsage } from "../shared/types";
+import { normalizeResponseUsage } from "../shared/usage";
+import type { AnthropicUsage } from "./types";
+
+export function usageFromAnthropicUsage(usage: AnthropicUsage | undefined): ResponseUsage | undefined {
+  if (!usage) return undefined;
+  return normalizeResponseUsage({
+    contextInputTokens: sumDefined(
+      usage.input_tokens,
+      usage.cache_creation_input_tokens,
+      usage.cache_read_input_tokens,
+    ),
+    inputTokens: usage.input_tokens,
+    outputTokens: usage.output_tokens,
+    cacheReadInputTokens: usage.cache_read_input_tokens,
+    cacheHitInputTokens: usage.cache_read_input_tokens,
+    cacheWriteInputTokens: usage.cache_creation_input_tokens,
+    cacheMissInputTokens: usage.cache_creation_input_tokens,
+    providerDetails: {
+      ...(usage.cache_creation_input_tokens !== undefined
+        ? { cacheCreationInputTokens: usage.cache_creation_input_tokens }
+        : {}),
+      ...(usage.cache_read_input_tokens !== undefined
+        ? { cacheReadInputTokens: usage.cache_read_input_tokens }
+        : {}),
+    },
+  });
+}
+
+function sumDefined(...values: Array<number | undefined>): number | undefined {
+  let total = 0;
+  let seen = false;
+  for (const value of values) {
+    if (typeof value !== "number" || !Number.isFinite(value)) continue;
+    total += value;
+    seen = true;
+  }
+  return seen ? total : undefined;
+}

--- a/src/tui/agent-command.ts
+++ b/src/tui/agent-command.ts
@@ -1,0 +1,64 @@
+import type { Accessor } from "solid-js";
+import type { AgentManager } from "../core/agents/manager";
+import { listAgentProfiles } from "../core/agents/profile";
+import type { AgentContinuationScheduler } from "../core/agents/scheduler";
+import type { AgentStore } from "../core/agents/store";
+import { agentCardFromMetadata, renderAgentDetail, retryAgentDelivery } from "./agent-view";
+import type { AgentCardState } from "./types";
+
+export type AgentCommandOptions = {
+  rootDir: string;
+  sessionId: Accessor<string | undefined>;
+  agentCards: Accessor<AgentCardState[]>;
+  agentManager: AgentManager;
+  agentStore: AgentStore;
+  pausedDeliveries: Set<string>;
+  scheduler: AgentContinuationScheduler;
+  reportError: (error: unknown) => void;
+};
+
+export function createAgentCommand(options: AgentCommandOptions) {
+  return async function agentCommand(args: string): Promise<string> {
+    const id = options.sessionId();
+    const [action, target] = args.trim().split(/\s+/, 2);
+    if (action === "stop") {
+      if (!target) return "Usage: /agents stop <agent-handle>";
+      if (!id) return "No active session.";
+      const interrupted = await options.agentManager.interrupt(target, id);
+      return interrupted ? `Interrupt requested for ${target}.` : `SubAgent is not running: ${target}.`;
+    }
+    if (action === "retry" && !target) {
+      if (!id) return "No active session.";
+      void retryAgentDelivery(options.pausedDeliveries, id, (session) => options.scheduler.notify(session)).catch(options.reportError);
+      return "SubAgent result delivery retry scheduled.";
+    }
+    if (action && !target) return inspectAgent(id, action);
+    if (args.trim()) return "Usage: /agents [handle|stop <handle>|retry]";
+    return listAgents(id);
+  };
+
+  async function inspectAgent(sessionId: string | undefined, reference: string): Promise<string> {
+    if (!sessionId) return "No active session.";
+    const agent = await options.agentStore.resolveReference(sessionId, reference);
+    if (!agent) return `Unknown SubAgent: ${reference}.`;
+    const inbox = (await options.agentStore.listInbox(sessionId)).filter((entry) => entry.runId === agent.runId);
+    const card = options.agentCards().find((candidate) => candidate.runId === agent.runId) ?? agentCardFromMetadata(agent, inbox);
+    return renderAgentDetail(agent, card, inbox);
+  }
+
+  async function listAgents(sessionId: string | undefined): Promise<string> {
+    const profiles = await listAgentProfiles(options.rootDir);
+    const agents = sessionId ? await options.agentStore.listByParent(sessionId) : [];
+    const inbox = sessionId ? await options.agentStore.listInbox(sessionId) : [];
+    const lines = ["Agent Profiles:"];
+    for (const profile of profiles) lines.push(`  ${profile.id} [${profile.defaultMode}/${profile.contextMode}] - ${profile.description}`);
+    lines.push("", "Current session SubAgents:");
+    if (agents.length === 0) lines.push("  (none)");
+    for (const agent of agents) {
+      const card = options.agentCards().find((candidate) => candidate.runId === agent.runId) ?? agentCardFromMetadata(agent, inbox);
+      lines.push(`  ${agent.handle} [${card.status}/${agent.mode}] ${agent.description}`);
+    }
+    lines.push("", "Use /agents <handle> for details, /agents stop <handle> to interrupt, or /agents retry after a delivery error.");
+    return lines.join("\n");
+  }
+}

--- a/src/tui/agent-delivery.ts
+++ b/src/tui/agent-delivery.ts
@@ -1,0 +1,5 @@
+export function sameInboxIds(value: unknown, expected: string[]): boolean {
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) return false;
+  const actual = [...new Set(value as string[])].sort();
+  return actual.length === expected.length && actual.every((entry, index) => entry === expected[index]);
+}

--- a/src/tui/agent-process-controller.ts
+++ b/src/tui/agent-process-controller.ts
@@ -1,0 +1,277 @@
+import type { Accessor, Setter } from "solid-js";
+import type { AgentLoopEvent } from "../core/agent-loop/run";
+import type { BackgroundProcessEvent, BackgroundProcessState } from "../core/process/manager";
+import type { ProcessToolEvent } from "../core/tools";
+import { processEventFromTask } from "../core/tools/shell";
+import { displayTextFromThinkingBlocks } from "../providers/shared/thinking";
+import type { ResponseUsage } from "../providers/shared/types";
+import { applyAgentEvent } from "./agent-view";
+import type { ActivityEntry, AgentCardState, Message } from "./types";
+
+export type AgentProcessControllerOptions = {
+  sessionId: Accessor<string | undefined>;
+  busy: Accessor<boolean>;
+  activeEngine: Accessor<import("../core/engine/profile").EngineId>;
+  activeModel: Accessor<string>;
+  backgroundProcesses: Accessor<BackgroundProcessState[]>;
+  setBackgroundProcesses: Setter<BackgroundProcessState[]>;
+  setAgentCards: Setter<AgentCardState[]>;
+  setMessages: Setter<Message[]>;
+  setActivity: Setter<ActivityEntry[]>;
+  setStatus: Setter<string>;
+  setStreamingAssistant: Setter<string>;
+  setStreamingReasoning: Setter<string>;
+  setLastDisplayedToolAssistantContent: Setter<string | null>;
+  markTurnSawResponse: () => void;
+  recordResponseUsage: (usage: ResponseUsage) => void;
+  recordIndependentAgentUsage: (usage: ResponseUsage) => void;
+  assetDriftKey: Accessor<string | undefined>;
+  setAssetDriftKey: (key: string) => void;
+};
+
+export function createAgentProcessController(options: AgentProcessControllerOptions) {
+  let formingToolName: string | undefined;
+
+  function recordActivity(entry: ActivityEntry): void {
+    options.setActivity((previous) => [...previous, entry].slice(-60));
+  }
+
+  function appendReasoningMessage(content: string): void {
+    if (!content.trim()) return;
+    options.setMessages((previous) => [...previous, { role: "system", content, kind: "reasoning" }]);
+  }
+
+  function handleAgentEvent(event: AgentLoopEvent): void {
+    projectAgentCard(event);
+    if (handleAgentLifecycle(event)) return;
+    if (handleProcessOrAsset(event)) return;
+    if (handleProviderEvent(event)) return;
+    if (handleToolEvent(event)) return;
+    handleInteractionEvent(event);
+  }
+
+  function projectAgentCard(event: AgentLoopEvent): void {
+    if (event.type !== "agent_created"
+      && event.type !== "agent_started"
+      && event.type !== "agent_progress"
+      && event.type !== "agent_completed"
+      && event.type !== "agent_integrated") return;
+    options.setAgentCards((cards) => applyAgentEvent(cards, event));
+    if (event.type !== "agent_created") return;
+    options.setMessages((current) => current.some((message) => message.kind === "agent" && message.agentRunId === event.agent.runId)
+      ? current
+      : [...current, { role: "system", content: "", kind: "agent", agentRunId: event.agent.runId }]);
+  }
+
+  function handleAgentLifecycle(event: AgentLoopEvent): boolean {
+    switch (event.type) {
+      case "agent_created":
+        recordActivity({ kind: "agent", text: `queued ${event.agent.profileId}: ${event.agent.description}` });
+        return true;
+      case "agent_started":
+        recordActivity({ kind: "agent", text: `started ${event.agent.handle}: ${event.agent.description}` });
+        return true;
+      case "agent_progress":
+        recordActivity({ kind: "agent", text: `${event.handle}: ${event.text}` });
+        return true;
+      case "agent_completed": {
+        const parentIsCurrent = event.result.parentSessionId === options.sessionId() || (!options.sessionId() && options.busy());
+        if (parentIsCurrent && event.result.mode === "foreground" && event.result.usage) {
+          options.recordIndependentAgentUsage(event.result.usage);
+        }
+        recordActivity({ kind: "agent", text: `${event.result.status} ${event.result.handle}: ${event.result.description}` });
+        return true;
+      }
+      case "agent_integrated":
+        recordActivity({ kind: "agent", text: `integrated ${event.handle}` });
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function handleProcessOrAsset(event: AgentLoopEvent): boolean {
+    if (event.type === "process_update") {
+      applyProcessUpdate(event.callId, event.processEvent);
+      if (event.processEvent.executionMode === "foreground") {
+        options.setStatus(event.processEvent.status === "running"
+          ? `running shell · ${Math.max(0, Math.round(event.processEvent.durationMs / 1000))}s`
+          : `shell ${event.processEvent.status}`);
+      }
+      return true;
+    }
+    if (event.type !== "asset_drift") return false;
+    const key = `${options.sessionId() ?? "unknown"}:${event.fingerprint}`;
+    if (options.assetDriftKey() === key) return true;
+    options.setAssetDriftKey(key);
+    const changed = event.changedPaths.length > 0 ? event.changedPaths.join(", ") : "effective assets";
+    options.setMessages((current) => [...current, {
+      role: "system",
+      content: `Asset drift detected since this session began: ${changed}. This continuation uses the current effective assets.`,
+    }]);
+    recordActivity({ kind: "system", text: `asset drift: ${changed}` });
+    return true;
+  }
+
+  function handleProviderEvent(event: AgentLoopEvent): boolean {
+    switch (event.type) {
+      case "provider_request":
+        options.setStreamingAssistant("");
+        options.setStreamingReasoning("");
+        formingToolName = undefined;
+        options.setStatus("sending request");
+        recordActivity({ kind: "provider", text: `provider request #${event.iteration + 1}` });
+        return true;
+      case "assistant_delta":
+        options.setStreamingAssistant((previous) => `${previous}${event.delta}`);
+        options.setStatus("generating response");
+        return true;
+      case "assistant_reasoning_delta":
+        options.setStreamingReasoning((previous) => `${previous}${event.delta}`);
+        options.setStatus("generating response");
+        return true;
+      case "tool_call_delta":
+        if (event.name) {
+          formingToolName = event.name;
+          recordActivity({ kind: "tool", text: `tool call forming: ${event.name}` });
+        }
+        options.setStatus(formingToolName ? `calling · ${formingToolName}` : "generating response");
+        return true;
+      case "assistant_response":
+        handleAssistantResponse(event);
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  function handleAssistantResponse(event: Extract<AgentLoopEvent, { type: "assistant_response" }>): void {
+    options.markTurnSawResponse();
+    options.setStreamingAssistant("");
+    options.setStreamingReasoning("");
+    if (event.usage) options.recordResponseUsage(event.usage);
+    if (event.toolCalls.length > 0) {
+      const reasoningText = displayTextFromThinkingBlocks(event.thinkingBlocks) ?? event.reasoningContent;
+      if (reasoningText) appendReasoningMessage(reasoningText);
+      if (event.content.trim()) {
+        options.setMessages((previous) => [...previous, {
+          role: "assistant",
+          content: event.content,
+          engine: options.activeEngine(),
+          model: options.activeModel(),
+        }]);
+      }
+      options.setLastDisplayedToolAssistantContent(event.content);
+    }
+    recordActivity({
+      kind: "assistant",
+      text: event.toolCalls.length > 0
+        ? `assistant response with ${event.toolCalls.length} tool call${event.toolCalls.length > 1 ? "s" : ""}`
+        : "assistant response complete",
+    });
+  }
+
+  function handleToolEvent(event: AgentLoopEvent): boolean {
+    if (event.type === "tool_call") {
+      if (event.name === "spawn_agent") {
+        options.setStatus("starting SubAgent");
+        recordActivity({ kind: "agent", text: "spawn_agent requested" });
+        return true;
+      }
+      options.setMessages((previous) => [...previous, {
+        role: "tool",
+        toolStage: "call",
+        toolName: event.name,
+        toolArgs: event.arguments,
+        toolCallId: event.callId,
+        content: "",
+      }]);
+      options.setStatus(`calling · ${event.name}`);
+      recordActivity({ kind: "tool", text: `calling ${event.name}` });
+      return true;
+    }
+    if (event.type !== "tool_result") return false;
+    if (event.name === "spawn_agent") {
+      if (!event.ok) {
+        options.setStatus("SubAgent launch failed");
+        options.setMessages((current) => [...current, { role: "system", content: `SubAgent launch failed: ${event.content}` }]);
+      }
+      recordActivity({ kind: "agent", text: `${event.ok ? "ok" : "failed"} spawn_agent` });
+      return true;
+    }
+    projectToolResult(event);
+    return true;
+  }
+
+  function projectToolResult(event: Extract<AgentLoopEvent, { type: "tool_result" }>): void {
+    const latestBackgroundProcess = event.processEvent?.taskId
+      ? options.backgroundProcesses().find((process) => process.taskId === event.processEvent?.taskId)
+      : undefined;
+    const displayedProcessEvent = latestBackgroundProcess ? processEventFromTask(latestBackgroundProcess) : event.processEvent;
+    options.setMessages((previous) => {
+      const next = previous.map((message) => message.toolCallId === event.callId && message.toolStage === "call"
+        ? { ...message, toolFileEvent: event.fileEvent, toolWebEvent: event.webEvent, toolMcpEvent: event.mcpEvent, toolProcessEvent: displayedProcessEvent, toolOk: event.ok, images: event.images }
+        : message);
+      next.push({
+        role: "tool",
+        toolStage: "result",
+        toolName: event.name,
+        toolCallId: event.callId,
+        toolOk: event.ok,
+        toolFileEvent: event.fileEvent,
+        toolWebEvent: event.webEvent,
+        toolMcpEvent: event.mcpEvent,
+        toolProcessEvent: displayedProcessEvent,
+        images: event.images,
+        content: event.ok ? "" : event.content,
+      });
+      return next;
+    });
+    recordActivity({ kind: "tool", text: `${event.ok ? "ok" : "failed"} ${event.name}: ${event.content}` });
+  }
+
+  function handleInteractionEvent(event: AgentLoopEvent): void {
+    switch (event.type) {
+      case "gate_pending":
+        recordActivity({ kind: "gate", text: `gate pending: ${event.gate}` });
+        return;
+      case "engine_switch_pending":
+        recordActivity({ kind: "gate", text: `engine switch pending: ${event.targetEngine}` });
+        return;
+      case "user_question_pending":
+        recordActivity({ kind: "gate", text: `question pending: ${event.header}` });
+        return;
+      case "validation":
+        recordActivity({ kind: "validation", text: event.ok ? "validation passed" : "validation found issues" });
+        return;
+      default:
+        return;
+    }
+  }
+
+  function handleBackgroundProcessEvent(event: BackgroundProcessEvent): void {
+    const process = event.process;
+    options.setBackgroundProcesses((current) => {
+      const index = current.findIndex((candidate) => candidate.taskId === process.taskId);
+      if (index < 0) return [...current, process];
+      return current.map((candidate, candidateIndex) => candidateIndex === index ? process : candidate);
+    });
+    applyProcessUpdate(process.parentToolCallId, processEventFromTask(process));
+    if (process.status !== "running") {
+      recordActivity({ kind: "tool", text: `${process.taskId} ${process.status}${process.exitCode !== undefined ? ` · exit ${process.exitCode}` : ""}` });
+    }
+  }
+
+  function applyProcessUpdate(callId: string, processEvent: ProcessToolEvent): void {
+    options.setMessages((current) => current.map((message) =>
+      message.toolCallId === callId ? { ...message, toolProcessEvent: processEvent } : message
+    ));
+  }
+
+  return {
+    appendReasoningMessage,
+    handleAgentEvent,
+    handleBackgroundProcessEvent,
+    recordActivity,
+  };
+}

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,178 +1,105 @@
 import { createEffect, createMemo, createSignal, Show, onCleanup, onMount } from "solid-js";
-import { useKeyboard, usePaste, useRenderer, useTerminalDimensions } from "@opentui/solid";
-import { inspectProviderConfig } from "../config/providers";
-import { loadPermissionSettings } from "../config/permissions";
-import type { ProviderRegistry, ProviderSelection } from "../config/providers";
-import type { ModelCapabilities, ModelLimits } from "../config/env";
-import { inspectMcpConfig } from "../mcp/registry";
-import { resolveEngineSwitch, resolveGate, resolvePermission, resolveUserQuestion, runPrompt } from "../core/agent-loop/run";
-import type { RunPromptResult } from "../core/agent-loop/run";
-import type { AgentLoopEvent } from "../core/agent-loop/run";
+import { useRenderer, useTerminalDimensions } from "@opentui/solid";
 import type { EngineId } from "../core/engine/profile";
-import type { EngineSwitchRequest } from "../core/engine/switch";
-import { ENGINE_HANDOFF_KIND, renderEngineHandoffPacket } from "../core/engine/transition";
-import type { EngineTransition } from "../core/engine/transition";
-import type { UserQuestionAnswer } from "../core/user-question/types";
-import type { ResponseUsage, VesicleImageAttachment, VesicleMessage } from "../providers/shared/types";
+import type { VesicleMessage } from "../providers/shared/types";
 import type { ReasoningTier } from "../providers/shared/types";
-import { displayTextFromThinkingBlocks } from "../providers/shared/thinking";
-import type { GateRequest, GateResolution } from "../core/gate/types";
-import { compactConversation } from "../core/compact/service";
-import { copySelectionToClipboard, readImageFromClipboard } from "./clipboard";
-import { engineAccent, engineDisplayName, palette } from "./theme";
-import { GatePrompt, engineSwitchGateFocusOrder, gateComposerIsActive, gateFocusOrder, gateResolutionFromState, gateSummaryLineBudget } from "./GatePrompt";
-import type { GateFocusTarget } from "./GatePrompt";
-import { createSessionStore, listSessions, loadSessionSnapshot } from "../core/session/store";
-import type { ReasoningDisplayMode, ResumedMessage, SessionSummary } from "../core/session/store";
+import { engineAccent, palette } from "./theme";
+import { listSessions } from "../core/session/store";
+import type { ReasoningDisplayMode, SessionSummary } from "../core/session/store";
 import { loadArtifactPreview, scanArtifacts } from "../core/artifacts/workbench";
 import type { ArtifactEntry } from "../core/artifacts/workbench";
 import { resolveTuiLayout } from "./layout";
-import { truncateLine, truncateMiddle } from "./format";
 import { Sidebar } from "./views/Sidebar";
-import type { SidebarMcpState } from "./views/Sidebar";
 import { MessageStream } from "./views/MessageStream";
-import { SessionPicker } from "./SessionPicker";
-import { RewindPicker, rewindPickerPanelHeight } from "./RewindPicker";
-import { QuestionPrompt, questionComposerIsActive, questionPanelMinHeight } from "./QuestionPrompt";
-import { PromptComposer } from "./PromptComposer";
-import { CommandMenu } from "./widgets/CommandMenu";
-import { ArgumentMenu } from "./widgets/ArgumentMenu";
-import { OptionPicker } from "./widgets/OptionPicker";
-import { renderModelDetails, renderValidationNotice } from "./commands/render";
-import { applyComposerKey, insertComposerImage, insertComposerText, normalizeKeyName, setComposerValue } from "./composer";
-import { composerVisualLineCount } from "./composer-layout";
-import type { ComposerElement, ComposerState } from "./composer";
-import {
-  listRewindPoints,
-  rewindConversation,
-  type ConversationRewind,
-} from "../core/rewind/service";
-import { renderResumedToolResultSummary } from "./tool-summary";
+import { rewindPickerPanelHeight } from "./RewindPicker";
 import { builtinCommands } from "./commands/builtin";
 import { executeCommand } from "./commands/dispatch";
-import { matchCommands } from "./commands/match";
-import {
-  completeAgentArgument,
-  completeFixedArgument,
-  completeModelArgument,
-  fixedArgumentOptions,
-  matchOptionItems,
-  parseAgentArgumentDraft,
-  parseFixedArgumentDraft,
-  parseModelArgumentDraft,
-} from "./commands/argument-completion";
-import type { AgentArgumentDraft, FixedArgumentDraft, ModelArgumentDraft } from "./commands/argument-completion";
-import { clampCommandMenuSelection, moveCommandMenuSelection } from "./commands/selection";
 import type { CommandContext } from "./commands/types";
-import type { ActivityEntry, AgentCardState, Message, OptionItem, SelectedArtifact, SessionPickerState } from "./types";
+import type { ActivityEntry, AgentCardState, Message, SelectedArtifact, SessionPickerState } from "./types";
 import { createRewindController } from "./rewind/controller";
 import { initDebugLogging } from "./debug-log";
 import { TurnCancellation } from "./turn-cancellation";
-import { PromptEscapeController } from "./prompt-escape";
-import { ingestImageBytes } from "../core/attachments/store";
-import { inspectEngineAssetDrift } from "../core/runtime/engine-assets";
 import { AgentManager } from "../core/agents/manager";
 import { AgentStore } from "../core/agents/store";
 import { runChildAgent } from "../core/agents/child-runner";
-import { AgentContinuationScheduler, AgentDeliveryDeferred } from "../core/agents/scheduler";
-import type { AgentInboxEntry } from "../core/agents/types";
-import { listAgentProfiles } from "../core/agents/profile";
-import { agentActivitySummary, agentCardFromMetadata, applyAgentEvent, mergeRestoredAgentCards, renderAgentDetail, retryAgentDelivery, setAgentDeliveryState } from "./agent-view";
-import { ToolPermissionBroker, type PermissionMode } from "../core/permissions";
-import type { PermissionResolution } from "../core/permissions";
-import { PermissionPrompt } from "./PermissionPrompt";
-import { YoloPrompt } from "./YoloPrompt";
-import { getProcessManager, type BackgroundProcessEvent, type BackgroundProcessState } from "../core/process/manager";
-import { processEventFromTask } from "../core/tools/shell";
-
-type PendingGate = Extract<RunPromptResult, { kind: "needs_user" }>;
-
-type PendingGateState = Omit<PendingGate, "profile"> & {
-  engine: EngineId;
-  profile?: PendingGate["profile"];
-};
-
-type PendingEngineSwitch = Extract<RunPromptResult, { kind: "needs_engine_switch" }>;
-
-type PendingEngineSwitchState = Omit<PendingEngineSwitch, "profile"> & {
-  profile?: PendingEngineSwitch["profile"];
-};
-
-type PendingUserQuestion = Extract<RunPromptResult, { kind: "needs_user_question" }>;
-
-type PendingUserQuestionState = Omit<PendingUserQuestion, "profile"> & {
-  engine: EngineId;
-  profile?: PendingUserQuestion["profile"];
-};
-
-type PendingPermission = Extract<RunPromptResult, { kind: "needs_permission" }>;
-
-type PendingPermissionState = Omit<PendingPermission, "profile"> & {
-  engine: EngineId;
-  profile?: PendingPermission["profile"];
-};
-
-type TuiKeyEvent = {
-  name?: string;
-  ctrl?: boolean;
-  shift?: boolean;
-  meta?: boolean;
-  option?: boolean;
-  sequence?: string;
-  raw?: string;
-  preventDefault?: () => void;
-  stopPropagation?: () => void;
-};
-
-// Two-step interactive provider→model picker state for "/model" with no args.
-type ModelPickerState = {
-  step: "provider" | "model";
-  providerId: string | null;
-  selected: number;
-};
-
-type PromptHistoryEntry = {
-  value: string;
-  elements: ComposerElement[];
-  images: VesicleImageAttachment[];
-};
+import { AgentContinuationScheduler } from "../core/agents/scheduler";
+import { agentActivitySummary } from "./agent-view";
+import { ToolPermissionBroker } from "../core/permissions";
+import { getProcessManager, type BackgroundProcessState } from "../core/process/manager";
+import {
+  backgroundProcessActivitySummary,
+  contextUsageTelemetryLine,
+  createUsageController,
+  footerLine,
+  headerLine,
+  latestTurnUsage,
+  sessionUsageTelemetryLine,
+  sumSessionUsage,
+  turnUsageTelemetryLine,
+  type TokenUsageSummary,
+} from "./telemetry";
+import { displayTranscriptFromSnapshot } from "./session-presenter";
+import { BottomSurface } from "./views/BottomSurface";
+import { createAgentProcessController } from "./agent-process-controller";
+import { createSessionResumeController } from "./session-resume-controller";
+import { createComposerController } from "./composer-controller";
+import { createDecisionController } from "./decision-controller";
+import { createTurnController } from "./turn-controller";
+import { createProviderConfigController, createProviderState } from "./provider-config-controller";
+import { createSessionActionsController } from "./session-actions-controller";
+import { createSessionPreferencesController } from "./session-preferences-controller";
+import { createAgentCommand } from "./agent-command";
+import { registerInputRouting } from "./input-routing";
 
 export type AppProps = {
   dangerouslySkipPermissions?: boolean;
 };
 
-export type TokenUsageSummary = {
-  inputTokens: number;
-  outputTokens: number;
-  cachedInputTokens: number;
-  contextInputTokens: number;
+export {
+  backgroundProcessActivitySummary,
+  contextUsageTelemetryLine,
+  displayTranscriptFromSnapshot,
+  footerLine,
+  headerLine,
+  latestTurnUsage,
+  sessionUsageTelemetryLine,
+  sumSessionUsage,
+  turnUsageTelemetryLine,
 };
+export type { TokenUsageSummary };
 
 export function App(props: AppProps = {}) {
   initDebugLogging();
   const renderer = useRenderer();
   const dimensions = useTerminalDimensions();
-  const [providerRegistry, setProviderRegistry] = createSignal<ProviderRegistry | null>(null);
-  const [activeProvider, setActiveProvider] = createSignal("loading");
-  const [activeModel, setActiveModel] = createSignal("loading");
-  const [activeModelLimits, setActiveModelLimits] = createSignal<ModelLimits | undefined>();
-  const [activeModelCapabilities, setActiveModelCapabilities] = createSignal<ModelCapabilities | undefined>();
+  const providerState = createProviderState(props.dangerouslySkipPermissions === true);
+  const {
+    activeModel,
+    activeModelCapabilities,
+    activeModelLimits,
+    activeProvider,
+    mcpStatus,
+    permissionMode,
+    permissionSettingsReady,
+    providerConfigReady,
+    providerHasApiKey,
+    providerRegistry,
+    setActiveModel,
+    setActiveModelCapabilities,
+    setActiveModelLimits,
+    setActiveProvider,
+    setMcpStatus,
+    setPermissionMode,
+    setPermissionSettingsReady,
+    setProviderConfigReady,
+    setProviderHasApiKey,
+    setProviderRegistry,
+    setShellExecEnabled,
+    shellExecEnabled,
+  } = providerState;
   const [activeEngine, setActiveEngine] = createSignal<EngineId>("etl");
   const [thinkingTier, setThinkingTier] = createSignal<ReasoningTier | undefined>();
   const [reasoningDisplayMode, setReasoningDisplayMode] = createSignal<ReasoningDisplayMode>("collapsed");
-  const [permissionMode, setPermissionMode] = createSignal<PermissionMode>(
-    props.dangerouslySkipPermissions ? "YOLO" : "MOMENTUM",
-  );
-  const [shellExecEnabled, setShellExecEnabled] = createSignal(props.dangerouslySkipPermissions === true);
-  const [permissionSettingsReady, setPermissionSettingsReady] = createSignal(props.dangerouslySkipPermissions === true);
-  const [providerHasApiKey, setProviderHasApiKey] = createSignal(false);
-  const [providerConfigReady, setProviderConfigReady] = createSignal(false);
-  const [mcpStatus, setMcpStatus] = createSignal<SidebarMcpState>({
-    loading: true,
-    configured: false,
-    enabled: false,
-    servers: [],
-  });
   const [messages, setMessages] = createSignal<Message[]>([
     {
       role: "system",
@@ -188,18 +115,11 @@ export function App(props: AppProps = {}) {
   const [sessionId, setSessionId] = createSignal<string | undefined>();
   const [conversation, setConversation] = createSignal<VesicleMessage[]>([]);
   const [output, setOutput] = createSignal("");
-  const [inputValue, setInputValue] = createSignal("");
-  const [inputCursor, setInputCursor] = createSignal(0);
-  const [inputKillBuffer, setInputKillBuffer] = createSignal<string | undefined>();
-  const [inputElements, setInputElements] = createSignal<ComposerElement[]>([]);
-  const [inputImages, setInputImages] = createSignal<VesicleImageAttachment[]>([]);
   const [busy, setBusy] = createSignal(false);
   const [restoringSession, setRestoringSession] = createSignal(false);
   const [resumableSessions, setResumableSessions] = createSignal<SessionSummary[]>([]);
   const [sessionPicker, setSessionPicker] = createSignal<SessionPickerState | null>(null);
   const [nextSessionParent, setNextSessionParent] = createSignal<{ uuid: string | null } | null>(null);
-  const [modelPicker, setModelPicker] = createSignal<ModelPickerState | null>(null);
-  const [modelPickerBusy, setModelPickerBusy] = createSignal(false);
   const [artifacts, setArtifacts] = createSignal<ArtifactEntry[]>([]);
   const [selectedArtifact, setSelectedArtifact] = createSignal<SelectedArtifact | null>(null);
   const [activity, setActivity] = createSignal<ActivityEntry[]>([
@@ -209,48 +129,222 @@ export function App(props: AppProps = {}) {
   const [backgroundProcesses, setBackgroundProcesses] = createSignal<BackgroundProcessState[]>([]);
   const [streamingAssistant, setStreamingAssistant] = createSignal("");
   const [streamingReasoning, setStreamingReasoning] = createSignal("");
-  const [lastTurnUsage, setLastTurnUsage] = createSignal<TokenUsageSummary | undefined>();
-  const [sessionUsage, setSessionUsage] = createSignal<TokenUsageSummary>(emptyUsageSummary());
+  const usageController = createUsageController();
+  const {
+    beginTurn: beginUsageTurn,
+    lastTurnUsage,
+    publishTurn: publishTurnUsage,
+    recordIndependent: recordIndependentAgentUsage,
+    recordResponse: recordResponseUsage,
+    sessionUsage,
+    setLastTurnUsage,
+    setSessionUsage,
+  } = usageController;
   const [lastDisplayedToolAssistantContent, setLastDisplayedToolAssistantContent] = createSignal<string | null>(null);
-  const [promptHistory, setPromptHistory] = createSignal<PromptHistoryEntry[]>([]);
-  const [historyIndex, setHistoryIndex] = createSignal<number | null>(null);
   const turnCancellation = new TurnCancellation();
 
+  let turnController!: ReturnType<typeof createTurnController>;
+  let sessionPreferences!: ReturnType<typeof createSessionPreferencesController>;
+  const decisionController = createDecisionController({
+    busy,
+    activeEngine,
+    permissionMode,
+    setStatus,
+    submitPermission: (resolution) => { void turnController.submitPermissionResolution(resolution); },
+    submitChildPermission: (resolution) => turnController.submitChildPermissionResolution(resolution),
+    submitEngineSwitch: (resolution, submitOptions) => { void turnController.submitEngineSwitchResolution(resolution, submitOptions); },
+    submitGate: (resolution) => { void turnController.submitGateResolution(resolution); },
+    submitQuestionOption: (selectedIndex) => { void turnController.submitUserQuestionAnswer(selectedIndex); },
+    submitQuestionFreeform: (value) => turnController.submitUserQuestionFreeform(value),
+    applyPermissionMode: (mode) => sessionPreferences.applyPermissionMode(mode),
+  });
+  const {
+    activeGateRequest,
+    activePermissionRequest,
+    clearGateFeedback,
+    clearQuestionFreeform,
+    decisionPanelMinHeight,
+    gateFeedback,
+    gateFeedbackCursor,
+    gateFeedbackMode,
+    gateFocus,
+    handleGateKey,
+    handlePaste: handleDecisionPaste,
+    handleQuestionKey,
+    handleYoloKey,
+    pendingChildPermission,
+    pendingEngineSwitch,
+    pendingGate,
+    pendingPermission,
+    pendingUserQuestion,
+    questionFreeformCursor,
+    questionFreeformText,
+    questionSelected,
+    setGateFeedback,
+    setGateFeedbackCursor,
+    setGateFeedbackKillBuffer,
+    setGateFeedbackMode,
+    setGateFocus,
+    setPendingChildPermission,
+    setPendingEngineSwitch,
+    setPendingGate,
+    setPendingPermission,
+    setPendingUserQuestion,
+    setQuestionFreeformCursor,
+    setQuestionFreeformKillBuffer,
+    setQuestionFreeformText,
+    setQuestionSelected,
+    setYoloConfirmStage,
+    yoloConfirmStage,
+  } = decisionController;
+  sessionPreferences = createSessionPreferencesController({
+    rootDir: process.cwd(),
+    dangerouslySkipPermissions: props.dangerouslySkipPermissions === true,
+    sessionId,
+    nextSessionParent,
+    setNextSessionParent,
+    permissionMode,
+    setPermissionMode,
+    setGateFocus,
+    setYoloConfirmStage,
+    setStatus,
+    setMessages,
+    setConversation,
+  });
+  const {
+    changePermissionMode,
+    persistEngineSwitch,
+    persistProviderSwitch,
+    persistReasoningSwitch,
+    persistThinkingSwitch,
+  } = sessionPreferences;
+  let lastReportedAssetDriftKey: string | undefined;
+  const agentStore = new AgentStore(process.cwd());
+  const processManager = getProcessManager(process.cwd());
+  const agentProcessController = createAgentProcessController({
+    sessionId,
+    busy,
+    activeEngine,
+    activeModel,
+    backgroundProcesses,
+    setBackgroundProcesses,
+    setAgentCards,
+    setMessages,
+    setActivity,
+    setStatus,
+    setStreamingAssistant,
+    setStreamingReasoning,
+    setLastDisplayedToolAssistantContent,
+    markTurnSawResponse: () => turnController.markTurnSawResponse(),
+    recordResponseUsage,
+    recordIndependentAgentUsage,
+    assetDriftKey: () => lastReportedAssetDriftKey,
+    setAssetDriftKey: (key) => { lastReportedAssetDriftKey = key; },
+  });
+  const {
+    handleAgentEvent,
+    handleBackgroundProcessEvent,
+    recordActivity,
+  } = agentProcessController;
+  const providerConfigController = createProviderConfigController({
+    dangerouslySkipPermissions: props.dangerouslySkipPermissions === true,
+    providerRegistry,
+    setProviderRegistry,
+    setActiveProvider,
+    setActiveModel,
+    setActiveModelLimits,
+    setActiveModelCapabilities,
+    setProviderHasApiKey,
+    setProviderConfigReady,
+    setMcpStatus,
+    setPermissionMode,
+    setShellExecEnabled,
+    setPermissionSettingsReady,
+    thinkingTier,
+    activeProvider,
+    activeModel,
+    setStatus,
+    recordActivity,
+  });
+  const {
+    activeGeneration,
+    activeProviderSelection,
+    applyProviderSelection,
+    ensureProviderRegistry,
+    loadPermissionSettingsOnce,
+    loadProviderConfigOnce,
+    refreshMcpStatus,
+  } = providerConfigController;
+  let sessionActions!: ReturnType<typeof createSessionActionsController>;
   const rewindController = createRewindController({
     rootDir: process.cwd(),
     sessionId,
     branchHead: nextSessionParent,
     busy,
     engine: activeEngine,
-    providerSelection: () => ({ provider: activeProvider(), model: activeModel() }),
+    providerSelection: activeProviderSelection,
     generation: activeGeneration,
     setStatus,
     setBusy,
     runCancellable: (operation) => turnCancellation.run(operation),
     refreshArtifacts,
-    applyConversation: applyConversationRewind,
+    applyConversation: (result) => sessionActions.applyConversationRewind(result),
   });
   const rewindPicker = rewindController.state;
-
-  // Gate UI state. When pendingGate is non-null the input bar is replaced
-  // by the Select-style gate prompt; keyboard routing switches to gate mode.
-  const [pendingGate, setPendingGate] = createSignal<PendingGateState | null>(null);
-  const [pendingEngineSwitch, setPendingEngineSwitch] = createSignal<PendingEngineSwitchState | null>(null);
-  const [pendingUserQuestion, setPendingUserQuestion] = createSignal<PendingUserQuestionState | null>(null);
-  const [pendingPermission, setPendingPermission] = createSignal<PendingPermissionState | null>(null);
-  const [pendingChildPermission, setPendingChildPermission] = createSignal<import("../core/permissions").PermissionRequest | null>(null);
-  const [yoloConfirmStage, setYoloConfirmStage] = createSignal<1 | 2 | null>(null);
-  const [questionSelected, setQuestionSelected] = createSignal(0);
-  const [questionFreeformText, setQuestionFreeformText] = createSignal("");
-  const [questionFreeformCursor, setQuestionFreeformCursor] = createSignal(0);
-  const [questionFreeformKillBuffer, setQuestionFreeformKillBuffer] = createSignal<string | undefined>();
-  const [gateFocus, setGateFocus] = createSignal<GateFocusTarget>("confirm");
-  const [gateFeedbackMode, setGateFeedbackMode] = createSignal<GateFocusTarget | null>(null);
-  const [gateFeedback, setGateFeedback] = createSignal("");
-  const [gateFeedbackCursor, setGateFeedbackCursor] = createSignal(0);
-  const [gateFeedbackKillBuffer, setGateFeedbackKillBuffer] = createSignal<string | undefined>();
-  const agentStore = new AgentStore(process.cwd());
-  const processManager = getProcessManager(process.cwd());
+  const composerController = createComposerController({
+    rootDir: process.cwd(),
+    terminalWidth: () => dimensions().width,
+    providerRegistry,
+    ensureProviderRegistry,
+    applyProviderSelection,
+    persistProviderSwitch,
+    agentCards,
+    sessionId,
+    busy,
+    activeModelCapabilities,
+    status,
+    setStatus,
+    setMessages,
+    recordActivity,
+    reportError: (error) => turnController.reportError(error),
+    submitPrompt: (value, images, elements) => turnController.submitPrompt(value, images, elements),
+    abortTurn: () => turnCancellation.abort(),
+    openRewind: rewindController.open,
+  });
+  const {
+    agentArgumentDraft,
+    applyState: applyComposerState,
+    clear: clearComposer,
+    commandArgumentItems,
+    commandArgumentMenuOpen,
+    commandArgumentSelected,
+    commandMenuItems,
+    commandMenuOpen,
+    commandMenuSelected,
+    composerInputWidth,
+    composerPopupOpen,
+    fixedArgumentDraft,
+    handleEscape: handleEscapeAtPrompt,
+    handleKey: handleComposerKey,
+    handleModelPickerKey,
+    historyIndex,
+    inputCursor,
+    inputElements,
+    inputImages,
+    inputNeedsExpandedBottom,
+    inputValue,
+    insertPastedText: insertComposerPaste,
+    modelArgumentDraft,
+    modelPicker,
+    modelPickerItems,
+    modelPickerTitle,
+    openModelPicker,
+    pasteClipboardImage,
+    recordHistory: recordPromptHistory,
+    setHistoryIndex,
+    setInputImages,
+    setPromptHistory,
+  } = composerController;
   const unsubscribeProcesses = processManager.subscribe(handleBackgroundProcessEvent);
   onCleanup(() => {
     unsubscribeProcesses();
@@ -259,7 +353,81 @@ export function App(props: AppProps = {}) {
   const permissionBroker = new ToolPermissionBroker();
   permissionBroker.subscribe((request) => setPendingChildPermission(request ?? null));
   const pausedAgentDeliveries = new Set<string>();
-  const continuationScheduler = new AgentContinuationScheduler(agentStore, deliverAgentResults, {
+  let agentManager!: AgentManager;
+  turnController = createTurnController({
+    rootDir: process.cwd(),
+    dangerouslySkipPermissions: props.dangerouslySkipPermissions === true,
+    busy,
+    setBusy,
+    providerConfigReady,
+    setProviderConfigReady,
+    loadProviderConfig: loadProviderConfigOnce,
+    permissionSettingsReady,
+    loadPermissionSettings: loadPermissionSettingsOnce,
+    activeModelCapabilities,
+    activeEngine,
+    setActiveEngine,
+    activeModel,
+    activeProviderSelection,
+    activeGeneration,
+    permissionMode,
+    shellExecEnabled,
+    sessionId,
+    setSessionId,
+    sessionPath,
+    setSessionPath,
+    conversation,
+    setConversation,
+    nextSessionParent,
+    setNextSessionParent,
+    setOutput,
+    setStatus,
+    messages,
+    setMessages,
+    agentCards,
+    setAgentCards,
+    setStreamingAssistant,
+    setStreamingReasoning,
+    lastDisplayedToolAssistantContent,
+    setLastDisplayedToolAssistantContent,
+    pendingGate,
+    setPendingGate,
+    pendingEngineSwitch,
+    setPendingEngineSwitch,
+    pendingUserQuestion,
+    setPendingUserQuestion,
+    pendingPermission,
+    setPendingPermission,
+    pendingChildPermission,
+    setQuestionSelected,
+    questionSelected,
+    questionFreeformText,
+    clearQuestionFreeform,
+    setGateFocus,
+    setGateFeedbackMode,
+    clearGateFeedback,
+    setSessionPicker,
+    pausedAgentDeliveries,
+    agentManager: () => agentManager,
+    permissionBroker,
+    runCancellable: (operation) => turnCancellation.run(operation),
+    handleAgentEvent,
+    beginUsageTurn,
+    publishTurnUsage,
+    recordIndependentAgentUsage,
+    recordActivity,
+    refreshArtifacts,
+    compactSession: (instructions) => sessionActions.compactSession(instructions),
+    executeLocalCommand: (prompt) => executeCommand(prompt, commandContext, builtinCommands),
+    recordPromptHistory,
+    applyComposerState,
+    setInputImages,
+    setHistoryIndex,
+    setPromptHistory,
+    applyConversationRewind: (result) => sessionActions.applyConversationRewind(result),
+  });
+  const { reportError } = turnController;
+  const continuationScheduler = new AgentContinuationScheduler(agentStore, turnController.deliverAgentResults, {
     isParentIdle: (parentSessionId) => sessionId() === parentSessionId
       && !pausedAgentDeliveries.has(parentSessionId)
       && !restoringSession()
@@ -270,124 +438,122 @@ export function App(props: AppProps = {}) {
       && !pendingPermission()
       && !pendingChildPermission(),
   });
-  const agentManager = new AgentManager(agentStore, runChildAgent, {
+  agentManager = new AgentManager(agentStore, runChildAgent, {
     onEvent: (event) => {
       handleAgentEvent(event);
       if (event.type === "agent_completed"
         && event.result.mode === "background"
         && event.result.status !== "cancelled") {
-        void continuationScheduler.notify(event.result.parentSessionId).catch(reportError);
+        void continuationScheduler.notify(event.result.parentSessionId).catch(turnController.reportError);
       }
     },
   });
+  const agentCommand = createAgentCommand({
+    rootDir: process.cwd(),
+    sessionId,
+    agentCards,
+    agentManager,
+    agentStore,
+    pausedDeliveries: pausedAgentDeliveries,
+    scheduler: continuationScheduler,
+    reportError,
+  });
+  const { resumeSession } = createSessionResumeController({
+    rootDir: process.cwd(),
+    dangerouslySkipPermissions: props.dangerouslySkipPermissions === true,
+    permissionSettingsReady,
+    loadPermissionSettings: loadPermissionSettingsOnce,
+    processManager,
+    agentStore,
+    agentCards,
+    setAgentCards,
+    permissionMode,
+    setPermissionMode,
+    applyProviderSelection,
+    setRestoringSession,
+    setSessionId,
+    setNextSessionParent,
+    setSessionPath,
+    setActiveEngine,
+    setConversation,
+    setLastTurnUsage,
+    setSessionUsage,
+    setOutput,
+    setSessionPicker,
+    setThinkingTier,
+    setReasoningDisplayMode,
+    setStatus,
+    setMessages,
+    setAssetDriftKey: (key) => { lastReportedAssetDriftKey = key; },
+    refreshArtifacts,
+    reportError: turnController.reportError,
+    setPendingGate,
+    setPendingEngineSwitch,
+    setPendingUserQuestion,
+    setPendingPermission,
+    setGateFocus,
+    setGateFeedbackMode,
+    setGateFeedback,
+    setGateFeedbackCursor,
+    setGateFeedbackKillBuffer,
+    setQuestionSelected,
+    setQuestionFreeformText,
+    setQuestionFreeformCursor,
+    setQuestionFreeformKillBuffer,
+  });
+  sessionActions = createSessionActionsController({
+    rootDir: process.cwd(),
+    sessionId,
+    activeEngine,
+    setActiveEngine,
+    activeProviderSelection,
+    activeGeneration,
+    providerConfigReady,
+    loadProviderConfig: loadProviderConfigOnce,
+    pendingGate,
+    setPendingGate,
+    pendingEngineSwitch,
+    setPendingEngineSwitch,
+    pendingUserQuestion,
+    setPendingUserQuestion,
+    pendingPermission,
+    setPendingPermission,
+    pendingChildPermission,
+    agentCards,
+    setConversation,
+    setMessages,
+    setThinkingTier,
+    setReasoningDisplayMode,
+    applyProviderSelection,
+    setOutput,
+    setNextSessionParent,
+    applyComposerState,
+    clearComposer,
+    setInputImages,
+    setHistoryIndex,
+    setLastTurnUsage,
+    setSessionUsage,
+    sessionPicker,
+    setSessionPicker,
+    setBusy,
+    setStatus,
+    recordActivity,
+    runCancellable: (operation) => turnCancellation.run(operation),
+    rewindReset: rewindController.reset,
+    refreshArtifacts,
+    resumeSession,
+  });
+  const {
+    compactSession,
+    handleSessionPickerKey,
+    resetRewindState,
+  } = sessionActions;
   createEffect(() => {
     const id = sessionId();
     const ready = !restoringSession() && !busy() && !pendingGate() && !pendingEngineSwitch() && !pendingUserQuestion() && !pendingPermission() && !pendingChildPermission();
     if (id && ready) void continuationScheduler.notify(id).catch(reportError);
   });
 
-  const inputShowsCommandHelp = createMemo(() => inputValue().startsWith("/"));
-  // Slash-command popup: open while the user is still typing the command
-  // token (input starts with "/" and has no space yet). Once `/model` reaches
-  // its arguments, the provider/model popup below takes over.
-  const commandMenuOpen = createMemo(() => inputShowsCommandHelp() && !inputValue().slice(1).includes(" "));
-  const commandMenuQuery = createMemo(() => inputValue().slice(1));
-  const commandMenuItems = createMemo(() => matchCommands(commandMenuQuery(), builtinCommands));
-  const [commandMenuSelected, setCommandMenuSelected] = createSignal(0);
-  createEffect(() => {
-    const count = commandMenuItems().length;
-    setCommandMenuSelected((selected) => clampCommandMenuSelection(selected, count));
-  });
-  // A filtered list has different row identities even when its length is the
-  // same. Reset on every query change so the cursor cannot stay attached to an
-  // unrelated row from the previous result set.
-  let previousCommandMenuQuery: string | null = null;
-  createEffect(() => {
-    const query = commandMenuOpen() ? commandMenuQuery() : null;
-    if (query !== previousCommandMenuQuery) setCommandMenuSelected(0);
-    previousCommandMenuQuery = query;
-  });
-  const modelArgumentDraft = createMemo(() => parseModelArgumentDraft(inputValue()));
-  const fixedArgumentDraft = createMemo(() => parseFixedArgumentDraft(inputValue()));
-  const agentArgumentDraft = createMemo(() => parseAgentArgumentDraft(inputValue()));
-  const commandArgumentMenuOpen = createMemo(() => modelArgumentDraft() !== null || fixedArgumentDraft() !== null || agentArgumentDraft() !== null);
-  const commandArgumentItems = createMemo<OptionItem[]>(() => {
-    const modelDraft = modelArgumentDraft();
-    if (modelDraft) {
-      const registry = providerRegistry();
-      if (!registry) return [];
-      const options = modelDraft.stage === "provider"
-        ? providerOptionItems(registry)
-        : modelOptionItems(registry, modelDraft.providerId);
-      return matchOptionItems(modelDraft.query, options);
-    }
-    const fixedDraft = fixedArgumentDraft();
-    if (fixedDraft) return matchOptionItems(fixedDraft.query, fixedArgumentOptions(fixedDraft.command));
-    const agentDraft = agentArgumentDraft();
-    if (!agentDraft) return [];
-    const handles: OptionItem[] = agentCards()
-      .filter((agent) => agent.parentSessionId === sessionId())
-      .map((agent) => ({
-        id: agent.handle,
-        label: agent.handle,
-        detail: `${agent.status} · ${agent.description}`,
-      }));
-    const options = agentDraft.stage === "command"
-      ? [
-        { id: "stop", label: "stop", detail: "Interrupt a running SubAgent" },
-        { id: "retry", label: "retry", detail: "Retry paused background-result delivery" },
-        ...handles,
-      ]
-      : handles.filter((item) => {
-        const agent = agentCards().find((candidate) => candidate.handle === item.id);
-        return agent?.status === "queued" || agent?.status === "running";
-      });
-    return matchOptionItems(agentDraft.query, options);
-  });
-  const [commandArgumentSelected, setCommandArgumentSelected] = createSignal(0);
-  createEffect(() => {
-    setCommandArgumentSelected((selected) => clampCommandMenuSelection(selected, commandArgumentItems().length));
-  });
-  let previousCommandArgumentKey: string | null = null;
-  createEffect(() => {
-    const modelDraft = modelArgumentDraft();
-    const fixedDraft = fixedArgumentDraft();
-    const agentDraft = agentArgumentDraft();
-    const key = modelDraft
-      ? `model:${modelDraft.stage}:${modelDraft.stage === "model" ? `${modelDraft.providerId}:` : ""}${modelDraft.query}`
-      : fixedDraft
-        ? `fixed:${fixedDraft.command}:${fixedDraft.query}`
-        : agentDraft
-          ? `agent:${agentDraft.stage}:${agentDraft.query}`
-        : null;
-    if (key !== previousCommandArgumentKey) setCommandArgumentSelected(0);
-    previousCommandArgumentKey = key;
-  });
-  // Items shown in the interactive model picker: providers first, then the
-  // chosen provider's models. Detail reuses the shared model formatter.
-  const modelPickerItems = createMemo<OptionItem[]>(() => {
-    const picker = modelPicker();
-    const registry = providerRegistry();
-    if (!picker || !registry) return [];
-    if (picker.step === "provider") {
-      return providerOptionItems(registry);
-    }
-    const provider = registry.providers.find((p) => p.id === picker.providerId);
-    if (!provider) return [];
-    return modelOptionItems(registry, provider.id);
-  });
-  const modelPickerTitle = (picker: ModelPickerState): string =>
-    picker.step === "provider" ? "Select provider" : `Select model · ${picker.providerId}`;
-
-  const composerInputWidth = createMemo(() => Math.max(8, dimensions().width - 4));
-  const inputVisualLines = createMemo(() => composerVisualLineCount(inputValue(), composerInputWidth()));
-  const composerPopupOpen = createMemo(() => commandMenuOpen() || commandArgumentMenuOpen());
-  const inputNeedsExpandedBottom = createMemo(() => composerPopupOpen() || inputVisualLines() > 1);
-  const decisionPanelMinHeight = createMemo(() => {
-    const pending = pendingUserQuestion();
-    if (pendingEngineSwitch()) return 10;
-    return pending ? questionPanelMinHeight(pending.question, questionSelected()) : 9;
-  });
   const layout = createMemo(() => resolveTuiLayout(
     dimensions().width,
     dimensions().height,
@@ -398,24 +564,6 @@ export function App(props: AppProps = {}) {
     rewindPicker() ? rewindPickerPanelHeight(rewindPicker()!) : 12,
   ));
   const composerPopupMaxRows = createMemo(() => Math.min(8, Math.max(1, layout().bottomHeight - 4)));
-  const activeGateRequest = createMemo(() => {
-    const gate = pendingGate();
-    if (gate) return gate.gate;
-    const engineSwitch = pendingEngineSwitch();
-    if (engineSwitch) return engineSwitchGateRequest(activeEngine(), engineSwitch.request);
-    return null;
-  });
-  const activePermissionRequest = createMemo(() => pendingPermission()?.request ?? pendingChildPermission() ?? undefined);
-
-  let lastCtrlCAt = 0;
-  const promptEscape = new PromptEscapeController();
-  let activeTurnSawResponse = false;
-  let activeTurnUsage = emptyUsageSummary();
-  let activeTurnAgentUsage = emptyUsageSummary();
-  let activeTurnUsagePublished = false;
-  let lastReportedAssetDriftKey: string | undefined;
-  let providerConfigLoad: Promise<void> | null = null;
-  let permissionSettingsLoad: Promise<void> | null = null;
 
   // On mount, detect existing sessions so the welcome line can offer resume.
   onMount(() => {
@@ -450,1810 +598,30 @@ export function App(props: AppProps = {}) {
     });
   });
 
-  useKeyboard((rawKey) => {
-    // Normalise once at the keypress entry point so every handler below sees
-    // canonical names. OpenTUI emits "up_arrow"/"down_arrow"/"return"; the
-    // pickers and composers expect "up"/"down"/"enter". applyComposerKey
-    // re-normalises harmlessly (the transform is idempotent).
-    const key = { ...rawKey, name: normalizeKeyName(rawKey.name) };
-    if (key.ctrl && key.name === "c") {
-      void copySelectionToClipboard(renderer).then((copied) => {
-        if (copied) {
-          renderer.clearSelection();
-          setStatus("selection copied");
-          lastCtrlCAt = 0;
-          return;
-        }
-        const now = Date.now();
-        if (now - lastCtrlCAt < 3000) {
-          process.nextTick(() => renderer.destroy());
-          return;
-        }
-        lastCtrlCAt = now;
-        setStatus("press Ctrl+C again to exit");
-      });
-      return;
-    }
-
-    // Ctrl+Q is the unconditional keyboard exit path. Handle it before modal
-    // pickers, whose routing intentionally owns every other key while active.
-    if (key.ctrl && key.name === "q") {
-      process.nextTick(() => renderer.destroy());
-      return;
-    }
-
-    if (rewindPicker()) {
-      if (rewindController.handleKey(key)) consumeKey(key);
-      return;
-    }
-
-    if (modelPicker()) {
-      if (handleModelPickerKey(key)) consumeKey(key);
-      return;
-    }
-
-    if (sessionPicker()) {
-      if (handleSessionPickerKey(key)) consumeKey(key);
-      return;
-    }
-
-    if (yoloConfirmStage()) {
-      if (handleYoloKey(key)) consumeKey(key);
-      return;
-    }
-
-    if (pendingUserQuestion()) {
-      if (handleQuestionKey(key)) consumeKey(key);
-      return;
-    }
-
-    if (pendingGate() || pendingEngineSwitch() || pendingPermission() || pendingChildPermission()) {
-      if (handleGateKey(key)) consumeKey(key);
-      return;
-    }
-
-    if (key.name?.toLowerCase() === "v" && (key.meta || key.option)) {
-      consumeKey(key);
-      void pasteClipboardImage();
-      return;
-    }
-
-    if (handleComposerKey(key)) {
-      consumeKey(key);
-      return;
-    }
-
-    if (key.name === "escape") {
-      handleEscapeAtPrompt();
-      consumeKey(key);
-    }
+  registerInputRouting({
+    renderer,
+    setStatus,
+    rewindPicker,
+    handleRewindKey: rewindController.handleKey,
+    modelPicker,
+    handleModelPickerKey,
+    sessionPicker,
+    handleSessionPickerKey,
+    yoloConfirmStage,
+    handleYoloKey,
+    pendingUserQuestion,
+    handleQuestionKey,
+    pendingGate,
+    pendingEngineSwitch,
+    pendingPermission,
+    pendingChildPermission,
+    handleGateKey,
+    pasteClipboardImage,
+    handleComposerKey,
+    handlePromptEscape: handleEscapeAtPrompt,
+    handleDecisionPaste,
+    insertComposerPaste,
   });
-
-  usePaste((event) => {
-    const text = new TextDecoder().decode(event.bytes);
-    if ((pendingGate() || pendingEngineSwitch() || pendingPermission() || pendingChildPermission()) && gateComposerIsActive(gateFocus(), gateFeedbackMode())) {
-      applyGateFeedbackState(insertComposerText(currentGateFeedbackState(), text));
-      event.preventDefault();
-      return;
-    }
-    if (pendingUserQuestion() && questionComposerIsActive(selectedQuestionOption())) {
-      applyQuestionFreeformState(insertComposerText(currentQuestionFreeformState(), text));
-      event.preventDefault();
-      return;
-    }
-    if (pendingGate() || pendingEngineSwitch() || pendingUserQuestion() || pendingPermission() || pendingChildPermission() || yoloConfirmStage() || sessionPicker() || rewindPicker()) return;
-    applyComposerState(insertComposerText(currentComposerState(), text));
-    event.preventDefault();
-  });
-
-  async function pasteClipboardImage(): Promise<void> {
-    setStatus("reading clipboard image");
-    try {
-      const bytes = await readImageFromClipboard();
-      if (!bytes) throw new Error("No supported image was found in the clipboard.");
-      const image = await ingestImageBytes(process.cwd(), bytes, {
-        source: "clipboard",
-        filename: "clipboard.png",
-      });
-      const number = inputElements().filter((element) => element.type === "image").length + 1;
-      const withImage = insertComposerImage(currentComposerState(), image.id, `[Image #${number}]`);
-      applyComposerState(insertComposerText(withImage, " "));
-      setInputImages((current) => [...current, image]);
-      setHistoryIndex(null);
-      setStatus(activeModelCapabilities()?.vision === true
-        ? `attached Image #${number}`
-        : `attached Image #${number}; current model does not declare vision support`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      setStatus(`image paste failed: ${message}`);
-      recordActivity({ kind: "system", text: `image paste failed: ${message}` });
-    }
-  }
-
-  function handleGateKey(key: TuiKeyEvent): boolean {
-    if (busy() && !pendingChildPermission()) return false;
-    const focusOrder = currentGateFocusOrder();
-    if (gateComposerIsActive(gateFocus(), gateFeedbackMode()) && key.name !== "tab" && key.name !== "escape") {
-      const result = applyComposerKey(currentGateFeedbackState(), key);
-      if (result.handled) {
-        applyGateFeedbackState(result.state);
-        if (result.action?.type === "submit") {
-          const resolution = gateResolutionFromState(gateFocus(), result.action.value);
-          if (pendingPermission()) {
-            void submitPermissionResolution(permissionResolutionFromGate(resolution));
-          } else if (pendingChildPermission()) {
-            submitChildPermissionResolution(permissionResolutionFromGate(resolution));
-          } else if (pendingEngineSwitch()) {
-            void submitEngineSwitchResolution(resolution, { summarizeContext: gateFocus() === "confirm-summary" });
-          } else {
-            void submitGateResolution(resolution);
-          }
-        } else if (result.action?.type === "history_up") {
-          moveGateFocus(-1, focusOrder);
-        } else if (result.action?.type === "history_down") {
-          moveGateFocus(1, focusOrder);
-        }
-        return true;
-      }
-    }
-    if (key.name === "up" || (key.ctrl && key.name === "p")) {
-      moveGateFocus(-1, focusOrder);
-      return true;
-    }
-    if (key.name === "down" || (key.ctrl && key.name === "n")) {
-      moveGateFocus(1, focusOrder);
-      return true;
-    }
-    if (key.name === "tab") {
-      const target = gateFocus();
-      if (target === "reject" || target === "confirm-summary") return true;
-      setGateFeedbackMode((prev) => (prev === target ? null : target));
-      setGateFeedback("");
-      setGateFeedbackCursor(0);
-      setGateFeedbackKillBuffer(undefined);
-      return true;
-    }
-    if (key.name === "return" || key.name === "enter") {
-      const resolution = gateResolutionFromState(gateFocus(), gateFeedback());
-      if (pendingPermission()) {
-        void submitPermissionResolution(permissionResolutionFromGate(resolution));
-      } else if (pendingChildPermission()) {
-        submitChildPermissionResolution(permissionResolutionFromGate(resolution));
-      } else if (pendingEngineSwitch()) {
-        void submitEngineSwitchResolution(resolution, { summarizeContext: gateFocus() === "confirm-summary" });
-      } else {
-        void submitGateResolution(resolution);
-      }
-      return true;
-    }
-    if (key.name === "escape") {
-      // Cancel = retreat to rejection/discussion without committing.
-      setGateFeedbackMode(null);
-      setGateFeedback("");
-      setGateFeedbackCursor(0);
-      setGateFeedbackKillBuffer(undefined);
-      setGateFocus("reject");
-      return true;
-    }
-    return false;
-  }
-
-  function handleYoloKey(key: TuiKeyEvent): boolean {
-    if (key.name === "up" || key.name === "down" || (key.ctrl && (key.name === "p" || key.name === "n"))) {
-      setGateFocus((current) => current === "confirm" ? "reject" : "confirm");
-      return true;
-    }
-    if (key.name === "escape") {
-      setGateFocus("reject");
-      setYoloConfirmStage(null);
-      setStatus(`permission mode ${permissionMode()}`);
-      return true;
-    }
-    if (key.name === "return" || key.name === "enter") {
-      if (gateFocus() === "reject") {
-        setYoloConfirmStage(null);
-        setStatus(`permission mode ${permissionMode()}`);
-      } else if (yoloConfirmStage() === 1) {
-        setYoloConfirmStage(2);
-      } else {
-        void applyPermissionMode("YOLO");
-        setYoloConfirmStage(null);
-      }
-      return true;
-    }
-    return false;
-  }
-
-  function currentGateFocusOrder(): GateFocusTarget[] {
-    return pendingEngineSwitch() ? engineSwitchGateFocusOrder : gateFocusOrder;
-  }
-
-  function moveGateFocus(delta: -1 | 1, order = currentGateFocusOrder()): void {
-    const current = gateFocus();
-    const idx = Math.max(0, order.indexOf(current));
-    setGateFocus(order[(idx + delta + order.length) % order.length]);
-  }
-
-  function handleEscapeAtPrompt(): void {
-    const draft = inputValue();
-    switch (promptEscape.press({ busy: busy(), draft, hasSession: Boolean(sessionId()) })) {
-      case "interrupt":
-        if (turnCancellation.abort()) setStatus("interrupting request");
-        return;
-      case "clear":
-        if (draft.trim() || inputImages().length > 0) {
-          recordPromptHistory(draft, inputElements(), inputImages());
-        }
-        clearComposer();
-        setStatus("input cleared");
-        return;
-      case "arm-clear":
-        setStatus("Esc again to clear");
-        setTimeout(() => {
-          if (status() === "Esc again to clear") setStatus("ready");
-        }, 1000);
-        return;
-      case "rewind":
-        void rewindController.open();
-        return;
-      case "arm-rewind":
-      case "noop":
-        return;
-    }
-  }
-
-  function handleQuestionKey(key: TuiKeyEvent): boolean {
-    const pending = pendingUserQuestion();
-    if (!pending || busy()) return false;
-    const selectedOption = pending.question.options[questionSelected()];
-    if (questionComposerIsActive(selectedOption)) {
-      if (key.name === "escape") {
-        setQuestionFreeformText("");
-        setQuestionFreeformCursor(0);
-        setQuestionFreeformKillBuffer(undefined);
-        setStatus(`question pending: ${pending.question.header}`);
-        return true;
-      }
-      const result = applyComposerKey(currentQuestionFreeformState(), key);
-      if (result.handled) {
-        applyQuestionFreeformState(result.state);
-        if (result.action?.type === "submit") {
-          submitUserQuestionFreeform(result.action.value);
-        } else if (result.action?.type === "history_up") {
-          setQuestionSelected((prev) => (prev - 1 + pending.question.options.length) % pending.question.options.length);
-        } else if (result.action?.type === "history_down") {
-          setQuestionSelected((prev) => (prev + 1) % pending.question.options.length);
-        }
-        return true;
-      }
-      return false;
-    }
-    if (key.name === "up" || (key.ctrl && key.name === "p")) {
-      setQuestionSelected((prev) => (prev - 1 + pending.question.options.length) % pending.question.options.length);
-      return true;
-    }
-    if (key.name === "down" || (key.ctrl && key.name === "n")) {
-      setQuestionSelected((prev) => (prev + 1) % pending.question.options.length);
-      return true;
-    }
-    if (key.name === "return" || key.name === "enter") {
-      void submitUserQuestionAnswer(questionSelected());
-      return true;
-    }
-    return false;
-  }
-
-  function handleComposerKey(key: TuiKeyEvent): boolean {
-    if (commandMenuOpen() && handleCommandMenuKey(key)) return true;
-    if (commandArgumentMenuOpen() && handleCommandArgumentMenuKey(key)) return true;
-    const result = applyComposerKey(currentComposerState(), key, { columns: composerInputWidth() });
-    if (!result.handled) return false;
-    applyComposerState(result.state);
-
-    if (result.action?.type === "submit") {
-      if (busy()) {
-        setStatus("request in flight; draft kept");
-        return true;
-      }
-      const submitted = result.action.value;
-      if (submitted.trim().length === 0) return true;
-      const submittedImages = imagesForElements(result.action.elements ?? []);
-      if (submittedImages.length > 0 && activeModelCapabilities()?.vision !== true) {
-        setStatus("current model does not declare vision support; draft kept");
-        return true;
-      }
-      clearComposer();
-      void submitPrompt(submitted, submittedImages, result.action.elements ?? []);
-      return true;
-    }
-    if (result.action?.type === "history_up") {
-      if (!busy()) recallPromptHistory(-1);
-      return true;
-    }
-    if (result.action?.type === "history_down") {
-      if (historyIndex() !== null && !busy()) recallPromptHistory(1);
-      return true;
-    }
-    setHistoryIndex(null);
-    return true;
-  }
-
-  // Navigate the slash-command popup. Returns true when it consumes the key
-  // (so handleComposerKey skips the normal composer path); false for printable
-  // chars so they flow into the composer and refilter the menu.
-  function handleCommandMenuKey(key: TuiKeyEvent): boolean {
-    const name = normalizeKeyName(key.name);
-    if (name === "up" || (key.ctrl && name === "p")) {
-      setCommandMenuSelected((selected) => moveCommandMenuSelection(selected, -1, commandMenuItems().length));
-      return true;
-    }
-    if (name === "down" || (key.ctrl && name === "n")) {
-      setCommandMenuSelected((selected) => moveCommandMenuSelection(selected, 1, commandMenuItems().length));
-      return true;
-    }
-    if (name === "tab") {
-      const cmd = commandMenuItems()[commandMenuSelected()];
-      if (cmd) completeCommandName(cmd.name);
-      return true;
-    }
-    if (name === "return" || name === "enter") {
-      const cmd = commandMenuItems()[commandMenuSelected()];
-      if (!cmd) return true;
-      // Typing the full command name and pressing Enter runs it; a partial
-      // token completes the name instead. Tab always just completes.
-      if (inputValue() === `/${cmd.name}`) {
-        if (busy()) {
-          setStatus("request in flight; draft kept");
-          return true;
-        }
-        clearComposer();
-        void submitPrompt(`/${cmd.name}`);
-      } else {
-        completeCommandName(cmd.name);
-      }
-      return true;
-    }
-    if (name === "escape") {
-      clearComposer();
-      return true;
-    }
-    return false;
-  }
-
-  // Replace the draft with "/<name> " and drop into argument mode; the menu
-  // closes itself because the value now contains a space.
-  function completeCommandName(name: string) {
-    const value = `/${name} `;
-    applyComposerState(setComposerValue(value));
-    setInputImages([]);
-    setCommandMenuSelected(0);
-    setHistoryIndex(null);
-  }
-
-  function handleCommandArgumentMenuKey(key: TuiKeyEvent): boolean {
-    const name = normalizeKeyName(key.name);
-    const items = commandArgumentItems();
-    if (name === "up" || (key.ctrl && name === "p")) {
-      setCommandArgumentSelected((selected) => moveCommandMenuSelection(selected, -1, items.length));
-      return true;
-    }
-    if (name === "down" || (key.ctrl && name === "n")) {
-      setCommandArgumentSelected((selected) => moveCommandMenuSelection(selected, 1, items.length));
-      return true;
-    }
-    if (name === "tab") {
-      completeSelectedCommandArgument();
-      return true;
-    }
-    if (name === "enter" || name === "return") {
-      const item = items[commandArgumentSelected()];
-      if (!item) return false;
-      const completed = selectedCommandArgumentValue(item);
-      if (!completed) return false;
-      const executable = completed.trimEnd();
-      if (inputValue() === executable) submitCompletedCommandArgument(executable);
-      else applyCompletedCommandArgument(completed);
-      return true;
-    }
-    if (name === "escape") {
-      clearComposer();
-      return true;
-    }
-    return false;
-  }
-
-  function completeSelectedCommandArgument() {
-    const item = commandArgumentItems()[commandArgumentSelected()];
-    const completed = item ? selectedCommandArgumentValue(item) : null;
-    if (completed) applyCompletedCommandArgument(completed);
-  }
-
-  function selectedCommandArgumentValue(item: OptionItem): string | null {
-    const modelDraft = modelArgumentDraft();
-    if (modelDraft) return completeModelArgument(modelDraft, item);
-    const fixedDraft = fixedArgumentDraft();
-    if (fixedDraft) return completeFixedArgument(fixedDraft, item);
-    const agentDraft = agentArgumentDraft();
-    return agentDraft ? completeAgentArgument(agentDraft, item) : null;
-  }
-
-  function submitCompletedCommandArgument(value: string) {
-    if (busy()) {
-      setStatus("request in flight; draft kept");
-      return;
-    }
-    clearComposer();
-    void submitPrompt(value);
-  }
-
-  function applyCompletedCommandArgument(value: string) {
-    applyComposerState(setComposerValue(value));
-    setInputImages([]);
-    setCommandArgumentSelected(0);
-    setHistoryIndex(null);
-  }
-
-  function recallPromptHistory(direction: -1 | 1) {
-    const history = promptHistory();
-    if (history.length === 0) return;
-    const current = historyIndex();
-    const next = current === null
-      ? history.length - 1
-      : Math.max(0, Math.min(history.length - 1, current + direction));
-    setHistoryIndex(next);
-    const entry = history[next];
-    if (!entry) return;
-    setInputValue(entry.value);
-    setInputCursor(entry.value.length);
-    setInputElements(entry.elements.map((element) => ({ ...element })));
-    setInputImages(entry.images.map((image) => ({ ...image })));
-  }
-
-  function imagesForElements(elements: ComposerElement[]): VesicleImageAttachment[] {
-    const byId = new Map(inputImages().map((image) => [image.id, image]));
-    return elements.flatMap((element) => {
-      const image = byId.get(element.attachmentId);
-      return image ? [{ ...image }] : [];
-    });
-  }
-
-  function recordPromptHistory(
-    value: string,
-    elements: ComposerElement[],
-    images: VesicleImageAttachment[],
-  ): void {
-    const entry: PromptHistoryEntry = {
-      value,
-      elements: elements.map((element) => ({ ...element })),
-      images: images.map((image) => ({ ...image })),
-    };
-    setPromptHistory((previous) => [
-      ...previous.filter((candidate) => candidate.value !== value),
-      entry,
-    ].slice(-50));
-  }
-
-  function resetRewindState(): void {
-    rewindController.reset();
-    setNextSessionParent(null);
-  }
-
-  async function applyConversationRewind(result: ConversationRewind): Promise<void> {
-    const snapshot = result.snapshot;
-    setConversation(vesicleMessagesFromResumed(snapshot.messages));
-    setMessages(displayTranscriptFromSnapshot(snapshot.messages, agentCards()));
-    setActiveEngine(snapshot.engine ?? "etl");
-    setThinkingTier(snapshot.reasoningTier);
-    setReasoningDisplayMode(snapshot.reasoningDisplayMode ?? "collapsed");
-    if (snapshot.providerSelection) {
-      try {
-        await applyProviderSelection(snapshot.providerSelection);
-      } catch (error) {
-        recordActivity({
-          kind: "system",
-          text: `rewind kept current provider: ${error instanceof Error ? error.message : String(error)}`,
-        });
-      }
-    }
-    setPendingGate(null);
-    setPendingEngineSwitch(null);
-    setPendingUserQuestion(null);
-    setPendingPermission(null);
-    setOutput("");
-    setNextSessionParent({ uuid: result.parentUuid });
-    const images = result.images ?? [];
-    applyComposerState({
-      value: result.prompt,
-      cursor: result.prompt.length,
-      elements: composerElementsForImages(result.prompt, images),
-    });
-    setInputImages(images.map((image) => ({ ...image })));
-    setHistoryIndex(null);
-    await refreshArtifacts();
-    setStatus("conversation rewound");
-  }
-
-  async function compactSession(instructions?: string): Promise<{ summary: string; messagesSummarized: number }> {
-    const id = sessionId();
-    if (!id) throw new Error("No active session to compact.");
-    if (pendingGate() || pendingEngineSwitch() || pendingUserQuestion() || pendingPermission() || pendingChildPermission()) {
-      throw new Error("Resolve the pending gate, engine switch, question, or permission before compacting.");
-    }
-    if (!providerConfigReady()) await loadProviderConfigOnce();
-
-    setBusy(true);
-    setStatus("compacting conversation");
-    recordActivity({ kind: "provider", text: "compacting conversation" });
-    try {
-      const outcome = await turnCancellation.run((signal) => compactConversation({
-        rootDir: process.cwd(),
-        sessionId: id,
-        engine: activeEngine(),
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        instructions,
-        signal,
-      }));
-      if (outcome.kind === "interrupted") throw new Error("Compaction canceled.");
-      const result = outcome.value;
-      const snapshot = result.snapshot;
-      setConversation(vesicleMessagesFromResumed(snapshot.messages));
-      setMessages(displayTranscriptFromSnapshot(snapshot.messages, agentCards()));
-      setLastTurnUsage(latestTurnUsage(snapshot.messages));
-      setSessionUsage(sumSessionUsage(snapshot.messages));
-      setOutput("");
-      setNextSessionParent({ uuid: result.parentUuid });
-      setPendingGate(null);
-      setPendingEngineSwitch(null);
-      setPendingUserQuestion(null);
-      setPendingPermission(null);
-      setSessionPicker(null);
-      rewindController.reset();
-      clearComposer();
-      setHistoryIndex(null);
-      setStatus(`compacted ${result.messagesSummarized} messages`);
-      recordActivity({ kind: "system", text: `compacted ${result.messagesSummarized} messages` });
-      return { summary: result.summary, messagesSummarized: result.messagesSummarized };
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  function handleSessionPickerKey(key: TuiKeyEvent): boolean {
-    const picker = sessionPicker();
-    if (!picker) return false;
-
-    if (key.name === "up" || (key.ctrl && key.name === "p")) {
-      setSessionPicker({
-        ...picker,
-        selected: (picker.selected - 1 + picker.sessions.length) % picker.sessions.length,
-      });
-      return true;
-    }
-    if (key.name === "down" || (key.ctrl && key.name === "n")) {
-      setSessionPicker({
-        ...picker,
-        selected: (picker.selected + 1) % picker.sessions.length,
-      });
-      return true;
-    }
-    if (key.name === "return" || key.name === "enter") {
-      const target = picker.sessions[picker.selected];
-      if (target) void resumeSession(target);
-      return true;
-    }
-    if (key.name === "escape") {
-      setSessionPicker(null);
-      setStatus("resume cancelled");
-      return true;
-    }
-    return false;
-  }
-
-  // Two-step model picker: provider step → model step → commit. Esc backs out
-  // of the model step to the provider step, or closes from the provider step.
-  function handleModelPickerKey(key: TuiKeyEvent): boolean {
-    const picker = modelPicker();
-    if (!picker) return false;
-    if (modelPickerBusy()) return true;
-    const items = modelPickerItems();
-    if (items.length === 0) return false;
-
-    if (key.name === "up" || (key.ctrl && key.name === "p")) {
-      setModelPicker({ ...picker, selected: (picker.selected - 1 + items.length) % items.length });
-      return true;
-    }
-    if (key.name === "down" || (key.ctrl && key.name === "n")) {
-      setModelPicker({ ...picker, selected: (picker.selected + 1) % items.length });
-      return true;
-    }
-    if (key.name === "return" || key.name === "enter") {
-      const item = items[picker.selected];
-      if (!item) return true;
-      if (picker.step === "provider") {
-        setModelPicker({ step: "model", providerId: item.id, selected: 0 });
-      } else {
-        setModelPickerBusy(true);
-        setStatus("switching provider/model");
-        void commitModelPicker(picker.providerId ?? "", item.id);
-      }
-      return true;
-    }
-    if (key.name === "escape") {
-      if (picker.step === "model") {
-        setModelPicker({ step: "provider", providerId: null, selected: 0 });
-      } else {
-        setModelPicker(null);
-        setStatus("model switch cancelled");
-      }
-      return true;
-    }
-    return false;
-  }
-
-  async function commitModelPicker(providerId: string, modelId: string) {
-    try {
-      const selection = await applyProviderSelection({ provider: providerId, model: modelId });
-      await persistProviderSwitch(selection);
-      setMessages((prev) => [...prev, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
-    } catch (error) {
-      reportError(error);
-    } finally {
-      setModelPicker(null);
-      setModelPickerBusy(false);
-    }
-  }
-
-  async function openModelPicker() {
-    try {
-      await ensureProviderRegistry();
-      setModelPickerBusy(false);
-      setModelPicker({ step: "provider", providerId: null, selected: 0 });
-    } catch (error) {
-      reportError(error);
-    }
-  }
-
-  function consumeKey(key: TuiKeyEvent) {
-    key.preventDefault?.();
-    key.stopPropagation?.();
-  }
-
-  function currentComposerState(): ComposerState {
-    return {
-      value: inputValue(),
-      cursor: inputCursor(),
-      ...(inputKillBuffer() ? { killBuffer: inputKillBuffer() } : {}),
-      ...(inputElements().length ? { elements: inputElements() } : {}),
-    };
-  }
-
-  function applyComposerState(state: ComposerState) {
-    setInputValue(state.value);
-    setInputCursor(state.cursor);
-    setInputKillBuffer(state.killBuffer);
-    const elements = state.elements ?? [];
-    setInputElements(elements);
-    const ids = new Set(elements.map((element) => element.attachmentId));
-    setInputImages((current) => current.filter((image) => ids.has(image.id)));
-  }
-
-  function clearComposer() {
-    applyComposerState(setComposerValue(""));
-    setInputImages([]);
-  }
-
-  function selectedQuestionOption() {
-    const pending = pendingUserQuestion();
-    return pending?.question.options[questionSelected()];
-  }
-
-  function currentGateFeedbackState(): ComposerState {
-    return {
-      value: gateFeedback(),
-      cursor: gateFeedbackCursor(),
-      ...(gateFeedbackKillBuffer() ? { killBuffer: gateFeedbackKillBuffer() } : {}),
-    };
-  }
-
-  function applyGateFeedbackState(state: ComposerState) {
-    setGateFeedback(state.value);
-    setGateFeedbackCursor(state.cursor);
-    setGateFeedbackKillBuffer(state.killBuffer);
-  }
-
-  function currentQuestionFreeformState(): ComposerState {
-    return {
-      value: questionFreeformText(),
-      cursor: questionFreeformCursor(),
-      ...(questionFreeformKillBuffer() ? { killBuffer: questionFreeformKillBuffer() } : {}),
-    };
-  }
-
-  function applyQuestionFreeformState(state: ComposerState) {
-    setQuestionFreeformText(state.value);
-    setQuestionFreeformCursor(state.cursor);
-    setQuestionFreeformKillBuffer(state.killBuffer);
-  }
-
-  const submitPrompt = async (
-    value: string,
-    images: VesicleImageAttachment[] = [],
-    elements: ComposerElement[] = [],
-  ) => {
-    const prompt = value.trim();
-    if (!prompt || busy()) return;
-
-    // Slash commands for session management. These never hit the provider.
-    if (prompt.startsWith("/") && images.length === 0) {
-      try {
-        await executeCommand(prompt, commandContext, builtinCommands);
-      } catch (error) {
-        reportError(error);
-      }
-      return;
-    }
-
-    if (!providerConfigReady()) {
-      setStatus("loading provider config");
-      try {
-        await loadProviderConfigOnce();
-      } catch (error) {
-        setProviderConfigReady(true);
-        reportError(error);
-        return;
-      }
-    }
-    if (!permissionSettingsReady()) {
-      setStatus("loading permission settings");
-      try {
-        await loadPermissionSettingsOnce();
-      } catch (error) {
-        reportError(error);
-        return;
-      }
-    }
-
-    if (images.length > 0 && activeModelCapabilities()?.vision !== true) {
-      applyComposerState({ value, cursor: value.length, elements: elements.map((element) => ({ ...element })) });
-      setInputImages(images.map((image) => ({ ...image })));
-      setStatus("current model does not declare vision support; draft restored");
-      return;
-    }
-
-    recordPromptHistory(value, elements, images);
-    if (sessionId()) pausedAgentDeliveries.delete(sessionId()!);
-    setHistoryIndex(null);
-    setSessionPicker(null);
-    setLastDisplayedToolAssistantContent(null);
-    setBusy(true);
-    setStatus("sending request");
-    recordActivity({ kind: "provider", text: "sending provider request" });
-    const requestMessages: VesicleMessage[] = [
-      ...conversation(),
-      { role: "user", content: prompt, ...(images.length ? { images } : {}) },
-    ];
-    setMessages((prev) => [...prev, { role: "user", content: prompt, ...(images.length ? { images } : {}) }]);
-    const branchParent = nextSessionParent();
-    setNextSessionParent(null);
-    activeTurnSawResponse = false;
-    beginUsageTurn();
-
-    try {
-      const outcome = await turnCancellation.run((signal) => runPrompt({
-        input: prompt,
-        engine: activeEngine(),
-        sessionId: sessionId(),
-        ...(branchParent ? { sessionParentUuid: branchParent.uuid } : {}),
-        messages: requestMessages,
-        ...(images.length ? { images } : {}),
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        permission: {
-          mode: permissionMode(),
-          ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}),
-          shellExecEnabled: shellExecEnabled(),
-        },
-        signal,
-        onEvent: handleAgentEvent,
-        agentManager,
-        permissionBroker,
-      }));
-      if (outcome.kind === "interrupted") {
-        if (!activeTurnSawResponse) await restoreInterruptedPrompt(value, images, elements);
-        handleInterruptedTurn();
-      } else {
-        handleResult(outcome.value, requestMessages);
-      }
-    } catch (error) {
-      if (!activeTurnSawResponse) {
-        await restoreInterruptedPrompt(value, images, elements).catch(() => undefined);
-      }
-      reportError(error);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  async function deliverAgentResults(parentSessionId: string, entries: AgentInboxEntry[], packet: string): Promise<void> {
-    if (sessionId() !== parentSessionId || busy() || pendingGate() || pendingEngineSwitch() || pendingUserQuestion() || pendingPermission() || pendingChildPermission()) {
-      throw new AgentDeliveryDeferred();
-    }
-    setBusy(true);
-    try {
-      setAgentCards((cards) => setAgentDeliveryState(cards, entries.map((entry) => entry.runId), "integrating", "integrating result into parent"));
-      setStatus(`integrating ${entries.length} SubAgent result${entries.length === 1 ? "" : "s"}`);
-      recordActivity({ kind: "agent", text: `delivering ${entries.length} background result${entries.length === 1 ? "" : "s"}` });
-      setMessages((current) => [...current, {
-        role: "system",
-        content: `Background SubAgent${entries.length === 1 ? "" : "s"} completed: ${entries.map((entry) => `${entry.description} (${entry.status})`).join(", ")}.`,
-      }]);
-      const requestMessages: VesicleMessage[] = [...conversation(), { role: "user", content: packet }];
-      activeTurnSawResponse = false;
-      beginUsageTurn();
-      for (const entry of entries) {
-        if (entry.usage) recordIndependentAgentUsage(entry.usage);
-      }
-      const childUsage = combineIndependentUsage(entries.map((entry) => entry.usage));
-      const inboxIds = entries.map((entry) => entry.inboxId).sort();
-      const persistedDelivery = (await loadSessionSnapshot(process.cwd(), parentSessionId, {
-        synthesizeDanglingToolResults: false,
-      })).records.find((record) => record.role === "user"
-        && record.metadata?.kind === "subagent-results"
-        && sameStringSet(record.metadata?.inboxIds, inboxIds));
-      const outcome = await turnCancellation.run((signal) => runPrompt({
-        input: packet,
-        engine: activeEngine(),
-        sessionId: parentSessionId,
-        messages: requestMessages,
-        inputMetadata: {
-          kind: "subagent-results",
-          inboxIds,
-          ...(childUsage ? { usage: childUsage } : {}),
-        },
-        ...(persistedDelivery ? { prePersistedInputUuid: persistedDelivery.uuid } : {}),
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        permission: {
-          mode: permissionMode(),
-          ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}),
-          shellExecEnabled: shellExecEnabled(),
-        },
-        signal,
-        onEvent: handleAgentEvent,
-        agentManager,
-        permissionBroker,
-      }));
-      if (outcome.kind === "interrupted") {
-        handleInterruptedTurn();
-        throw new Error("SubAgent result delivery was interrupted.");
-      }
-      handleResult(outcome.value, requestMessages);
-      setAgentCards((cards) => setAgentDeliveryState(cards, entries.map((entry) => entry.runId), "integrated", "result integrated"));
-    } catch (error) {
-      setAgentCards((cards) => setAgentDeliveryState(cards, entries.map((entry) => entry.runId), "pending", "integration paused; use /agents retry or send input"));
-      pausedAgentDeliveries.add(parentSessionId);
-      throw error;
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  const submitPermissionResolution = async (resolution: PermissionResolution) => {
-    const pending = pendingPermission();
-    if (!pending || busy()) return;
-    setBusy(true);
-    setStatus(`resolving permission: ${resolution.decision}`);
-    recordActivity({ kind: "tool", text: `${resolution.decision} ${pending.request.toolName}` });
-    setPendingPermission(null);
-    setGateFeedbackMode(null);
-    setGateFeedback("");
-    setGateFeedbackCursor(0);
-    setGateFeedbackKillBuffer(undefined);
-    beginUsageTurn();
-    try {
-      const outcome = await turnCancellation.run((signal) => resolvePermission({
-        engine: pending.engine,
-        sessionId: pending.sessionId,
-        messages: pending.messages,
-        request: pending.request,
-        remainingToolCalls: pending.remainingToolCalls,
-        deferredAgentPermissions: pending.deferredAgentPermissions,
-        resolution,
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        permission: {
-          mode: permissionMode(),
-          ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}),
-          shellExecEnabled: shellExecEnabled(),
-        },
-        signal,
-        onEvent: handleAgentEvent,
-        agentManager,
-        permissionBroker,
-      }));
-      if (outcome.kind === "interrupted") {
-        await reconcilePermissionAfterContinuationFailure(pending);
-        handleInterruptedTurn();
-      } else {
-        handleResult(outcome.value, pending.messages);
-      }
-    } catch (error) {
-      await reconcilePermissionAfterContinuationFailure(pending);
-      reportError(error);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  async function reconcilePermissionAfterContinuationFailure(pending: PendingPermissionState): Promise<void> {
-    try {
-      const snapshot = await loadSessionSnapshot(process.cwd(), pending.sessionId, {
-        synthesizeDanglingToolResults: false,
-      });
-      if (snapshot.pendingPermission?.id === pending.request.id) {
-        setPendingPermission(pending);
-        return;
-      }
-      setPendingPermission(null);
-      setConversation(vesicleMessagesFromResumed(snapshot.messages));
-      setMessages(displayTranscriptFromSnapshot(snapshot.messages, agentCards()));
-      setStatus("permission resolved; provider continuation stopped");
-    } catch {
-      setPendingPermission(pending);
-    }
-  }
-
-  function submitChildPermissionResolution(resolution: PermissionResolution): void {
-    const request = pendingChildPermission();
-    if (!request) return;
-    if (!permissionBroker.resolve(request.id, resolution)) return;
-    setGateFeedbackMode(null);
-    setGateFeedback("");
-    setGateFeedbackCursor(0);
-    setGateFeedbackKillBuffer(undefined);
-    setStatus(`${resolution.decision} ${request.agent?.handle ?? "SubAgent"} ${request.toolName}`);
-    recordActivity({
-      kind: "agent",
-      text: `${resolution.decision} ${request.agent?.handle ?? "SubAgent"} ${request.toolName}`,
-    });
-  }
-
-  const submitGateResolution = async (resolution: GateResolution) => {
-    const gate = pendingGate();
-    if (!gate || busy()) return;
-
-    setBusy(true);
-    setStatus(`resolving gate: ${resolution.decision}`);
-    recordActivity({ kind: "gate", text: `resolving ${gate.gate.gate} as ${resolution.decision}` });
-    setPendingGate(null);
-    setGateFeedbackMode(null);
-    setGateFeedback("");
-    setGateFeedbackCursor(0);
-    setGateFeedbackKillBuffer(undefined);
-    setMessages((prev) => [
-      ...prev,
-      { role: "user", content: `[gate:${gate.gate.gate}] ${resolution.decision}${resolution.feedback ? ` — ${resolution.feedback}` : ""}` },
-    ]);
-    beginUsageTurn();
-
-    try {
-      const outcome = await turnCancellation.run((signal) => resolveGate({
-        engine: gate.engine,
-        sessionId: gate.sessionId,
-        messages: gate.messages,
-        toolCallId: gate.toolCallId,
-        gate: gate.gate,
-        resolution,
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        permission: { mode: permissionMode(), shellExecEnabled: shellExecEnabled(), ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}) },
-        signal,
-        onEvent: handleAgentEvent,
-        agentManager,
-        permissionBroker,
-      }));
-      if (outcome.kind === "interrupted") {
-        setPendingGate(gate);
-        handleInterruptedTurn();
-      } else {
-        handleResult(outcome.value, gate.messages);
-      }
-    } catch (error) {
-      setPendingGate(gate);
-      reportError(error);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const submitEngineSwitchResolution = async (
-    resolution: GateResolution,
-    options: { summarizeContext?: boolean } = {},
-  ) => {
-    const pending = pendingEngineSwitch();
-    if (!pending || busy()) return;
-    const summarizeContext = resolution.decision === "confirm" && options.summarizeContext === true;
-    let switchApplied = false;
-
-    setBusy(true);
-    setStatus(summarizeContext ? "resolving engine switch with summary" : `resolving engine switch: ${resolution.decision}`);
-    recordActivity({ kind: "gate", text: `resolving engine switch to ${pending.request.targetEngine} as ${summarizeContext ? "confirm-summary" : resolution.decision}` });
-    setPendingEngineSwitch(null);
-    setGateFeedbackMode(null);
-    setGateFeedback("");
-    setGateFeedbackCursor(0);
-    setGateFeedbackKillBuffer(undefined);
-    setMessages((prev) => [
-      ...prev,
-      { role: "user", content: `[engine-switch:${pending.request.targetEngine}] ${resolution.decision}${resolution.feedback ? ` — ${resolution.feedback}` : ""}` },
-    ]);
-    // Confirming an engine switch is host-only: resolveEngineSwitch writes the
-    // tool result and engine metadata without calling the provider, so it
-    // should not clear the previous provider turn's token telemetry. Rejection
-    // does call the current engine again and therefore starts a new
-    // measured turn.
-    if (resolution.decision !== "confirm") beginUsageTurn();
-
-    try {
-      const outcome = await turnCancellation.run((signal) => resolveEngineSwitch({
-        engine: pending.profile?.id ?? activeEngine(),
-        sessionId: pending.sessionId,
-        messages: pending.messages,
-        toolCallId: pending.toolCallId,
-        request: pending.request,
-        resolution,
-        ...(summarizeContext ? { contextPolicy: "summary" as const } : {}),
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        permission: { mode: permissionMode(), shellExecEnabled: shellExecEnabled(), ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}) },
-        signal,
-        onEvent: handleAgentEvent,
-        agentManager,
-        permissionBroker,
-      }));
-      if (outcome.kind === "interrupted") {
-        setPendingEngineSwitch(pending);
-        handleInterruptedTurn();
-        return;
-      }
-      const result = outcome.value;
-      if (result.kind === "engine_switched") {
-        switchApplied = true;
-        setConversation([...result.messages]);
-        setSessionId(result.sessionId);
-        setSessionPath(result.sessionPath);
-        setActiveEngine(result.engine);
-        setStatus(`engine ${result.engine}`);
-        recordActivity({ kind: "system", text: `engine switched to ${result.engine}` });
-        if (summarizeContext) {
-          const compact = await compactSession("Preserve the engine handoff, user intent, important files/artifacts, unresolved issues, and the next useful step.");
-          setMessages((prev) => [
-            ...prev,
-            { role: "system", content: `Engine switched to ${result.engine} with summarized context (${compact.messagesSummarized} messages). Future turns will use that profile.` },
-          ]);
-        } else {
-          setMessages((prev) => [...prev, { role: "system", content: `Engine switched to ${result.engine}. Future turns will use that profile.` }]);
-        }
-      } else {
-        handleResult(result, result.messages);
-      }
-    } catch (error) {
-      if (!switchApplied) setPendingEngineSwitch(pending);
-      reportError(error);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  const submitUserQuestionAnswer = async (selectedIndex: number) => {
-    const pending = pendingUserQuestion();
-    if (!pending || busy()) return;
-    const option = pending.question.options[selectedIndex];
-    if (!option) return;
-    if (option.kind === "freeform") {
-      submitUserQuestionFreeform(questionFreeformText());
-      return;
-    }
-    const answer: UserQuestionAnswer = {
-      selectedIndex,
-      label: option.label,
-      description: option.description,
-      ...(option.kind ? { kind: option.kind } : {}),
-    };
-    await submitUserQuestionAnswerPayload(pending, answer, selectedIndex);
-  };
-
-  const submitUserQuestionFreeform = (value: unknown) => {
-    const pending = pendingUserQuestion();
-    if (!pending || busy()) return;
-    const text = (typeof value === "string" ? value : questionFreeformText()).trim();
-    if (!text) {
-      setStatus("type a free-form answer or press Esc");
-      return;
-    }
-    const selectedIndex = questionSelected();
-    const option = pending.question.options[selectedIndex];
-    if (!option || option.kind !== "freeform") return;
-    const answer: UserQuestionAnswer = {
-      selectedIndex,
-      label: option.label,
-      description: option.description,
-      kind: "freeform",
-      freeformText: text,
-    };
-    setQuestionFreeformText("");
-    setQuestionFreeformCursor(0);
-    setQuestionFreeformKillBuffer(undefined);
-    void submitUserQuestionAnswerPayload(pending, answer, selectedIndex);
-  };
-
-  async function submitUserQuestionAnswerPayload(
-    pending: PendingUserQuestionState,
-    answer: UserQuestionAnswer,
-    selectedIndex: number,
-  ) {
-    setBusy(true);
-    setStatus(`answering question: ${pending.question.header}`);
-    recordActivity({
-      kind: "gate",
-      text: `answering question ${pending.question.header}: ${answer.kind === "freeform" ? "Other" : answer.label}`,
-    });
-    setPendingUserQuestion(null);
-    setQuestionSelected(0);
-    setQuestionFreeformText("");
-    setQuestionFreeformCursor(0);
-    setQuestionFreeformKillBuffer(undefined);
-    setMessages((prev) => [
-      ...prev,
-      { role: "user", content: displayUserQuestionAnswer(pending.question.header, answer) },
-    ]);
-    beginUsageTurn();
-
-    try {
-      const outcome = await turnCancellation.run((signal) => resolveUserQuestion({
-        engine: pending.engine,
-        sessionId: pending.sessionId,
-        messages: pending.messages,
-        toolCallId: pending.toolCallId,
-        question: pending.question,
-        answer,
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        permission: { mode: permissionMode(), shellExecEnabled: shellExecEnabled(), ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}) },
-        signal,
-        onEvent: handleAgentEvent,
-        agentManager,
-        permissionBroker,
-      }));
-      if (outcome.kind === "interrupted") {
-        setPendingUserQuestion(pending);
-        setQuestionSelected(selectedIndex);
-        handleInterruptedTurn();
-      } else {
-        handleResult(outcome.value, outcome.value.messages);
-      }
-    } catch (error) {
-      setPendingUserQuestion(pending);
-      setQuestionSelected(selectedIndex);
-      reportError(error);
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  /**
-   * Apply a runPrompt/resolveGate result. Shared by both paths so the
-   * needs_user / complete branching stays in one place.
-   */
-  function beginUsageTurn(): void {
-    activeTurnUsage = emptyUsageSummary();
-    activeTurnAgentUsage = emptyUsageSummary();
-    activeTurnUsagePublished = false;
-    setLastTurnUsage(undefined);
-  }
-
-  function recordResponseUsage(usage: ResponseUsage): void {
-    activeTurnUsage = addResponseUsageToTurn(activeTurnUsage, usage);
-    activeTurnUsagePublished = false;
-  }
-
-  function recordIndependentAgentUsage(usage: ResponseUsage): void {
-    activeTurnAgentUsage = addIndependentUsageToTurn(activeTurnAgentUsage, usage);
-    activeTurnUsagePublished = false;
-  }
-
-  function publishTurnUsage(): void {
-    const combined = mergeLogicalTurnUsage(activeTurnUsage, activeTurnAgentUsage);
-    const usage = hasUsageSummary(combined) ? combined : undefined;
-    setLastTurnUsage(usage);
-    if (usage && !activeTurnUsagePublished) {
-      setSessionUsage((current) => addTurnUsageToSession(current, usage));
-      activeTurnUsagePublished = true;
-    }
-  }
-
-  function handleResult(result: RunPromptResult, carriedMessages: VesicleMessage[]) {
-    publishTurnUsage();
-    if (result.kind === "needs_user") {
-      setConversation([...result.messages]);
-      setSessionId(result.sessionId);
-      setSessionPath(result.sessionPath);
-      setPendingGate({ ...result, engine: result.profile.id });
-      setPendingEngineSwitch(null);
-      setPendingUserQuestion(null);
-      setPendingPermission(null);
-      setQuestionFreeformText("");
-      setQuestionFreeformCursor(0);
-      setQuestionFreeformKillBuffer(undefined);
-      setSessionPicker(null);
-      setGateFocus("confirm");
-      setGateFeedbackMode(null);
-      setGateFeedback("");
-      setGateFeedbackCursor(0);
-      setGateFeedbackKillBuffer(undefined);
-      setOutput(result.assistantContent);
-      const alreadyDisplayed = lastDisplayedToolAssistantContent() === result.assistantContent;
-      setMessages((prev) => [
-        ...prev,
-        ...(alreadyDisplayed ? [] : [{ role: "assistant" as const, content: result.assistantContent }]),
-        { role: "system", content: `Stop gate pending: ${result.gate.gate}. Use ↑/↓ + Enter, or type into the amend box (Tab).` },
-      ]);
-      setStatus(`gate pending: ${result.gate.gate}`);
-      return;
-    }
-
-    if (result.kind === "needs_engine_switch") {
-      setConversation([...result.messages]);
-      setSessionId(result.sessionId);
-      setSessionPath(result.sessionPath);
-      setPendingGate(null);
-      setPendingEngineSwitch(result);
-      setPendingUserQuestion(null);
-      setQuestionFreeformText("");
-      setQuestionFreeformCursor(0);
-      setQuestionFreeformKillBuffer(undefined);
-      setSessionPicker(null);
-      setGateFocus("confirm");
-      setGateFeedbackMode(null);
-      setGateFeedback("");
-      setGateFeedbackCursor(0);
-      setGateFeedbackKillBuffer(undefined);
-      setOutput(result.assistantContent);
-      const alreadyDisplayed = lastDisplayedToolAssistantContent() === result.assistantContent;
-      setMessages((prev) => [
-        ...prev,
-        ...(alreadyDisplayed ? [] : [{ role: "assistant" as const, content: result.assistantContent }]),
-        { role: "system", content: `Engine switch requested: ${result.profile.id} -> ${result.request.targetEngine}. Confirm below to switch future turns.` },
-      ]);
-      setStatus(`engine switch pending: ${result.request.targetEngine}`);
-      return;
-    }
-
-    if (result.kind === "needs_user_question") {
-      setConversation([...result.messages]);
-      setSessionId(result.sessionId);
-      setSessionPath(result.sessionPath);
-      setPendingGate(null);
-      setPendingEngineSwitch(null);
-      setPendingUserQuestion({ ...result, engine: result.profile.id });
-      setPendingPermission(null);
-      setQuestionSelected(0);
-      setQuestionFreeformText("");
-      setQuestionFreeformCursor(0);
-      setQuestionFreeformKillBuffer(undefined);
-      setSessionPicker(null);
-      setOutput(result.assistantContent);
-      const alreadyDisplayed = lastDisplayedToolAssistantContent() === result.assistantContent;
-      setMessages((prev) => [
-        ...prev,
-        ...(alreadyDisplayed ? [] : [{ role: "assistant" as const, content: result.assistantContent }]),
-        { role: "system", content: `Question pending: ${result.question.header}. Choose an option below to continue.` },
-      ]);
-      setStatus(`question pending: ${result.question.header}`);
-      return;
-    }
-
-    if (result.kind === "needs_permission") {
-      setConversation([...result.messages]);
-      setSessionId(result.sessionId);
-      setSessionPath(result.sessionPath);
-      setPendingGate(null);
-      setPendingEngineSwitch(null);
-      setPendingUserQuestion(null);
-      setPendingPermission({ ...result, engine: result.profile.id });
-      setOutput(result.assistantContent);
-      setMessages((prev) => [
-        ...prev,
-        ...(result.assistantContent && lastDisplayedToolAssistantContent() !== result.assistantContent
-          ? [{ role: "assistant" as const, content: result.assistantContent }]
-          : []),
-        { role: "system", content: `Permission pending: ${result.request.toolName}.` },
-      ]);
-      setStatus(`permission pending: ${result.request.toolName}`);
-      return;
-    }
-
-    setPendingGate(null);
-    setPendingEngineSwitch(null);
-    setPendingUserQuestion(null);
-    setPendingPermission(null);
-    setQuestionFreeformText("");
-    setQuestionFreeformCursor(0);
-    setQuestionFreeformKillBuffer(undefined);
-    setGateFeedbackMode(null);
-    setGateFeedback("");
-    setGateFeedbackCursor(0);
-    setGateFeedbackKillBuffer(undefined);
-    setLastDisplayedToolAssistantContent(null);
-
-    const profileValidation = result.validation;
-    const ok = profileValidation ? profileValidation.ok : true;
-
-    // CR B2: carry the loop's full message list forward rather than appending
-    // to a stale snapshot. result.messages already contains every prior turn
-    // including tool calls and their results, so the next user prompt builds
-    // on a provider-valid view.
-    setConversation([...result.messages]);
-    setSessionId(result.sessionId);
-    setSessionPath(result.sessionPath);
-    setOutput(result.response.content);
-    void refreshArtifacts();
-
-    const appended: Message[] = [];
-    const reasoningText = displayTextFromThinkingBlocks(result.response.thinkingBlocks) ?? result.response.reasoningContent;
-    if (!result.response.toolCalls?.length && reasoningText?.trim()) {
-      appended.push({ role: "system", content: reasoningText, kind: "reasoning" });
-    }
-    if (!result.response.toolCalls?.length && result.response.content.trim()) {
-      appended.push({ role: "assistant", content: result.response.content, engine: activeEngine(), model: activeModel() });
-    }
-    if (profileValidation) {
-      appended.push({ role: "system", content: renderValidationNotice(profileValidation) });
-    }
-    setMessages((prev) => [...prev, ...appended]);
-    setStatus(ok ? "complete" : "complete with validation findings");
-  }
-
-  function reportError(error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    setStatus("error");
-    setOutput(message);
-    setStreamingAssistant("");
-    setStreamingReasoning("");
-    recordActivity({ kind: "system", text: `error: ${message}` });
-    setMessages((prev) => [...prev, { role: "assistant", content: `Error: ${message}` }]);
-  }
-
-  function handleInterruptedTurn() {
-    setStatus("Interrupted");
-    setStreamingAssistant("");
-    setStreamingReasoning("");
-    setLastDisplayedToolAssistantContent(null);
-    recordActivity({ kind: "system", text: "request interrupted" });
-  }
-
-  async function restoreInterruptedPrompt(
-    prompt: string,
-    images: VesicleImageAttachment[] = [],
-    elements: ComposerElement[] = [],
-  ): Promise<void> {
-    const id = sessionId();
-    if (!id) return;
-    const points = await listRewindPoints(process.cwd(), id);
-    const point = [...points].reverse().find((entry) => entry.content.trim() === prompt.trim());
-    if (!point) return;
-    await applyConversationRewind(await rewindConversation(process.cwd(), id, point));
-    setPromptHistory((previous) => previous.at(-1)?.value === prompt ? previous.slice(0, -1) : previous);
-    applyComposerState({ value: prompt, cursor: prompt.length, elements: elements.map((element) => ({ ...element })) });
-    setInputImages(images.map((image) => ({ ...image })));
-  }
-
-  // Name of the tool call currently streaming into shape. tool_call_delta only
-  // carries `name` on the first chunk; the long arguments tail (e.g. a large
-  // write_file content) has none, so remember it to hold the status on
-  // "calling · {tool}" through the whole argument stream. Cleared per request.
-  let formingToolName: string | undefined;
-
-  function handleAgentEvent(event: AgentLoopEvent) {
-    if (event.type === "agent_created"
-      || event.type === "agent_started"
-      || event.type === "agent_progress"
-      || event.type === "agent_completed"
-      || event.type === "agent_integrated") {
-      setAgentCards((cards) => applyAgentEvent(cards, event));
-      if (event.type === "agent_created") {
-        setMessages((current) => current.some((message) => message.kind === "agent" && message.agentRunId === event.agent.runId)
-          ? current
-          : [...current, { role: "system", content: "", kind: "agent", agentRunId: event.agent.runId }]);
-      }
-    }
-    const eventParentSessionId = event.type === "agent_created" || event.type === "agent_started"
-      ? event.agent.parentSessionId
-      : event.type === "agent_progress" || event.type === "agent_integrated"
-        ? event.parentSessionId
-        : event.type === "agent_completed"
-          ? event.result.parentSessionId
-          : undefined;
-    const currentAgentEvent = eventParentSessionId === undefined
-      || eventParentSessionId === sessionId()
-      || (!sessionId() && busy());
-    switch (event.type) {
-      case "agent_created":
-        recordActivity({ kind: "agent", text: `queued ${event.agent.profileId}: ${event.agent.description}` });
-        return;
-      case "agent_started":
-        recordActivity({ kind: "agent", text: `started ${event.agent.handle}: ${event.agent.description}` });
-        return;
-      case "agent_progress":
-        recordActivity({ kind: "agent", text: `${event.handle}: ${event.text}` });
-        return;
-      case "agent_completed":
-        if (currentAgentEvent && event.result.mode === "foreground" && event.result.usage) {
-          recordIndependentAgentUsage(event.result.usage);
-        }
-        recordActivity({ kind: "agent", text: `${event.result.status} ${event.result.handle}: ${event.result.description}` });
-        return;
-      case "agent_integrated":
-        recordActivity({ kind: "agent", text: `integrated ${event.handle}` });
-        return;
-      case "process_update":
-        applyProcessUpdate(event.callId, event.processEvent);
-        if (event.processEvent.executionMode === "foreground") {
-          setStatus(event.processEvent.status === "running"
-            ? `running shell · ${Math.max(0, Math.round(event.processEvent.durationMs / 1000))}s`
-            : `shell ${event.processEvent.status}`);
-        }
-        return;
-      case "asset_drift": {
-        const key = `${sessionId() ?? "unknown"}:${event.fingerprint}`;
-        if (lastReportedAssetDriftKey === key) return;
-        lastReportedAssetDriftKey = key;
-        const changed = event.changedPaths.length > 0 ? event.changedPaths.join(", ") : "effective assets";
-        setMessages((current) => [...current, {
-          role: "system",
-          content: `Asset drift detected since this session began: ${changed}. This continuation uses the current effective assets.`,
-        }]);
-        recordActivity({ kind: "system", text: `asset drift: ${changed}` });
-        return;
-      }
-      case "provider_request":
-        setStreamingAssistant("");
-        setStreamingReasoning("");
-        formingToolName = undefined;
-        setStatus("sending request");
-        recordActivity({ kind: "provider", text: `provider request #${event.iteration + 1}` });
-        return;
-      case "assistant_delta":
-        setStreamingAssistant((prev) => `${prev}${event.delta}`);
-        setStatus("generating response");
-        return;
-      case "assistant_reasoning_delta":
-        setStreamingReasoning((prev) => `${prev}${event.delta}`);
-        setStatus("generating response");
-        return;
-      case "tool_call_delta":
-        if (event.name) {
-          formingToolName = event.name;
-          recordActivity({ kind: "tool", text: `tool call forming: ${event.name}` });
-        }
-        // `name` only arrives on the first chunk; the long arguments tail has
-        // none, so reuse the remembered name to stay on "calling · {tool}".
-        setStatus(formingToolName ? `calling · ${formingToolName}` : "generating response");
-        return;
-      case "assistant_response":
-        activeTurnSawResponse = true;
-        setStreamingAssistant("");
-        setStreamingReasoning("");
-        const responseUsage = event.usage;
-        if (responseUsage) {
-          recordResponseUsage(responseUsage);
-        }
-        if (event.toolCalls.length > 0) {
-          const reasoningText = displayTextFromThinkingBlocks(event.thinkingBlocks) ?? event.reasoningContent;
-          if (reasoningText) appendReasoningMessage(reasoningText);
-        }
-        if (event.toolCalls.length > 0) {
-          // Show only the assistant prose; the calls themselves render as inline
-          // tool cards via the tool_call/tool_result events that follow. An
-          // empty-prose tool turn pushes no assistant message.
-          if (event.content.trim()) {
-            setMessages((prev) => [...prev, { role: "assistant", content: event.content, engine: activeEngine(), model: activeModel() }]);
-          }
-          setLastDisplayedToolAssistantContent(event.content);
-        }
-        recordActivity({
-          kind: "assistant",
-          text: event.toolCalls.length > 0
-            ? `assistant response with ${event.toolCalls.length} tool call${event.toolCalls.length > 1 ? "s" : ""}`
-            : "assistant response complete",
-        });
-        return;
-      case "tool_call":
-        if (event.name === "spawn_agent") {
-          setStatus("starting SubAgent");
-          recordActivity({ kind: "agent", text: "spawn_agent requested" });
-          return;
-        }
-        setMessages((prev) => [
-          ...prev,
-          { role: "tool", toolStage: "call", toolName: event.name, toolArgs: event.arguments, toolCallId: event.callId, content: "" },
-        ]);
-        setStatus(`calling · ${event.name}`);
-        recordActivity({ kind: "tool", text: `calling ${event.name}` });
-        return;
-      case "tool_result":
-        if (event.name === "spawn_agent") {
-          if (!event.ok) {
-            setStatus("SubAgent launch failed");
-            setMessages((current) => [...current, {
-              role: "system",
-              content: `SubAgent launch failed: ${event.content}`,
-            }]);
-          }
-          recordActivity({ kind: "agent", text: `${event.ok ? "ok" : "failed"} spawn_agent` });
-          return;
-        }
-        const latestBackgroundProcess = event.processEvent?.taskId
-          ? backgroundProcesses().find((process) => process.taskId === event.processEvent?.taskId)
-          : undefined;
-        const displayedProcessEvent = latestBackgroundProcess ? processEventFromTask(latestBackgroundProcess) : event.processEvent;
-        setMessages((prev) => {
-          // Merge the outcome onto the matching call card so its diff can show
-          // the affected line range (matchLines → git-style hunk + gutter),
-          // then add the `⎿` footer beneath it.
-          const next = prev.map((m) =>
-            m.toolCallId === event.callId && m.toolStage === "call"
-              ? { ...m, toolFileEvent: event.fileEvent, toolWebEvent: event.webEvent, toolMcpEvent: event.mcpEvent, toolProcessEvent: displayedProcessEvent, toolOk: event.ok, images: event.images }
-              : m,
-          );
-          next.push({
-            role: "tool",
-            toolStage: "result",
-            toolName: event.name,
-            toolCallId: event.callId,
-            toolOk: event.ok,
-            toolFileEvent: event.fileEvent,
-            toolWebEvent: event.webEvent,
-            toolMcpEvent: event.mcpEvent,
-            toolProcessEvent: displayedProcessEvent,
-            images: event.images,
-            // Content is only needed for failure messages; on success the
-            // structured fileEvent/webEvent/mcpEvent carries the footer detail.
-            content: event.ok ? "" : event.content,
-          });
-          return next;
-        });
-        recordActivity({ kind: "tool", text: `${event.ok ? "ok" : "failed"} ${event.name}: ${event.content}` });
-        return;
-      case "gate_pending":
-        recordActivity({ kind: "gate", text: `gate pending: ${event.gate}` });
-        return;
-      case "engine_switch_pending":
-        recordActivity({ kind: "gate", text: `engine switch pending: ${event.targetEngine}` });
-        return;
-      case "user_question_pending":
-        recordActivity({ kind: "gate", text: `question pending: ${event.header}` });
-        return;
-      case "validation":
-        recordActivity({ kind: "validation", text: event.ok ? "validation passed" : "validation found issues" });
-        return;
-    }
-  }
-
-  function handleBackgroundProcessEvent(event: BackgroundProcessEvent): void {
-    const process = event.process;
-    setBackgroundProcesses((current) => {
-      const index = current.findIndex((candidate) => candidate.taskId === process.taskId);
-      if (index < 0) return [...current, process];
-      return current.map((candidate, candidateIndex) => candidateIndex === index ? process : candidate);
-    });
-    applyProcessUpdate(process.parentToolCallId, processEventFromTask(process));
-    if (process.status !== "running") {
-      recordActivity({ kind: "tool", text: `${process.taskId} ${process.status}${process.exitCode !== undefined ? ` · exit ${process.exitCode}` : ""}` });
-    }
-  }
-
-  function applyProcessUpdate(callId: string, processEvent: import("../core/tools").ProcessToolEvent): void {
-    setMessages((current) => current.map((message) =>
-      message.toolCallId === callId ? { ...message, toolProcessEvent: processEvent } : message
-    ));
-  }
-
-  function recordActivity(entry: ActivityEntry) {
-    setActivity((prev) => [...prev, entry].slice(-60));
-  }
-
-  function appendReasoningMessage(content: string) {
-    if (!content.trim()) return;
-    setMessages((prev) => [...prev, { role: "system", content, kind: "reasoning" }]);
-  }
-
-  async function refreshProviderConfig(selection?: Partial<ProviderSelection>) {
-    const inspected = await inspectProviderConfig(selection);
-    setProviderRegistry(inspected.registry);
-    setActiveProvider(inspected.providerId);
-    setActiveModel(inspected.model);
-    setActiveModelLimits(inspected.limits);
-    setActiveModelCapabilities(inspected.capabilities);
-    setProviderHasApiKey(inspected.hasApiKey);
-    recordActivity({
-      kind: "provider",
-      text: `active ${inspected.providerId}/${inspected.model} (${inspected.registry.source})`,
-    });
-    setProviderConfigReady(true);
-    setStatus(inspected.hasApiKey ? "ready" : `missing API key for ${inspected.providerId}`);
-  }
-
-  async function refreshMcpStatus() {
-    setMcpStatus((current) => ({ ...current, loading: true }));
-    const inspected = await inspectMcpConfig();
-    setMcpStatus({
-      loading: false,
-      configured: inspected.configured,
-      enabled: inspected.enabled,
-      servers: inspected.statuses.map((status) => ({
-        id: status.id,
-        enabled: status.enabled,
-        connected: status.connected,
-        toolCount: status.toolCount,
-        ...(status.error ? { error: status.error } : {}),
-      })),
-    });
-  }
-
-  async function ensureProviderRegistry(): Promise<ProviderRegistry> {
-    const existing = providerRegistry();
-    if (existing) return existing;
-    await loadProviderConfigOnce();
-    const loaded = providerRegistry();
-    if (!loaded) throw new Error("Provider registry did not load.");
-    return loaded;
-  }
-
-  function loadProviderConfigOnce(): Promise<void> {
-    providerConfigLoad ??= refreshProviderConfig().finally(() => {
-      providerConfigLoad = null;
-    });
-    return providerConfigLoad;
-  }
-
-  function loadPermissionSettingsOnce(): Promise<void> {
-    permissionSettingsLoad ??= loadPermissionSettings().then((settings) => {
-      setShellExecEnabled(props.dangerouslySkipPermissions === true || settings.shellExec);
-      if (!props.dangerouslySkipPermissions) setPermissionMode(settings.defaultMode);
-      setPermissionSettingsReady(true);
-    }).finally(() => {
-      permissionSettingsLoad = null;
-    });
-    return permissionSettingsLoad;
-  }
-
-  async function applyProviderSelection(selection: Partial<ProviderSelection>): Promise<ProviderSelection> {
-    const inspected = await inspectProviderConfig(selection);
-    setProviderRegistry(inspected.registry);
-    setActiveProvider(inspected.providerId);
-    setActiveModel(inspected.model);
-    setActiveModelLimits(inspected.limits);
-    setActiveModelCapabilities(inspected.capabilities);
-    setProviderHasApiKey(inspected.hasApiKey);
-    setStatus(inspected.hasApiKey ? "ready" : `missing API key for ${inspected.providerId}`);
-    recordActivity({ kind: "provider", text: `switched to ${inspected.providerId}/${inspected.model}` });
-    return { provider: inspected.providerId, model: inspected.model };
-  }
-
-  function activeProviderSelection(): ProviderSelection {
-    return { provider: activeProvider(), model: activeModel() };
-  }
-
-  function activeGeneration() {
-    const reasoningTier = thinkingTier();
-    return reasoningTier ? { reasoningTier } : undefined;
-  }
-
-  async function persistProviderSwitch(selection: ProviderSelection) {
-    await appendHostSessionRecord({
-      role: "system",
-      content: `Provider switched to ${selection.provider}/${selection.model}.`,
-      metadata: {
-        kind: "provider-switch",
-        providerId: selection.provider,
-        model: selection.model,
-      },
-    });
-  }
-
-  async function persistEngineSwitch(transition: EngineTransition) {
-    await appendHostSessionRecord({
-      role: "system",
-      content: `Engine switched to ${transition.toEngine}.`,
-      metadata: {
-        kind: "engine-switch",
-        engine: transition.toEngine,
-        targetEngine: transition.toEngine,
-        reason: transition.reason,
-        handoffSummary: transition.handoffSummary,
-        ...(transition.recommendedNextAction ? { recommendedNextAction: transition.recommendedNextAction } : {}),
-        transition,
-      },
-    });
-    const packet = renderEngineHandoffPacket(transition);
-    const appended = await appendHostSessionRecord({
-      role: "user",
-      content: packet,
-      metadata: {
-        kind: ENGINE_HANDOFF_KIND,
-        engine: transition.toEngine,
-        transition,
-      },
-    });
-    if (appended) {
-      setConversation((prev) => [...prev, { role: "user", content: packet }]);
-    }
-  }
-
-  async function persistThinkingSwitch(tier: ReasoningTier | undefined) {
-    await appendHostSessionRecord({
-      role: "system",
-      content: tier ? `Thinking effort switched to ${tier}.` : "Thinking effort reset to provider default.",
-      metadata: {
-        kind: "thinking-switch",
-        reasoningTier: tier ?? null,
-      },
-    });
-  }
-
-  async function persistReasoningSwitch(mode: ReasoningDisplayMode) {
-    await appendHostSessionRecord({
-      role: "system",
-      content: `Reasoning display switched to ${mode}.`,
-      metadata: {
-        kind: "reasoning-switch",
-        reasoningDisplayMode: mode,
-      },
-    });
-  }
-
-  async function changePermissionMode(mode: PermissionMode): Promise<void> {
-    if (mode === "YOLO" && permissionMode() !== "YOLO" && !props.dangerouslySkipPermissions) {
-      setGateFocus("confirm");
-      setYoloConfirmStage(1);
-      setStatus("confirm YOLO permission mode");
-      return;
-    }
-    await applyPermissionMode(mode);
-  }
-
-  async function applyPermissionMode(mode: PermissionMode): Promise<void> {
-    setPermissionMode(mode);
-    setStatus(`permission mode ${mode}`);
-    await appendHostSessionRecord({
-      role: "system",
-      content: `Permission mode switched to ${mode}.`,
-      metadata: { kind: "permission-mode-switch", permissionMode: mode },
-    });
-    setMessages((prev) => [...prev, {
-      role: "system",
-      content: mode === "YOLO"
-        ? "DANGER: YOLO enabled for this process. All tool approvals are bypassed; runtime hard guards remain active."
-        : `Permission mode switched to ${mode}.`,
-    }]);
-  }
-
-  async function appendHostSessionRecord(record: { role: "system" | "user"; content: string; metadata: Record<string, unknown> }) {
-    const id = sessionId();
-    if (!id) return undefined;
-    const branch = nextSessionParent();
-    const store = await createSessionStore(
-      process.cwd(),
-      id,
-      branch ? { parentUuid: branch.uuid } : {},
-    );
-    const appended = await store.append(record);
-    if (branch) setNextSessionParent({ uuid: appended.uuid });
-    return appended;
-  }
-
   /**
    * Slash commands for session management and help. These run locally and
    * never touch the provider:
@@ -2322,250 +690,6 @@ export function App(props: AppProps = {}) {
     openModelPicker,
   };
 
-  async function agentCommand(args: string): Promise<string> {
-    const id = sessionId();
-    const [action, target] = args.trim().split(/\s+/, 2);
-    if (action === "stop") {
-      if (!target) return "Usage: /agents stop <agent-handle>";
-      if (!id) return "No active session.";
-      const interrupted = await agentManager.interrupt(target, id);
-      return interrupted ? `Interrupt requested for ${target}.` : `SubAgent is not running: ${target}.`;
-    }
-    if (action === "retry" && !target) {
-      if (!id) return "No active session.";
-      void retryAgentDelivery(pausedAgentDeliveries, id, (session) => continuationScheduler.notify(session)).catch(reportError);
-      return "SubAgent result delivery retry scheduled.";
-    }
-    if (action && !target) {
-      if (!id) return "No active session.";
-      const agent = await agentStore.resolveReference(id, action);
-      if (!agent) return `Unknown SubAgent: ${action}.`;
-      const inbox = (await agentStore.listInbox(id)).filter((entry) => entry.runId === agent.runId);
-      const card = agentCards().find((candidate) => candidate.runId === agent.runId)
-        ?? agentCardFromMetadata(agent, inbox);
-      return renderAgentDetail(agent, card, inbox);
-    }
-    if (args.trim()) return "Usage: /agents [handle|stop <handle>|retry]";
-    const profiles = await listAgentProfiles(process.cwd());
-    const agents = id ? await agentStore.listByParent(id) : [];
-    const inbox = id ? await agentStore.listInbox(id) : [];
-    const lines = ["Agent Profiles:"];
-    for (const profile of profiles) {
-      lines.push(`  ${profile.id} [${profile.defaultMode}/${profile.contextMode}] - ${profile.description}`);
-    }
-    lines.push("", "Current session SubAgents:");
-    if (agents.length === 0) lines.push("  (none)");
-    for (const agent of agents) {
-      const card = agentCards().find((candidate) => candidate.runId === agent.runId)
-        ?? agentCardFromMetadata(agent, inbox);
-      lines.push(`  ${agent.handle} [${card.status}/${agent.mode}] ${agent.description}`);
-    }
-    lines.push("", "Use /agents <handle> for details, /agents stop <handle> to interrupt, or /agents retry after a delivery error.");
-    return lines.join("\n");
-  }
-
-  async function resumeSession(target: SessionSummary, commandEcho?: string) {
-    setRestoringSession(true);
-    try {
-      if (!permissionSettingsReady()) await loadPermissionSettingsOnce();
-      const snapshot = await loadSessionSnapshot(process.cwd(), target.sessionId, {
-        synthesizeDanglingToolResults: false,
-      });
-      const liveProcesses = await processManager.list(target.sessionId);
-      const liveProcessesByTaskId = new Map(liveProcesses.map((process) => [process.taskId, process]));
-      for (const message of snapshot.messages) {
-        const taskId = message.toolProcessEvent?.taskId;
-        const live = taskId ? liveProcessesByTaskId.get(taskId) : undefined;
-        if (live) message.toolProcessEvent = processEventFromTask(live);
-      }
-      const resumedMessages = vesicleMessagesFromResumed(snapshot.messages);
-      // Tool-call arguments live on the assistant record's toolCalls; build a
-      // callId → {name, arguments} lookup so resumed tool results can render
-      // the same inline cards as live tool calls.
-      const argsByCallId = new Map<string, { name: string; arguments: string }>();
-      for (const m of snapshot.messages) {
-        if (m.toolCalls) {
-          for (const tc of m.toolCalls) argsByCallId.set(tc.id, { name: tc.name, arguments: tc.arguments });
-        }
-      }
-      const [storedAgents, storedInbox] = await Promise.all([
-        agentStore.listByParent(target.sessionId),
-        agentStore.listInbox(target.sessionId),
-      ]);
-      const restoredAgentCards = storedAgents.map((agent) => agentCardFromMetadata(agent, storedInbox));
-      setAgentCards((current) => mergeRestoredAgentCards(current, target.sessionId, restoredAgentCards));
-      const agentsByToolCallId = new Map(restoredAgentCards.map((agent) => [agent.parentToolCallId, agent]));
-      const transcript = snapshot.messages.flatMap((m) => displayMessagesFromResumed(m, argsByCallId, agentsByToolCallId));
-      const restoredEngine = snapshot.engine ?? "etl";
-      setSessionId(target.sessionId);
-      setNextSessionParent(null);
-      setSessionPath(joinSessionPath(target.sessionId));
-      setActiveEngine(restoredEngine);
-      setConversation(resumedMessages);
-      setLastTurnUsage(latestTurnUsage(snapshot.messages));
-      setSessionUsage(sumSessionUsage(snapshot.messages));
-      setOutput(snapshot.pendingGate?.assistantContent ?? snapshot.pendingEngineSwitch?.assistantContent ?? snapshot.pendingUserQuestion?.assistantContent ?? "");
-      setSessionPicker(null);
-
-      const hostMessages: Message[] = [];
-      if (commandEcho) hostMessages.push({ role: "user", content: commandEcho });
-      hostMessages.push({ role: "system", content: `Restored engine ${restoredEngine} from session.` });
-      const restoredPermissionMode = props.dangerouslySkipPermissions
-        ? "YOLO"
-        : snapshot.permissionMode === "YOLO"
-          ? "MOMENTUM"
-          : snapshot.permissionMode ?? permissionMode();
-      setPermissionMode(restoredPermissionMode);
-      hostMessages.push({ role: "system", content: snapshot.permissionMode === "YOLO" && !props.dangerouslySkipPermissions
-        ? "Previous YOLO permission mode was downgraded to MOMENTUM on resume. Re-enable YOLO explicitly if needed."
-        : `Restored permission mode ${restoredPermissionMode}.` });
-      const assetDrift = await inspectEngineAssetDrift(snapshot.assets, restoredEngine, process.cwd());
-      if (assetDrift) {
-        lastReportedAssetDriftKey = `${target.sessionId}:${assetDrift.current.sha256}`;
-        const changed = assetDrift.changedPaths.length > 0
-          ? assetDrift.changedPaths.join(", ")
-          : "effective profile/prompt assets";
-        hostMessages.push({
-          role: "system",
-          content: `Asset drift detected since this session began: ${changed}. Continued turns use the current effective assets.`,
-        });
-      }
-      if (snapshot.providerSelection) {
-        try {
-          const selection = await applyProviderSelection(snapshot.providerSelection);
-          hostMessages.push({ role: "system", content: `Restored provider ${selection.provider}/${selection.model} from session.` });
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          hostMessages.push({ role: "system", content: `Session provider was not restored: ${message}` });
-        }
-      }
-      if (snapshot.reasoningTier) {
-        setThinkingTier(snapshot.reasoningTier);
-        hostMessages.push({ role: "system", content: `Restored thinking effort ${snapshot.reasoningTier} from session.` });
-      }
-      if (snapshot.reasoningDisplayMode) {
-        setReasoningDisplayMode(snapshot.reasoningDisplayMode);
-        hostMessages.push({ role: "system", content: `Restored reasoning display ${snapshot.reasoningDisplayMode} from session.` });
-      }
-
-      if (snapshot.pendingPermission) {
-        setPendingGate(null);
-        setPendingEngineSwitch(null);
-        setPendingUserQuestion(null);
-        setPendingPermission({
-          kind: "needs_permission",
-          sessionId: target.sessionId,
-          sessionPath: joinSessionPath(target.sessionId),
-          engine: restoredEngine,
-          request: snapshot.pendingPermission,
-          remainingToolCalls: unresolvedToolCalls(snapshot.messages, snapshot.pendingPermission.toolCallId),
-          assistantContent: "",
-          messages: resumedMessages,
-        });
-        setGateFocus("confirm");
-        setGateFeedbackMode(null);
-        setGateFeedback("");
-        setGateFeedbackCursor(0);
-        setGateFeedbackKillBuffer(undefined);
-        setStatus(`permission pending: ${snapshot.pendingPermission.toolName}`);
-        hostMessages.push({ role: "system", content: `Resumed pending permission for ${snapshot.pendingPermission.toolName}.` });
-      } else if (snapshot.pendingGate) {
-        setPendingPermission(null);
-        setPendingUserQuestion(null);
-        setPendingGate({
-          kind: "needs_user",
-          sessionId: target.sessionId,
-          sessionPath: joinSessionPath(target.sessionId),
-          engine: restoredEngine,
-          gate: snapshot.pendingGate.gate,
-          toolCallId: snapshot.pendingGate.toolCallId,
-          assistantContent: snapshot.pendingGate.assistantContent,
-          messages: resumedMessages,
-        });
-        setGateFocus("confirm");
-        setGateFeedbackMode(null);
-        setGateFeedback("");
-        setGateFeedbackCursor(0);
-        setGateFeedbackKillBuffer(undefined);
-        setStatus(`gate pending: ${snapshot.pendingGate.gate.gate}`);
-        hostMessages.push({
-          role: "system",
-          content: `Resumed pending gate ${snapshot.pendingGate.gate.gate}. Use the gate controls below to continue.`,
-        });
-      } else if (snapshot.pendingEngineSwitch) {
-        setPendingPermission(null);
-        setPendingGate(null);
-        setPendingUserQuestion(null);
-        setPendingEngineSwitch({
-          kind: "needs_engine_switch",
-          sessionId: target.sessionId,
-          sessionPath: joinSessionPath(target.sessionId),
-          request: snapshot.pendingEngineSwitch.request,
-          toolCallId: snapshot.pendingEngineSwitch.toolCallId,
-          assistantContent: snapshot.pendingEngineSwitch.assistantContent,
-          messages: resumedMessages,
-        });
-        setGateFocus("confirm");
-        setGateFeedbackMode(null);
-        setGateFeedback("");
-        setGateFeedbackCursor(0);
-        setGateFeedbackKillBuffer(undefined);
-        setStatus(`engine switch pending: ${snapshot.pendingEngineSwitch.request.targetEngine}`);
-        hostMessages.push({
-          role: "system",
-          content: `Resumed pending engine switch to ${snapshot.pendingEngineSwitch.request.targetEngine}. Use the gate controls below to continue.`,
-        });
-      } else if (snapshot.pendingUserQuestion) {
-        setPendingPermission(null);
-        setPendingGate(null);
-        setPendingEngineSwitch(null);
-        setPendingUserQuestion({
-          kind: "needs_user_question",
-          sessionId: target.sessionId,
-          sessionPath: joinSessionPath(target.sessionId),
-          engine: restoredEngine,
-          question: snapshot.pendingUserQuestion.question,
-          toolCallId: snapshot.pendingUserQuestion.toolCallId,
-          assistantContent: snapshot.pendingUserQuestion.assistantContent,
-          messages: resumedMessages,
-        });
-        setQuestionSelected(0);
-        setQuestionFreeformText("");
-        setQuestionFreeformCursor(0);
-        setQuestionFreeformKillBuffer(undefined);
-        setStatus(`question pending: ${snapshot.pendingUserQuestion.question.header}`);
-        hostMessages.push({
-          role: "system",
-          content: `Resumed pending question ${snapshot.pendingUserQuestion.question.header}. Choose an option below to continue.`,
-        });
-      } else {
-        setPendingGate(null);
-        setPendingEngineSwitch(null);
-        setPendingUserQuestion(null);
-        setPendingPermission(null);
-        setQuestionFreeformText("");
-        setQuestionFreeformCursor(0);
-        setQuestionFreeformKillBuffer(undefined);
-        setGateFeedbackMode(null);
-        setGateFeedback("");
-        setGateFeedbackCursor(0);
-        setGateFeedbackKillBuffer(undefined);
-        setStatus(`resumed ${target.sessionId.slice(11)}`);
-        hostMessages.push({
-          role: "system",
-          content: `Resumed session ${target.sessionId} with ${snapshot.messages.length} prior turns. Continue below.`,
-        });
-      }
-
-      setMessages([...transcript, ...hostMessages]);
-      await refreshArtifacts();
-    } catch (error) {
-      reportError(error);
-    } finally {
-      setRestoringSession(false);
-    }
-  }
-
   async function refreshArtifacts(): Promise<ArtifactEntry[]> {
     const entries = await scanArtifacts(process.cwd());
     setArtifacts(entries);
@@ -2618,145 +742,43 @@ export function App(props: AppProps = {}) {
             Workspace sidebar holds the persistent artifact list. */}
       </box>
 
-      <Show
-        when={yoloConfirmStage()}
-        fallback={
-          <Show
-            when={activePermissionRequest()}
-            fallback={
-          <Show
-            when={pendingUserQuestion()}
-            fallback={
-          <Show
-            when={activeGateRequest()}
-            fallback={
-              <Show
-                when={rewindPicker()}
-                fallback={
-                  <Show
-                    when={sessionPicker()}
-                    fallback={
-                      <Show when={modelPicker()} fallback={
-                        <box height={inputNeedsExpandedBottom() ? layout().bottomHeight : 3} border borderColor={palette.panelBorder} paddingX={1} flexDirection="column">
-                      <Show when={commandMenuOpen()} fallback={
-                        <Show when={commandArgumentMenuOpen()} fallback={<box height={0} />}>
-                          <box flexDirection="column">
-                            <ArgumentMenu
-                              items={commandArgumentItems()}
-                              selected={commandArgumentSelected()}
-                              width={layout().width - 4}
-                              maxVisible={composerPopupMaxRows()}
-                            />
-                            <text content={commandArgumentHint(modelArgumentDraft(), fixedArgumentDraft(), agentArgumentDraft())} fg={palette.textDim} />
-                          </box>
-                        </Show>
-                      }>
-                        <box flexDirection="column">
-                          <CommandMenu
-                            commands={commandMenuItems()}
-                            selected={commandMenuSelected()}
-                            width={layout().width - 4}
-                            maxVisible={composerPopupMaxRows()}
-                          />
-                          <text content="↑/↓ choose · Tab/Enter complete · Esc cancel" fg={palette.textDim} />
-                        </box>
-                      </Show>
-                      <PromptComposer
-                        value={inputValue()}
-                        cursor={inputCursor()}
-                        placeholder={busy() ? "Request in flight..." : !providerConfigReady() ? "Loading provider config..." : "Type prompt, Enter send, Ctrl+Enter newline, /help commands"}
-                        width={composerInputWidth()}
-                        maxLines={Math.max(1, layout().bottomHeight - (composerPopupOpen() ? composerPopupMaxRows() + 3 : 2))}
-                      />
-                        </box>
-                      }>
-                        {(mp) => (
-                          <box height={layout().bottomHeight}>
-                            <OptionPicker
-                              title={modelPickerTitle(mp())}
-                              items={modelPickerItems()}
-                              selected={mp().selected}
-                              width={layout().width}
-                              hint="↑/↓ choose · Enter select · Esc back"
-                              maxVisible={Math.max(1, layout().bottomHeight - 3)}
-                            />
-                          </box>
-                        )}
-                      </Show>
-                    }
-                  >
-                    {(picker) => (
-                      <box height={layout().bottomHeight}>
-                        <SessionPicker sessions={picker().sessions} selected={picker().selected} width={layout().width} />
-                      </box>
-                    )}
-                  </Show>
-                }
-              >
-                {(picker) => (
-                  <box height={layout().bottomHeight}>
-                    <RewindPicker state={picker()} width={layout().width} />
-                  </box>
-                )}
-              </Show>
-            }
-          >
-            {(g) => (
-              <box height={layout().bottomHeight}>
-                <GatePrompt
-                  gate={g()}
-                  focused={gateFocus()}
-                  feedbackMode={gateFeedbackMode()}
-                  feedback={gateFeedback()}
-                  feedbackCursor={gateFeedbackCursor()}
-                  width={layout().width}
-                  maxSummaryLines={gateSummaryLineBudget(
-                    layout().summaryLines,
-                    gateComposerIsActive(gateFocus(), gateFeedbackMode()),
-                    pendingEngineSwitch() ? 1 : 0,
-                  )}
-                  showSummaryOption={Boolean(pendingEngineSwitch())}
-                />
-              </box>
-            )}
-          </Show>
-            }
-          >
-            {(question) => (
-              <box height={layout().bottomHeight}>
-                <QuestionPrompt
-                  question={question().question}
-                  selected={questionSelected()}
-                  width={layout().width}
-                  freeformValue={questionFreeformText()}
-                  freeformCursor={questionFreeformCursor()}
-                />
-              </box>
-            )}
-          </Show>
-            }
-          >
-            {(permission) => (
-              <box height={layout().bottomHeight}>
-                <PermissionPrompt
-                  request={permission()}
-                  focused={gateFocus()}
-                  feedbackMode={gateFeedbackMode()}
-                  feedback={gateFeedback()}
-                  feedbackCursor={gateFeedbackCursor()}
-                  width={layout().width}
-                />
-              </box>
-            )}
-          </Show>
-        }
-      >
-        {(stage) => (
-          <box height={layout().bottomHeight}>
-            <YoloPrompt stage={stage()} focused={gateFocus()} width={layout().width} />
-          </box>
-        )}
-      </Show>
+      <BottomSurface
+        layout={layout()}
+        yoloStage={yoloConfirmStage()}
+        permissionRequest={activePermissionRequest()}
+        question={pendingUserQuestion()}
+        gate={activeGateRequest()}
+        rewind={rewindPicker()}
+        session={sessionPicker()}
+        model={modelPicker()}
+        gateFocus={gateFocus()}
+        gateFeedbackMode={gateFeedbackMode()}
+        gateFeedback={gateFeedback()}
+        gateFeedbackCursor={gateFeedbackCursor()}
+        engineSwitchPending={Boolean(pendingEngineSwitch())}
+        questionSelected={questionSelected()}
+        questionFreeformText={questionFreeformText()}
+        questionFreeformCursor={questionFreeformCursor()}
+        modelItems={modelPickerItems()}
+        modelTitle={modelPickerTitle()}
+        commandMenuOpen={commandMenuOpen()}
+        commandItems={commandMenuItems()}
+        commandSelected={commandMenuSelected()}
+        commandArgumentMenuOpen={commandArgumentMenuOpen()}
+        commandArgumentItems={commandArgumentItems()}
+        commandArgumentSelected={commandArgumentSelected()}
+        modelArgumentDraft={modelArgumentDraft()}
+        fixedArgumentDraft={fixedArgumentDraft()}
+        agentArgumentDraft={agentArgumentDraft()}
+        composerPopupMaxRows={composerPopupMaxRows()}
+        composerPopupOpen={composerPopupOpen()}
+        inputNeedsExpandedBottom={inputNeedsExpandedBottom()}
+        inputValue={inputValue()}
+        inputCursor={inputCursor()}
+        inputWidth={composerInputWidth()}
+        busy={busy()}
+        providerConfigReady={providerConfigReady()}
+      />
       <box height={layout().footerHeight} paddingLeft={1}>
         <text
           content={footerLine(activeProvider(), activeModel(), providerHasApiKey(), layout().width, lastTurnUsage(), sessionUsage(), activeModelLimits())}
@@ -2765,475 +787,4 @@ export function App(props: AppProps = {}) {
       </box>
     </box>
   );
-}
-
-function composerElementsForImages(value: string, images: VesicleImageAttachment[]): ComposerElement[] {
-  const matches = [...value.matchAll(/\[Image #\d+\]/g)];
-  return images.flatMap((image, index) => {
-    const match = matches[index];
-    if (!match || match.index === undefined) return [];
-    return [{
-      type: "image" as const,
-      attachmentId: image.id,
-      placeholder: match[0],
-      start: match.index,
-      end: match.index + match[0].length,
-    }];
-  });
-}
-
-function unresolvedToolCalls(messages: ResumedMessage[], activeToolCallId: string) {
-  const answered = new Set(messages.flatMap((message) => message.toolCallId ? [message.toolCallId] : []));
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const calls = messages[index].toolCalls;
-    if (!calls?.some((call) => call.id === activeToolCallId)) continue;
-    return calls.filter((call) => call.id !== activeToolCallId && !answered.has(call.id));
-  }
-  return [];
-}
-
-function engineSwitchGateRequest(currentEngine: EngineId, request: EngineSwitchRequest): GateRequest {
-  const lines = [
-    `Current Engine: ${currentEngine}`,
-    `Target Engine: ${request.targetEngine}`,
-    "",
-    `Reason: ${request.reason}`,
-    "",
-    `Handoff Summary: ${request.handoffSummary}`,
-  ];
-  if (request.recommendedNextAction) {
-    lines.push("", `Recommended Next Action: ${request.recommendedNextAction}`);
-  }
-  return {
-    gate: "engine-switch",
-    summary: lines.join("\n"),
-    options: [
-      { label: `Confirm - switch to ${request.targetEngine}`, decision: "confirm" },
-      { label: `Reject - stay on ${currentEngine} and discuss`, decision: "reject" },
-    ],
-  };
-}
-
-function permissionResolutionFromGate(resolution: GateResolution): PermissionResolution {
-  const resolvedAt = new Date().toISOString();
-  return resolution.decision === "confirm"
-    ? { decision: "allow_once", resolvedAt }
-    : {
-        decision: "reject",
-        resolvedAt,
-        ...(resolution.feedback ? { feedback: resolution.feedback } : {}),
-      };
-}
-
-function displayUserQuestionAnswer(header: string, answer: UserQuestionAnswer): string {
-  if (answer.kind === "skip") return `[question:${header}] skipped`;
-  if (answer.kind === "freeform") return `[question:${header}] ${answer.freeformText ?? answer.label}`;
-  return `[question:${header}] ${answer.label}`;
-}
-
-export function headerLine(engine: EngineId, width: number, agents?: string, processes?: string): string {
-  const left = `Prism Vesicle · ${engineDisplayName(engine)}`;
-  const content = [left, ...(agents ? [`Agents ${agents}`] : []), ...(processes ? [`Shell ${processes}`] : [])].join(" · ");
-  return truncateLine(content, Math.max(20, width - 4));
-}
-
-export function backgroundProcessActivitySummary(processes: BackgroundProcessState[]): string | undefined {
-  const running = processes.filter((process) => process.status === "running").length;
-  return running > 0 ? `${running} running` : undefined;
-}
-
-/**
- * Bottom telemetry line: connection identity plus current-turn and session
- * token counters. A turn is one logical user/gate/question input through the
- * provider tool loop that follows. Repeated provider requests inside the same
- * turn reuse most of the same context, so upstream/cache counters use the
- * latest request's context occupancy while downstream output still sums newly
- * generated tokens. Pricing intentionally stays out of this layer; adapters
- * only normalize runtime usage facts.
- */
-export function footerLine(
-  provider: string,
-  model: string,
-  hasKey: boolean,
-  width: number,
-  turnUsage?: TokenUsageSummary,
-  sessionUsage?: TokenUsageSummary,
-  modelLimits?: ModelLimits,
-): string {
-  const turnTelemetry = turnUsageTelemetryLine(turnUsage);
-  const sessionTelemetry = sessionUsageTelemetryLine(sessionUsage);
-  const contextTelemetry = contextUsageTelemetryLine(turnUsage, modelLimits);
-  const left = `${provider}/${model} · key ${hasKey ? "ok" : "missing"}${turnTelemetry ? ` · ${turnTelemetry}` : ""}${sessionTelemetry ? ` · ${sessionTelemetry}` : ""}`;
-  return footerWithRightTelemetry(left, contextTelemetry, Math.max(20, width - 2));
-}
-
-export function turnUsageTelemetryLine(usage: TokenUsageSummary | undefined): string | undefined {
-  if (!usage) return undefined;
-  if (!hasUsageSummary(usage)) return undefined;
-  const parts: string[] = [];
-  parts.push("turn", tokenArrowPair(usage));
-  const cached = formatTokenCount(usage.cachedInputTokens);
-  if (cached && usage.cachedInputTokens > 0) parts.push(`↻ ${cached}`);
-  return parts.join(" ");
-}
-
-export function sessionUsageTelemetryLine(usage: TokenUsageSummary | undefined): string | undefined {
-  if (!usage) return undefined;
-  if (!hasUsageSummary(usage)) return undefined;
-  return `session ${tokenArrowPair(usage)} ↻ ${formatTokenCount(usage.cachedInputTokens) ?? "0"}`;
-}
-
-export function contextUsageTelemetryLine(usage: TokenUsageSummary | undefined, modelLimits: ModelLimits | undefined): string | undefined {
-  const contextWindow = modelLimits?.contextWindow;
-  if (!usage || !contextWindow || contextWindow <= 0 || usage.contextInputTokens <= 0) return undefined;
-  return `ctx ${formatTokenCount(usage.contextInputTokens)}/${formatTokenCount(contextWindow)} ${formatContextPercent(usage.contextInputTokens, contextWindow)}`;
-}
-
-function footerWithRightTelemetry(left: string, right: string | undefined, width: number): string {
-  if (!right) return truncateLine(left, width);
-  const gap = 4;
-  if (right.length + gap >= width) return truncateLine(right, width);
-  const leftWidth = width - right.length - gap;
-  const leftText = truncateLine(left, leftWidth);
-  const padding = Math.max(gap, width - leftText.length - right.length);
-  return `${leftText}${" ".repeat(padding)}${right}`;
-}
-
-function tokenArrowPair(usage: TokenUsageSummary): string {
-  return `↑${formatTokenCount(usage.inputTokens) ?? "0"} ↓${formatTokenCount(usage.outputTokens) ?? "0"}`;
-}
-
-function formatTokenCount(value: number | undefined): string | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(value) >= 1000) return `${(value / 1000).toFixed(1)}k`;
-  return String(value);
-}
-
-function formatContextPercent(used: number, total: number): string {
-  const percent = (used / total) * 100;
-  return percent < 1 && percent > 0 ? "<1%" : `${Math.round(percent)}%`;
-}
-
-function emptyUsageSummary(): TokenUsageSummary {
-  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, contextInputTokens: 0 };
-}
-
-function addResponseUsageToTurn(current: TokenUsageSummary, usage: ResponseUsage): TokenUsageSummary {
-  const contextInputTokens = contextInputTokensForDisplay(usage);
-  return {
-    inputTokens: latestNonZero(current.inputTokens, contextInputTokens),
-    outputTokens: current.outputTokens + finiteOrZero(usage.outputTokens),
-    cachedInputTokens: latestNonZero(current.cachedInputTokens, cachedInputTokens(usage)),
-    contextInputTokens: latestNonZero(current.contextInputTokens, contextInputTokens),
-  };
-}
-
-function addIndependentUsageToTurn(current: TokenUsageSummary, usage: ResponseUsage): TokenUsageSummary {
-  const input = contextInputTokensForDisplay(usage);
-  return {
-    inputTokens: current.inputTokens + input,
-    outputTokens: current.outputTokens + finiteOrZero(usage.outputTokens),
-    cachedInputTokens: current.cachedInputTokens + cachedInputTokens(usage),
-    contextInputTokens: latestNonZero(current.contextInputTokens, input),
-  };
-}
-
-function combineIndependentUsage(usages: Array<ResponseUsage | undefined>): ResponseUsage | undefined {
-  const present = usages.filter((usage): usage is ResponseUsage => Boolean(usage));
-  if (present.length === 0) return undefined;
-  const sum = (read: (usage: ResponseUsage) => number | undefined) => present.reduce((total, usage) => total + finiteOrZero(read(usage)), 0);
-  const inputTokens = sum((usage) => usage.inputTokens ?? usage.contextInputTokens);
-  const outputTokens = sum((usage) => usage.outputTokens);
-  return {
-    inputTokens,
-    outputTokens,
-    totalTokens: inputTokens + outputTokens,
-    cacheReadInputTokens: sum((usage) => usage.cacheReadInputTokens),
-    cacheWriteInputTokens: sum((usage) => usage.cacheWriteInputTokens),
-    cacheHitInputTokens: sum((usage) => usage.cacheHitInputTokens),
-    cacheMissInputTokens: sum((usage) => usage.cacheMissInputTokens),
-    reasoningTokens: sum((usage) => usage.reasoningTokens),
-    effectiveTokens: sum((usage) => usage.effectiveTokens),
-  };
-}
-
-function mergeLogicalTurnUsage(parent: TokenUsageSummary, agents: TokenUsageSummary): TokenUsageSummary {
-  return {
-    inputTokens: parent.inputTokens + agents.inputTokens,
-    outputTokens: parent.outputTokens + agents.outputTokens,
-    cachedInputTokens: parent.cachedInputTokens + agents.cachedInputTokens,
-    contextInputTokens: parent.contextInputTokens || agents.contextInputTokens,
-  };
-}
-
-function addTurnUsageToSession(current: TokenUsageSummary, turn: TokenUsageSummary): TokenUsageSummary {
-  return {
-    inputTokens: current.inputTokens + turn.inputTokens,
-    outputTokens: current.outputTokens + turn.outputTokens,
-    cachedInputTokens: current.cachedInputTokens + turn.cachedInputTokens,
-    contextInputTokens: latestNonZero(current.contextInputTokens, turn.contextInputTokens),
-  };
-}
-
-export function sumSessionUsage(messages: ResumedMessage[]): TokenUsageSummary {
-  let session = emptyUsageSummary();
-  let turn = emptyUsageSummary();
-  let agents = emptyUsageSummary();
-  for (const message of messages) {
-    if (message.role === "user" && isAuthoredUserMessage(message)) {
-      const combined = mergeLogicalTurnUsage(turn, agents);
-      if (hasUsageSummary(combined)) session = addTurnUsageToSession(session, combined);
-      turn = emptyUsageSummary();
-      agents = emptyUsageSummary();
-      continue;
-    }
-    if (message.usage) {
-      if (message.kind === "subagent-result" || message.kind === "subagent-results") {
-        agents = addIndependentUsageToTurn(agents, message.usage);
-      } else {
-        turn = addResponseUsageToTurn(turn, message.usage);
-      }
-    }
-  }
-  const combined = mergeLogicalTurnUsage(turn, agents);
-  if (hasUsageSummary(combined)) session = addTurnUsageToSession(session, combined);
-  return session;
-}
-
-export function latestTurnUsage(messages: ResumedMessage[]): TokenUsageSummary | undefined {
-  let lastUserIndex = -1;
-  for (let index = messages.length - 1; index >= 0; index--) {
-    if (messages[index].role === "user" && isAuthoredUserMessage(messages[index])) {
-      lastUserIndex = index;
-      break;
-    }
-  }
-  if (lastUserIndex < 0) return undefined;
-  let summary = emptyUsageSummary();
-  let agents = emptyUsageSummary();
-  for (const message of messages.slice(lastUserIndex + 1)) {
-    if (message.usage) {
-      if (message.kind === "subagent-result" || message.kind === "subagent-results") {
-        agents = addIndependentUsageToTurn(agents, message.usage);
-      } else {
-        summary = addResponseUsageToTurn(summary, message.usage);
-      }
-    }
-  }
-  const combined = mergeLogicalTurnUsage(summary, agents);
-  return hasUsageSummary(combined) ? combined : undefined;
-}
-
-function isAuthoredUserMessage(message: ResumedMessage): boolean {
-  return message.kind !== "gate-resolution"
-    && message.kind !== "user-question-answer"
-    && message.kind !== "compact-summary"
-    && message.kind !== "subagent-results"
-    && message.kind !== "background-process-results"
-    && message.kind !== ENGINE_HANDOFF_KIND;
-}
-
-function cachedInputTokens(usage: ResponseUsage): number {
-  return finiteOrZero(usage.cacheReadInputTokens ?? usage.cacheHitInputTokens);
-}
-
-function contextInputTokensForDisplay(usage: ResponseUsage): number {
-  return finiteOrZero(usage.contextInputTokens ?? usage.inputTokens);
-}
-
-function latestNonZero(current: number, next: number): number {
-  return next > 0 ? next : current;
-}
-
-function hasUsageSummary(usage: TokenUsageSummary): boolean {
-  return usage.inputTokens > 0 || usage.outputTokens > 0 || usage.cachedInputTokens > 0 || usage.contextInputTokens > 0;
-}
-
-function finiteOrZero(value: number | undefined): number {
-  return typeof value === "number" && Number.isFinite(value) ? value : 0;
-}
-
-function sameStringSet(value: unknown, expected: string[]): boolean {
-  if (!Array.isArray(value) || value.some((entry) => typeof entry !== "string")) return false;
-  const actual = [...new Set(value as string[])].sort();
-  return actual.length === expected.length && actual.every((entry, index) => entry === expected[index]);
-}
-
-function activityLine(entry: ActivityEntry, width: number): string {
-  const label = entry.kind.padEnd(10, " ");
-  return truncateLine(`${label} ${entry.text}`, width);
-}
-
-function activityColor(kind: ActivityEntry["kind"]): string {
-  switch (kind) {
-    case "provider":
-      return palette.user;
-    case "assistant":
-      return palette.assistant;
-    case "tool":
-      return palette.tool;
-    case "agent":
-      return palette.brand;
-    case "gate":
-      return palette.gateAccent;
-    case "validation":
-      return palette.warn;
-    case "system":
-      return palette.textDim;
-  }
-}
-
-function vesicleMessagesFromResumed(messages: ResumedMessage[]): VesicleMessage[] {
-  return messages.map((message) => ({
-    role: message.role,
-    content: message.content,
-    ...(message.reasoningContent ? { reasoningContent: message.reasoningContent } : {}),
-    ...(message.thinkingBlocks ? { thinkingBlocks: message.thinkingBlocks.map((block) => ({ ...block })) } : {}),
-    ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
-    ...(message.toolCalls ? { toolCalls: message.toolCalls.map((call) => ({ ...call })) } : {}),
-    ...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
-  }));
-}
-
-export function displayTranscriptFromSnapshot(messages: ResumedMessage[], agents: AgentCardState[] = []): Message[] {
-  const argsByCallId = new Map<string, { name: string; arguments: string }>();
-  for (const message of messages) {
-    for (const call of message.toolCalls ?? []) {
-      argsByCallId.set(call.id, { name: call.name, arguments: call.arguments });
-    }
-  }
-  const agentsByToolCallId = new Map(agents.map((agent) => [agent.parentToolCallId, agent]));
-  return messages.flatMap((message) => displayMessagesFromResumed(message, argsByCallId, agentsByToolCallId));
-}
-
-function displayMessagesFromResumed(
-  message: ResumedMessage,
-  argsByCallId: Map<string, { name: string; arguments: string }>,
-  agentsByToolCallId: Map<string, AgentCardState> = new Map(),
-): Message[] {
-  if (message.kind === ENGINE_HANDOFF_KIND) {
-    return [{
-      role: "system",
-      content: message.content
-        .replace(/^\[engine_handoff\]\s*/i, "Engine handoff\n")
-        .replace(/\s*\[\/engine_handoff\]\s*$/i, ""),
-    }];
-  }
-  if (message.kind === "compact-summary") {
-    return [{ role: "system", content: message.content.replace(/^\[conversation summary\]\s*/i, "Conversation summary\n") }];
-  }
-  if (message.role === "assistant") {
-    // Prose only — the tool calls render as inline cards from the tool-result
-    // records that follow (mirrors the live assistant_response handling).
-    const reasoningText = displayTextFromThinkingBlocks(message.thinkingBlocks) ?? message.reasoningContent;
-    const out: Message[] = [];
-    if (reasoningText?.trim()) out.push({ role: "system", content: reasoningText, kind: "reasoning" });
-    if (message.content.trim()) {
-      out.push({
-        role: "assistant",
-        content: message.content,
-        ...(message.engine ? { engine: message.engine } : {}),
-        ...(message.model ? { model: message.model } : {}),
-      });
-    }
-    return out;
-  }
-  if (message.role === "tool") {
-    const lookup = message.toolCallId ? argsByCallId.get(message.toolCallId) : undefined;
-    if (lookup?.name === "spawn_agent") {
-      const agent = message.toolCallId ? agentsByToolCallId.get(message.toolCallId) : undefined;
-      return agent ? [{ role: "system", content: "", kind: "agent", agentRunId: agent.runId }] : [];
-    }
-    if (lookup) {
-      // Reconstruct the same call + result pair the live event flow produces.
-      const ok = message.toolOk ?? true;
-      return [
-        {
-          role: "tool",
-          toolStage: "call",
-          toolName: lookup.name,
-          toolArgs: lookup.arguments,
-          toolCallId: message.toolCallId,
-          toolFileEvent: message.toolFileEvent,
-          toolWebEvent: message.toolWebEvent,
-          toolMcpEvent: message.toolMcpEvent,
-          toolProcessEvent: message.toolProcessEvent,
-          toolOk: ok,
-          images: message.images,
-          content: "",
-        },
-        {
-          role: "tool",
-          toolStage: "result",
-          toolName: lookup.name,
-          toolCallId: message.toolCallId,
-          toolOk: ok,
-          toolFileEvent: message.toolFileEvent,
-          toolWebEvent: message.toolWebEvent,
-          toolMcpEvent: message.toolMcpEvent,
-          toolProcessEvent: message.toolProcessEvent,
-          images: message.images,
-          content: ok ? "" : extractResultContent(message.content),
-        },
-      ];
-    }
-    return [{ role: "tool", content: renderResumedToolResultSummary(message.content), images: message.images }];
-  }
-  if (message.role === "user" && message.kind === "subagent-results") {
-    return [{ role: "system", content: "Background SubAgent results were delivered to the parent Engine." }];
-  }
-  if (message.role === "user" && message.kind === "background-process-results") {
-    return [{ role: "system", content: "Background shell completion was delivered to the active Engine." }];
-  }
-  if (message.role === "user") {
-    return [{
-      role: message.role,
-      content: message.content,
-      ...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
-    }];
-  }
-  return [{ role: "system", content: message.content }];
-}
-
-/** Pull the result text out of a stored `{ok, result}` tool-record content. */
-function extractResultContent(raw: string): string {
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && typeof (parsed as { result?: unknown }).result === "string") {
-      return (parsed as { result: string }).result;
-    }
-  } catch {
-    // fall through
-  }
-  return raw;
-}
-
-function providerOptionItems(registry: ProviderRegistry): OptionItem[] {
-  return registry.providers.map((provider) => ({
-    id: provider.id,
-    label: provider.id,
-    detail: `${provider.protocol} · ${provider.models.length} model${provider.models.length === 1 ? "" : "s"}`,
-  }));
-}
-
-function commandArgumentHint(modelDraft: ModelArgumentDraft | null, fixedDraft: FixedArgumentDraft | null, agentDraft: AgentArgumentDraft | null): string {
-  const scope = modelDraft
-    ? modelDraft.stage === "provider" ? "providers" : `models · ${modelDraft.providerId}`
-    : fixedDraft?.command ?? (agentDraft ? agentDraft.stage === "stop" ? "running agents" : "agents" : "arguments");
-  return `${scope} · ↑/↓ choose · Tab complete · Enter select`;
-}
-
-function modelOptionItems(registry: ProviderRegistry, providerId: string): OptionItem[] {
-  const provider = registry.providers.find((entry) => entry.id === providerId);
-  if (!provider) return [];
-  return provider.models.map((model) => ({
-    id: model.id,
-    label: model.id,
-    detail: renderModelDetails(model),
-  }));
-}
-
-function joinSessionPath(sessionId: string): string {
-  return `.vesicle/sessions/${sessionId}.jsonl`;
 }

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -49,7 +49,7 @@ import { createProviderConfigController, createProviderState } from "./provider-
 import { createSessionActionsController } from "./session-actions-controller";
 import { createSessionPreferencesController } from "./session-preferences-controller";
 import { createAgentCommand } from "./agent-command";
-import { registerInputRouting } from "./input-routing";
+import { useInputRouting } from "./input-routing";
 
 export type AppProps = {
   dangerouslySkipPermissions?: boolean;
@@ -598,7 +598,7 @@ export function App(props: AppProps = {}) {
     });
   });
 
-  registerInputRouting({
+  useInputRouting({
     renderer,
     setStatus,
     rewindPicker,
@@ -609,12 +609,10 @@ export function App(props: AppProps = {}) {
     handleSessionPickerKey,
     yoloConfirmStage,
     handleYoloKey,
+    activePermissionRequest,
     pendingUserQuestion,
     handleQuestionKey,
-    pendingGate,
-    pendingEngineSwitch,
-    pendingPermission,
-    pendingChildPermission,
+    activeGateRequest,
     handleGateKey,
     pasteClipboardImage,
     handleComposerKey,

--- a/src/tui/command-completion-controller.ts
+++ b/src/tui/command-completion-controller.ts
@@ -1,0 +1,224 @@
+import { createEffect, createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import type { ProviderRegistry } from "../config/providers";
+import type { VesicleImageAttachment } from "../providers/shared/types";
+import { builtinCommands } from "./commands/builtin";
+import {
+  completeAgentArgument,
+  completeFixedArgument,
+  completeModelArgument,
+  fixedArgumentOptions,
+  matchOptionItems,
+  parseAgentArgumentDraft,
+  parseFixedArgumentDraft,
+  parseModelArgumentDraft,
+} from "./commands/argument-completion";
+import { matchCommands } from "./commands/match";
+import { modelOptionItems, providerOptionItems } from "./commands/options";
+import { clampCommandMenuSelection, moveCommandMenuSelection } from "./commands/selection";
+import { normalizeKeyName, setComposerValue, type ComposerState } from "./composer";
+import type { TuiKeyEvent } from "./decision-interaction";
+import type { AgentCardState, OptionItem } from "./types";
+
+export type CommandCompletionControllerOptions = {
+  inputValue: Accessor<string>;
+  applyComposerState: (state: ComposerState) => void;
+  clearComposer: () => void;
+  setInputImages: Setter<VesicleImageAttachment[]>;
+  setHistoryIndex: Setter<number | null>;
+  providerRegistry: Accessor<ProviderRegistry | null>;
+  agentCards: Accessor<AgentCardState[]>;
+  sessionId: Accessor<string | undefined>;
+  busy: Accessor<boolean>;
+  setStatus: Setter<string>;
+  submitPrompt: (value: string) => Promise<void>;
+};
+
+export function createCommandCompletionController(options: CommandCompletionControllerOptions) {
+  const commandMenuOpen = createMemo(() => options.inputValue().startsWith("/") && !options.inputValue().slice(1).includes(" "));
+  const commandMenuQuery = createMemo(() => options.inputValue().slice(1));
+  const commandMenuItems = createMemo(() => matchCommands(commandMenuQuery(), builtinCommands));
+  const [commandMenuSelected, setCommandMenuSelected] = createSignal(0);
+  createEffect(() => {
+    setCommandMenuSelected((selected) => clampCommandMenuSelection(selected, commandMenuItems().length));
+  });
+  let previousCommandMenuQuery: string | null = null;
+  createEffect(() => {
+    const query = commandMenuOpen() ? commandMenuQuery() : null;
+    if (query !== previousCommandMenuQuery) setCommandMenuSelected(0);
+    previousCommandMenuQuery = query;
+  });
+
+  const modelArgumentDraft = createMemo(() => parseModelArgumentDraft(options.inputValue()));
+  const fixedArgumentDraft = createMemo(() => parseFixedArgumentDraft(options.inputValue()));
+  const agentArgumentDraft = createMemo(() => parseAgentArgumentDraft(options.inputValue()));
+  const commandArgumentMenuOpen = createMemo(() => Boolean(modelArgumentDraft() || fixedArgumentDraft() || agentArgumentDraft()));
+  const commandArgumentItems = createMemo<OptionItem[]>(() => {
+    const modelDraft = modelArgumentDraft();
+    if (modelDraft) {
+      const registry = options.providerRegistry();
+      if (!registry) return [];
+      const candidates = modelDraft.stage === "provider"
+        ? providerOptionItems(registry)
+        : modelOptionItems(registry, modelDraft.providerId);
+      return matchOptionItems(modelDraft.query, candidates);
+    }
+    const fixedDraft = fixedArgumentDraft();
+    if (fixedDraft) return matchOptionItems(fixedDraft.query, fixedArgumentOptions(fixedDraft.command));
+    const agentDraft = agentArgumentDraft();
+    if (!agentDraft) return [];
+    const handles = agentOptionItems();
+    const candidates = agentDraft.stage === "command"
+      ? [
+          { id: "stop", label: "stop", detail: "Interrupt a running SubAgent" },
+          { id: "retry", label: "retry", detail: "Retry paused background-result delivery" },
+          ...handles,
+        ]
+      : handles.filter((item) => {
+          const agent = options.agentCards().find((candidate) => candidate.handle === item.id);
+          return agent?.status === "queued" || agent?.status === "running";
+        });
+    return matchOptionItems(agentDraft.query, candidates);
+  });
+  const [commandArgumentSelected, setCommandArgumentSelected] = createSignal(0);
+  createEffect(() => {
+    setCommandArgumentSelected((selected) => clampCommandMenuSelection(selected, commandArgumentItems().length));
+  });
+  let previousCommandArgumentKey: string | null = null;
+  createEffect(() => {
+    const modelDraft = modelArgumentDraft();
+    const fixedDraft = fixedArgumentDraft();
+    const agentDraft = agentArgumentDraft();
+    const key = modelDraft
+      ? `model:${modelDraft.stage}:${modelDraft.stage === "model" ? `${modelDraft.providerId}:` : ""}${modelDraft.query}`
+      : fixedDraft
+        ? `fixed:${fixedDraft.command}:${fixedDraft.query}`
+        : agentDraft
+          ? `agent:${agentDraft.stage}:${agentDraft.query}`
+          : null;
+    if (key !== previousCommandArgumentKey) setCommandArgumentSelected(0);
+    previousCommandArgumentKey = key;
+  });
+
+  function agentOptionItems(): OptionItem[] {
+    return options.agentCards()
+      .filter((agent) => agent.parentSessionId === options.sessionId())
+      .map((agent) => ({ id: agent.handle, label: agent.handle, detail: `${agent.status} · ${agent.description}` }));
+  }
+
+  function handleKey(key: TuiKeyEvent): boolean {
+    if (commandMenuOpen()) return handleCommandMenuKey(key);
+    if (commandArgumentMenuOpen()) return handleCommandArgumentMenuKey(key);
+    return false;
+  }
+
+  function handleCommandMenuKey(key: TuiKeyEvent): boolean {
+    const name = normalizeKeyName(key.name);
+    if (name === "up" || (key.ctrl && name === "p")) {
+      setCommandMenuSelected((selected) => moveCommandMenuSelection(selected, -1, commandMenuItems().length));
+      return true;
+    }
+    if (name === "down" || (key.ctrl && name === "n")) {
+      setCommandMenuSelected((selected) => moveCommandMenuSelection(selected, 1, commandMenuItems().length));
+      return true;
+    }
+    if (name === "tab") {
+      const command = commandMenuItems()[commandMenuSelected()];
+      if (command) completeCommandName(command.name);
+      return true;
+    }
+    if (name === "return" || name === "enter") {
+      const command = commandMenuItems()[commandMenuSelected()];
+      if (!command) return true;
+      if (options.inputValue() === `/${command.name}`) submitCompletedCommandArgument(`/${command.name}`);
+      else completeCommandName(command.name);
+      return true;
+    }
+    if (name === "escape") {
+      options.clearComposer();
+      return true;
+    }
+    return false;
+  }
+
+  function completeCommandName(name: string): void {
+    options.applyComposerState(setComposerValue(`/${name} `));
+    options.setInputImages([]);
+    setCommandMenuSelected(0);
+    options.setHistoryIndex(null);
+  }
+
+  function handleCommandArgumentMenuKey(key: TuiKeyEvent): boolean {
+    const name = normalizeKeyName(key.name);
+    const items = commandArgumentItems();
+    if (name === "up" || (key.ctrl && name === "p")) {
+      setCommandArgumentSelected((selected) => moveCommandMenuSelection(selected, -1, items.length));
+      return true;
+    }
+    if (name === "down" || (key.ctrl && name === "n")) {
+      setCommandArgumentSelected((selected) => moveCommandMenuSelection(selected, 1, items.length));
+      return true;
+    }
+    if (name === "tab") {
+      completeSelectedCommandArgument();
+      return true;
+    }
+    if (name === "enter" || name === "return") {
+      const item = items[commandArgumentSelected()];
+      const completed = item ? selectedCommandArgumentValue(item) : null;
+      if (!completed) return false;
+      const executable = completed.trimEnd();
+      if (options.inputValue() === executable) submitCompletedCommandArgument(executable);
+      else applyCompletedCommandArgument(completed);
+      return true;
+    }
+    if (name === "escape") {
+      options.clearComposer();
+      return true;
+    }
+    return false;
+  }
+
+  function completeSelectedCommandArgument(): void {
+    const item = commandArgumentItems()[commandArgumentSelected()];
+    const completed = item ? selectedCommandArgumentValue(item) : null;
+    if (completed) applyCompletedCommandArgument(completed);
+  }
+
+  function selectedCommandArgumentValue(item: OptionItem): string | null {
+    const modelDraft = modelArgumentDraft();
+    if (modelDraft) return completeModelArgument(modelDraft, item);
+    const fixedDraft = fixedArgumentDraft();
+    if (fixedDraft) return completeFixedArgument(fixedDraft, item);
+    const agentDraft = agentArgumentDraft();
+    return agentDraft ? completeAgentArgument(agentDraft, item) : null;
+  }
+
+  function submitCompletedCommandArgument(value: string): void {
+    if (options.busy()) {
+      options.setStatus("request in flight; draft kept");
+      return;
+    }
+    options.clearComposer();
+    void options.submitPrompt(value);
+  }
+
+  function applyCompletedCommandArgument(value: string): void {
+    options.applyComposerState(setComposerValue(value));
+    options.setInputImages([]);
+    setCommandArgumentSelected(0);
+    options.setHistoryIndex(null);
+  }
+
+  return {
+    agentArgumentDraft,
+    commandArgumentItems,
+    commandArgumentMenuOpen,
+    commandArgumentSelected,
+    commandMenuItems,
+    commandMenuOpen,
+    commandMenuSelected,
+    fixedArgumentDraft,
+    handleKey,
+    modelArgumentDraft,
+  };
+}

--- a/src/tui/commands/options.ts
+++ b/src/tui/commands/options.ts
@@ -1,0 +1,33 @@
+import type { ProviderRegistry } from "../../config/providers";
+import { renderModelDetails } from "./render";
+import type { AgentArgumentDraft, FixedArgumentDraft, ModelArgumentDraft } from "./argument-completion";
+import type { OptionItem } from "../types";
+
+export function providerOptionItems(registry: ProviderRegistry): OptionItem[] {
+  return registry.providers.map((provider) => ({
+    id: provider.id,
+    label: provider.id,
+    detail: `${provider.protocol} · ${provider.models.length} model${provider.models.length === 1 ? "" : "s"}`,
+  }));
+}
+
+export function modelOptionItems(registry: ProviderRegistry, providerId: string): OptionItem[] {
+  const provider = registry.providers.find((entry) => entry.id === providerId);
+  if (!provider) return [];
+  return provider.models.map((model) => ({
+    id: model.id,
+    label: model.id,
+    detail: renderModelDetails(model),
+  }));
+}
+
+export function commandArgumentHint(
+  modelDraft: ModelArgumentDraft | null,
+  fixedDraft: FixedArgumentDraft | null,
+  agentDraft: AgentArgumentDraft | null,
+): string {
+  const scope = modelDraft
+    ? modelDraft.stage === "provider" ? "providers" : `models · ${modelDraft.providerId}`
+    : fixedDraft?.command ?? (agentDraft ? agentDraft.stage === "stop" ? "running agents" : "agents" : "arguments");
+  return `${scope} · ↑/↓ choose · Tab complete · Enter select`;
+}

--- a/src/tui/composer-controller.ts
+++ b/src/tui/composer-controller.ts
@@ -1,0 +1,248 @@
+import { createEffect, createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import type { ModelCapabilities } from "../config/env";
+import type { ProviderRegistry, ProviderSelection } from "../config/providers";
+import { ingestImageBytes } from "../core/attachments/store";
+import type { VesicleImageAttachment } from "../providers/shared/types";
+import { readImageFromClipboard } from "./clipboard";
+import {
+  applyComposerKey,
+  insertComposerImage,
+  insertComposerText,
+  setComposerValue,
+  type ComposerElement,
+  type ComposerState,
+} from "./composer";
+import type { PromptHistoryEntry } from "./composer-history";
+import { composerVisualLineCount } from "./composer-layout";
+import type { ActivityEntry, AgentCardState, Message, OptionItem } from "./types";
+import type { TuiKeyEvent } from "./decision-interaction";
+import { PromptEscapeController } from "./prompt-escape";
+import { createModelPickerController } from "./model-picker-controller";
+import { createCommandCompletionController } from "./command-completion-controller";
+
+export type ComposerControllerOptions = {
+  rootDir: string;
+  terminalWidth: Accessor<number>;
+  providerRegistry: Accessor<ProviderRegistry | null>;
+  ensureProviderRegistry: () => Promise<ProviderRegistry>;
+  applyProviderSelection: (selection: Partial<ProviderSelection>) => Promise<ProviderSelection>;
+  persistProviderSwitch: (selection: ProviderSelection) => Promise<void>;
+  agentCards: Accessor<AgentCardState[]>;
+  sessionId: Accessor<string | undefined>;
+  busy: Accessor<boolean>;
+  activeModelCapabilities: Accessor<ModelCapabilities | undefined>;
+  status: Accessor<string>;
+  setStatus: Setter<string>;
+  setMessages: Setter<Message[]>;
+  recordActivity: (entry: ActivityEntry) => void;
+  reportError: (error: unknown) => void;
+  submitPrompt: (value: string, images?: VesicleImageAttachment[], elements?: ComposerElement[]) => Promise<void>;
+  abortTurn: () => boolean;
+  openRewind: () => Promise<void>;
+};
+
+export function createComposerController(options: ComposerControllerOptions) {
+  const [inputValue, setInputValue] = createSignal("");
+  const [inputCursor, setInputCursor] = createSignal(0);
+  const [inputKillBuffer, setInputKillBuffer] = createSignal<string | undefined>();
+  const [inputElements, setInputElements] = createSignal<ComposerElement[]>([]);
+  const [inputImages, setInputImages] = createSignal<VesicleImageAttachment[]>([]);
+  const [promptHistory, setPromptHistory] = createSignal<PromptHistoryEntry[]>([]);
+  const [historyIndex, setHistoryIndex] = createSignal<number | null>(null);
+  const promptEscape = new PromptEscapeController();
+  const modelPickerController = createModelPickerController(options);
+  const commandCompletionController = createCommandCompletionController({
+    inputValue,
+    applyComposerState: applyState,
+    clearComposer: clear,
+    setInputImages,
+    setHistoryIndex,
+    providerRegistry: options.providerRegistry,
+    agentCards: options.agentCards,
+    sessionId: options.sessionId,
+    busy: options.busy,
+    setStatus: options.setStatus,
+    submitPrompt: (value) => options.submitPrompt(value),
+  });
+
+  const {
+    agentArgumentDraft,
+    commandArgumentItems,
+    commandArgumentMenuOpen,
+    commandArgumentSelected,
+    commandMenuItems,
+    commandMenuOpen,
+    commandMenuSelected,
+    fixedArgumentDraft,
+    handleKey: handleCommandCompletionKey,
+    modelArgumentDraft,
+  } = commandCompletionController;
+  const composerInputWidth = createMemo(() => Math.max(8, options.terminalWidth() - 4));
+  const inputVisualLines = createMemo(() => composerVisualLineCount(inputValue(), composerInputWidth()));
+  const composerPopupOpen = createMemo(() => commandMenuOpen() || commandArgumentMenuOpen());
+  const inputNeedsExpandedBottom = createMemo(() => composerPopupOpen() || inputVisualLines() > 1);
+
+  function currentState(): ComposerState {
+    return {
+      value: inputValue(),
+      cursor: inputCursor(),
+      killBuffer: inputKillBuffer(),
+      elements: inputElements(),
+    };
+  }
+
+  function applyState(state: ComposerState): void {
+    setInputValue(state.value);
+    setInputCursor(state.cursor);
+    setInputKillBuffer(state.killBuffer);
+    setInputElements(state.elements ?? []);
+  }
+
+  function clear(): void {
+    applyState(setComposerValue(""));
+    setInputImages([]);
+  }
+
+  function handleKey(key: TuiKeyEvent): boolean {
+    if (handleCommandCompletionKey(key)) return true;
+    const result = applyComposerKey(currentState(), key, { columns: composerInputWidth() });
+    if (!result.handled) return false;
+    applyState(result.state);
+    if (result.action?.type === "submit") submitComposerAction(result.action.value, result.action.elements ?? []);
+    else if (result.action?.type === "history_up") {
+      if (!options.busy()) recallHistory(-1);
+    } else if (result.action?.type === "history_down") {
+      if (historyIndex() !== null && !options.busy()) recallHistory(1);
+    } else {
+      setHistoryIndex(null);
+    }
+    return true;
+  }
+
+  function submitComposerAction(value: string, elements: ComposerElement[]): void {
+    if (options.busy()) {
+      options.setStatus("request in flight; draft kept");
+      return;
+    }
+    if (value.trim().length === 0) return;
+    const images = imagesForElements(elements);
+    if (images.length > 0 && options.activeModelCapabilities()?.vision !== true) {
+      options.setStatus("current model does not declare vision support; draft kept");
+      return;
+    }
+    clear();
+    void options.submitPrompt(value, images, elements);
+  }
+
+  function recallHistory(direction: -1 | 1): void {
+    const history = promptHistory();
+    if (history.length === 0) return;
+    const current = historyIndex();
+    const next = current === null ? history.length - 1 : Math.max(0, Math.min(history.length - 1, current + direction));
+    setHistoryIndex(next);
+    const entry = history[next];
+    if (!entry) return;
+    applyState({ value: entry.value, cursor: entry.value.length, elements: entry.elements.map((element) => ({ ...element })) });
+    setInputImages(entry.images.map((image) => ({ ...image })));
+  }
+
+  function imagesForElements(elements: ComposerElement[]): VesicleImageAttachment[] {
+    const byId = new Map(inputImages().map((image) => [image.id, image]));
+    return elements.flatMap((element) => {
+      const image = byId.get(element.attachmentId);
+      return image ? [{ ...image }] : [];
+    });
+  }
+
+  function recordHistory(value: string, elements: ComposerElement[], images: VesicleImageAttachment[]): void {
+    const entry: PromptHistoryEntry = {
+      value,
+      elements: elements.map((element) => ({ ...element })),
+      images: images.map((image) => ({ ...image })),
+    };
+    setPromptHistory((previous) => [...previous.filter((candidate) => candidate.value !== value), entry].slice(-50));
+  }
+
+  function handleEscape(): void {
+    const draft = inputValue();
+    switch (promptEscape.press({ busy: options.busy(), draft, hasSession: Boolean(options.sessionId()) })) {
+      case "interrupt":
+        if (options.abortTurn()) options.setStatus("interrupting request");
+        return;
+      case "clear":
+        if (draft.trim() || inputImages().length > 0) recordHistory(draft, inputElements(), inputImages());
+        clear();
+        options.setStatus("input cleared");
+        return;
+      case "arm-clear":
+        options.setStatus("Esc again to clear");
+        setTimeout(() => {
+          if (options.status() === "Esc again to clear") options.setStatus("ready");
+        }, 1000);
+        return;
+      case "rewind":
+        void options.openRewind();
+        return;
+      case "arm-rewind":
+      case "noop":
+        return;
+    }
+  }
+
+  async function pasteClipboardImage(): Promise<void> {
+    options.setStatus("reading clipboard image");
+    try {
+      const bytes = await readImageFromClipboard();
+      if (!bytes) throw new Error("No supported image was found in the clipboard.");
+      const image = await ingestImageBytes(options.rootDir, bytes, { source: "clipboard", filename: "clipboard.png" });
+      const number = inputElements().filter((element) => element.type === "image").length + 1;
+      const withImage = insertComposerImage(currentState(), image.id, `[Image #${number}]`);
+      applyState(insertComposerText(withImage, " "));
+      setInputImages((current) => [...current, image]);
+      setHistoryIndex(null);
+      options.setStatus(options.activeModelCapabilities()?.vision === true
+        ? `attached Image #${number}`
+        : `attached Image #${number}; current model does not declare vision support`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      options.setStatus(`image paste failed: ${message}`);
+      options.recordActivity({ kind: "system", text: `image paste failed: ${message}` });
+    }
+  }
+
+  function insertPastedText(text: string): void {
+    applyState(insertComposerText(currentState(), text));
+  }
+
+  return {
+    ...modelPickerController,
+    agentArgumentDraft,
+    applyState,
+    clear,
+    commandArgumentItems,
+    commandArgumentMenuOpen,
+    commandArgumentSelected,
+    commandMenuItems,
+    commandMenuOpen,
+    commandMenuSelected,
+    composerInputWidth,
+    composerPopupOpen,
+    fixedArgumentDraft,
+    handleEscape,
+    handleKey,
+    historyIndex,
+    inputCursor,
+    inputElements,
+    inputImages,
+    inputNeedsExpandedBottom,
+    inputValue,
+    insertPastedText,
+    modelArgumentDraft,
+    pasteClipboardImage,
+    promptHistory,
+    recordHistory,
+    setHistoryIndex,
+    setInputImages,
+    setPromptHistory,
+  };
+}

--- a/src/tui/composer-history.ts
+++ b/src/tui/composer-history.ts
@@ -1,0 +1,23 @@
+import type { VesicleImageAttachment } from "../providers/shared/types";
+import type { ComposerElement } from "./composer";
+
+export type PromptHistoryEntry = {
+  value: string;
+  elements: ComposerElement[];
+  images: VesicleImageAttachment[];
+};
+
+export function composerElementsForImages(value: string, images: VesicleImageAttachment[]): ComposerElement[] {
+  const matches = [...value.matchAll(/\[Image #\d+\]/g)];
+  return images.flatMap((image, index) => {
+    const match = matches[index];
+    if (!match || match.index === undefined) return [];
+    return [{
+      type: "image" as const,
+      attachmentId: image.id,
+      placeholder: match[0],
+      start: match.index,
+      end: match.index + match[0].length,
+    }];
+  });
+}

--- a/src/tui/decision-continuations.ts
+++ b/src/tui/decision-continuations.ts
@@ -1,0 +1,284 @@
+import type { EngineSwitchConfirmedResult, RunPromptResult } from "../core/agent-loop/run";
+import { resolveEngineSwitch, resolveGate, resolvePermission, resolveUserQuestion } from "../core/agent-loop/run";
+import type { GateResolution } from "../core/gate/types";
+import type { PermissionResolution } from "../core/permissions";
+import { loadSessionSnapshot } from "../core/session/store";
+import type { UserQuestionAnswer } from "../core/user-question/types";
+import type { PendingEngineSwitchState, PendingPermissionState, PendingUserQuestionState } from "./decision-interaction";
+import { displayUserQuestionAnswer } from "./decision-interaction";
+import { displayTranscriptFromSnapshot, vesicleMessagesFromResumed } from "./session-presenter";
+import type { DecisionContinuationOptions } from "./turn-controller-options";
+
+export function createDecisionContinuations(options: DecisionContinuationOptions) {
+  async function submitPermissionResolution(resolution: PermissionResolution): Promise<void> {
+    const pending = options.pendingPermission();
+    if (!pending || options.busy()) return;
+    options.setBusy(true);
+    options.setStatus(`resolving permission: ${resolution.decision}`);
+    options.recordActivity({ kind: "tool", text: `${resolution.decision} ${pending.request.toolName}` });
+    options.setPendingPermission(null);
+    options.setGateFeedbackMode(null);
+    options.clearGateFeedback();
+    options.beginUsageTurn();
+    try {
+      const outcome = await options.runCancellable((signal) => resolvePermission({
+        engine: pending.engine,
+        sessionId: pending.sessionId,
+        messages: pending.messages,
+        request: pending.request,
+        remainingToolCalls: pending.remainingToolCalls,
+        deferredAgentPermissions: pending.deferredAgentPermissions,
+        resolution,
+        providerSelection: options.activeProviderSelection(),
+        generation: options.activeGeneration(),
+        permission: options.permissionContext(),
+        signal,
+        onEvent: options.handleAgentEvent,
+        agentManager: options.agentManager(),
+        permissionBroker: options.permissionBroker,
+      }));
+      if (outcome.kind === "interrupted") {
+        await reconcilePermissionAfterContinuationFailure(pending);
+        options.handleInterruptedTurn();
+      } else options.handleResult(outcome.value);
+    } catch (error) {
+      await reconcilePermissionAfterContinuationFailure(pending);
+      options.reportError(error);
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
+  async function reconcilePermissionAfterContinuationFailure(pending: PendingPermissionState): Promise<void> {
+    try {
+      const snapshot = await loadSessionSnapshot(options.rootDir, pending.sessionId, { synthesizeDanglingToolResults: false });
+      if (snapshot.pendingPermission?.id === pending.request.id) {
+        options.setPendingPermission(pending);
+        return;
+      }
+      options.setPendingPermission(null);
+      options.setConversation(vesicleMessagesFromResumed(snapshot.messages));
+      options.setMessages(displayTranscriptFromSnapshot(snapshot.messages, options.agentCards()));
+      options.setStatus("permission resolved; provider continuation stopped");
+    } catch {
+      options.setPendingPermission(pending);
+    }
+  }
+
+  function submitChildPermissionResolution(resolution: PermissionResolution): void {
+    const request = options.pendingChildPermission() as import("../core/permissions").PermissionRequest | null;
+    if (!request || !options.permissionBroker.resolve(request.id, resolution)) return;
+    options.setGateFeedbackMode(null);
+    options.clearGateFeedback();
+    options.setStatus(`${resolution.decision} ${request.agent?.handle ?? "SubAgent"} ${request.toolName}`);
+    options.recordActivity({ kind: "agent", text: `${resolution.decision} ${request.agent?.handle ?? "SubAgent"} ${request.toolName}` });
+  }
+
+  async function submitGateResolution(resolution: GateResolution): Promise<void> {
+    const gate = options.pendingGate();
+    if (!gate || options.busy()) return;
+    beginGateResolution(gate.gate.gate, resolution);
+    try {
+      const outcome = await options.runCancellable((signal) => resolveGate({
+        engine: gate.engine,
+        sessionId: gate.sessionId,
+        messages: gate.messages,
+        toolCallId: gate.toolCallId,
+        gate: gate.gate,
+        resolution,
+        providerSelection: options.activeProviderSelection(),
+        generation: options.activeGeneration(),
+        permission: options.permissionContext(),
+        signal,
+        onEvent: options.handleAgentEvent,
+        agentManager: options.agentManager(),
+        permissionBroker: options.permissionBroker,
+      }));
+      if (outcome.kind === "interrupted") {
+        options.setPendingGate(gate);
+        options.handleInterruptedTurn();
+      } else options.handleResult(outcome.value);
+    } catch (error) {
+      options.setPendingGate(gate);
+      options.reportError(error);
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
+  function beginGateResolution(gateName: string, resolution: GateResolution): void {
+    options.setBusy(true);
+    options.setStatus(`resolving gate: ${resolution.decision}`);
+    options.recordActivity({ kind: "gate", text: `resolving ${gateName} as ${resolution.decision}` });
+    options.setPendingGate(null);
+    options.setGateFeedbackMode(null);
+    options.clearGateFeedback();
+    options.setMessages((previous) => [...previous, {
+      role: "user",
+      content: `[gate:${gateName}] ${resolution.decision}${resolution.feedback ? ` — ${resolution.feedback}` : ""}`,
+    }]);
+    options.beginUsageTurn();
+  }
+
+  async function submitEngineSwitchResolution(
+    resolution: GateResolution,
+    submitOptions: { summarizeContext?: boolean } = {},
+  ): Promise<void> {
+    const pending = options.pendingEngineSwitch();
+    if (!pending || options.busy()) return;
+    const summarizeContext = resolution.decision === "confirm" && submitOptions.summarizeContext === true;
+    let switchApplied = false;
+    beginEngineSwitchResolution(pending, resolution, summarizeContext);
+    try {
+      const outcome = await options.runCancellable((signal) => resolveEngineSwitch({
+        engine: pending.profile?.id ?? options.activeEngine(),
+        sessionId: pending.sessionId,
+        messages: pending.messages,
+        toolCallId: pending.toolCallId,
+        request: pending.request,
+        resolution,
+        ...(summarizeContext ? { contextPolicy: "summary" as const } : {}),
+        providerSelection: options.activeProviderSelection(),
+        generation: options.activeGeneration(),
+        permission: options.permissionContext(),
+        signal,
+        onEvent: options.handleAgentEvent,
+        agentManager: options.agentManager(),
+        permissionBroker: options.permissionBroker,
+      }));
+      if (outcome.kind === "interrupted") {
+        options.setPendingEngineSwitch(pending);
+        options.handleInterruptedTurn();
+        return;
+      }
+      if (outcome.value.kind === "engine_switched") {
+        switchApplied = true;
+        await applyEngineSwitchResult(outcome.value, summarizeContext);
+      } else options.handleResult(outcome.value);
+    } catch (error) {
+      if (!switchApplied) options.setPendingEngineSwitch(pending);
+      options.reportError(error);
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
+  function beginEngineSwitchResolution(pending: PendingEngineSwitchState, resolution: GateResolution, summarize: boolean): void {
+    options.setBusy(true);
+    options.setStatus(summarize ? "resolving engine switch with summary" : `resolving engine switch: ${resolution.decision}`);
+    options.recordActivity({ kind: "gate", text: `resolving engine switch to ${pending.request.targetEngine} as ${summarize ? "confirm-summary" : resolution.decision}` });
+    options.setPendingEngineSwitch(null);
+    options.setGateFeedbackMode(null);
+    options.clearGateFeedback();
+    options.setMessages((previous) => [...previous, {
+      role: "user",
+      content: `[engine-switch:${pending.request.targetEngine}] ${resolution.decision}${resolution.feedback ? ` — ${resolution.feedback}` : ""}`,
+    }]);
+    if (resolution.decision !== "confirm") options.beginUsageTurn();
+  }
+
+  async function applyEngineSwitchResult(result: EngineSwitchConfirmedResult, summarizeContext: boolean): Promise<void> {
+    options.setConversation([...result.messages]);
+    options.setSessionId(result.sessionId);
+    options.setSessionPath(result.sessionPath);
+    options.setActiveEngine(result.engine);
+    options.setStatus(`engine ${result.engine}`);
+    options.recordActivity({ kind: "system", text: `engine switched to ${result.engine}` });
+    if (summarizeContext) {
+      const compact = await options.compactSession("Preserve the engine handoff, user intent, important files/artifacts, unresolved issues, and the next useful step.");
+      options.setMessages((previous) => [...previous, { role: "system", content: `Engine switched to ${result.engine} with summarized context (${compact.messagesSummarized} messages). Future turns will use that profile.` }]);
+    } else {
+      options.setMessages((previous) => [...previous, { role: "system", content: `Engine switched to ${result.engine}. Future turns will use that profile.` }]);
+    }
+  }
+
+  async function submitUserQuestionAnswer(selectedIndex: number): Promise<void> {
+    const pending = options.pendingUserQuestion();
+    if (!pending || options.busy()) return;
+    const option = pending.question.options[selectedIndex];
+    if (!option) return;
+    if (option.kind === "freeform") {
+      submitUserQuestionFreeform(options.questionFreeformText());
+      return;
+    }
+    await submitUserQuestionAnswerPayload(pending, {
+      selectedIndex,
+      label: option.label,
+      description: option.description,
+      ...(option.kind ? { kind: option.kind } : {}),
+    }, selectedIndex);
+  }
+
+  function submitUserQuestionFreeform(value: unknown): void {
+    const pending = options.pendingUserQuestion();
+    if (!pending || options.busy()) return;
+    const text = (typeof value === "string" ? value : options.questionFreeformText()).trim();
+    if (!text) {
+      options.setStatus("type a free-form answer or press Esc");
+      return;
+    }
+    const selectedIndex = options.questionSelected();
+    const option = pending.question.options[selectedIndex];
+    if (!option || option.kind !== "freeform") return;
+    options.clearQuestionFreeform();
+    void submitUserQuestionAnswerPayload(pending, {
+      selectedIndex,
+      label: option.label,
+      description: option.description,
+      kind: "freeform",
+      freeformText: text,
+    }, selectedIndex);
+  }
+
+  async function submitUserQuestionAnswerPayload(
+    pending: PendingUserQuestionState,
+    answer: UserQuestionAnswer,
+    selectedIndex: number,
+  ): Promise<void> {
+    options.setBusy(true);
+    options.setStatus(`answering question: ${pending.question.header}`);
+    options.recordActivity({ kind: "gate", text: `answering question ${pending.question.header}: ${answer.kind === "freeform" ? "Other" : answer.label}` });
+    options.setPendingUserQuestion(null);
+    options.setQuestionSelected(0);
+    options.clearQuestionFreeform();
+    options.setMessages((previous) => [...previous, { role: "user", content: displayUserQuestionAnswer(pending.question.header, answer) }]);
+    options.beginUsageTurn();
+    try {
+      const outcome = await options.runCancellable((signal) => resolveUserQuestion({
+        engine: pending.engine,
+        sessionId: pending.sessionId,
+        messages: pending.messages,
+        toolCallId: pending.toolCallId,
+        question: pending.question,
+        answer,
+        providerSelection: options.activeProviderSelection(),
+        generation: options.activeGeneration(),
+        permission: options.permissionContext(),
+        signal,
+        onEvent: options.handleAgentEvent,
+        agentManager: options.agentManager(),
+        permissionBroker: options.permissionBroker,
+      }));
+      if (outcome.kind === "interrupted") {
+        options.setPendingUserQuestion(pending);
+        options.setQuestionSelected(selectedIndex);
+        options.handleInterruptedTurn();
+      } else options.handleResult(outcome.value);
+    } catch (error) {
+      options.setPendingUserQuestion(pending);
+      options.setQuestionSelected(selectedIndex);
+      options.reportError(error);
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
+  return {
+    submitChildPermissionResolution,
+    submitEngineSwitchResolution,
+    submitGateResolution,
+    submitPermissionResolution,
+    submitUserQuestionAnswer,
+    submitUserQuestionFreeform,
+  };
+}

--- a/src/tui/decision-controller.ts
+++ b/src/tui/decision-controller.ts
@@ -1,0 +1,282 @@
+import { createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import type { EngineId } from "../core/engine/profile";
+import type { GateResolution } from "../core/gate/types";
+import type { PermissionMode, PermissionRequest, PermissionResolution } from "../core/permissions";
+import {
+  applyComposerKey,
+  insertComposerText,
+  type ComposerState,
+} from "./composer";
+import {
+  engineSwitchGateFocusOrder,
+  gateComposerIsActive,
+  gateFocusOrder,
+  gateResolutionFromState,
+  type GateFocusTarget,
+} from "./GatePrompt";
+import { questionComposerIsActive, questionPanelMinHeight } from "./QuestionPrompt";
+import {
+  engineSwitchGateRequest,
+  permissionResolutionFromGate,
+  type PendingEngineSwitchState,
+  type PendingGateState,
+  type PendingPermissionState,
+  type PendingUserQuestionState,
+  type TuiKeyEvent,
+} from "./decision-interaction";
+
+export type DecisionControllerOptions = {
+  busy: Accessor<boolean>;
+  activeEngine: Accessor<EngineId>;
+  permissionMode: Accessor<PermissionMode>;
+  setStatus: Setter<string>;
+  submitPermission: (resolution: PermissionResolution) => void;
+  submitChildPermission: (resolution: PermissionResolution) => void;
+  submitEngineSwitch: (resolution: GateResolution, options?: { summarizeContext?: boolean }) => void;
+  submitGate: (resolution: GateResolution) => void;
+  submitQuestionOption: (selectedIndex: number) => void;
+  submitQuestionFreeform: (value: unknown) => void;
+  applyPermissionMode: (mode: PermissionMode) => Promise<void>;
+};
+
+export function createDecisionController(options: DecisionControllerOptions) {
+  const [pendingGate, setPendingGate] = createSignal<PendingGateState | null>(null);
+  const [pendingEngineSwitch, setPendingEngineSwitch] = createSignal<PendingEngineSwitchState | null>(null);
+  const [pendingUserQuestion, setPendingUserQuestion] = createSignal<PendingUserQuestionState | null>(null);
+  const [pendingPermission, setPendingPermission] = createSignal<PendingPermissionState | null>(null);
+  const [pendingChildPermission, setPendingChildPermission] = createSignal<PermissionRequest | null>(null);
+  const [yoloConfirmStage, setYoloConfirmStage] = createSignal<1 | 2 | null>(null);
+  const [questionSelected, setQuestionSelected] = createSignal(0);
+  const [questionFreeformText, setQuestionFreeformText] = createSignal("");
+  const [questionFreeformCursor, setQuestionFreeformCursor] = createSignal(0);
+  const [questionFreeformKillBuffer, setQuestionFreeformKillBuffer] = createSignal<string | undefined>();
+  const [gateFocus, setGateFocus] = createSignal<GateFocusTarget>("confirm");
+  const [gateFeedbackMode, setGateFeedbackMode] = createSignal<GateFocusTarget | null>(null);
+  const [gateFeedback, setGateFeedback] = createSignal("");
+  const [gateFeedbackCursor, setGateFeedbackCursor] = createSignal(0);
+  const [gateFeedbackKillBuffer, setGateFeedbackKillBuffer] = createSignal<string | undefined>();
+
+  const activeGateRequest = createMemo(() => {
+    const gate = pendingGate();
+    if (gate) return gate.gate;
+    const engineSwitch = pendingEngineSwitch();
+    return engineSwitch ? engineSwitchGateRequest(options.activeEngine(), engineSwitch.request) : null;
+  });
+  const activePermissionRequest = createMemo(() => pendingPermission()?.request ?? pendingChildPermission() ?? undefined);
+  const decisionPanelMinHeight = createMemo(() => {
+    const pending = pendingUserQuestion();
+    if (pendingEngineSwitch()) return 10;
+    return pending ? questionPanelMinHeight(pending.question, questionSelected()) : 9;
+  });
+
+  function handleGateKey(key: TuiKeyEvent): boolean {
+    if (options.busy() && !pendingChildPermission()) return false;
+    const focusOrder = currentGateFocusOrder();
+    if (gateComposerIsActive(gateFocus(), gateFeedbackMode()) && key.name !== "tab" && key.name !== "escape") {
+      const result = applyComposerKey(currentGateFeedbackState(), key);
+      if (result.handled) {
+        applyGateFeedbackState(result.state);
+        if (result.action?.type === "submit") submitFocusedGate(gateResolutionFromState(gateFocus(), result.action.value));
+        else if (result.action?.type === "history_up") moveGateFocus(-1, focusOrder);
+        else if (result.action?.type === "history_down") moveGateFocus(1, focusOrder);
+        return true;
+      }
+    }
+    if (key.name === "up" || (key.ctrl && key.name === "p")) {
+      moveGateFocus(-1, focusOrder);
+      return true;
+    }
+    if (key.name === "down" || (key.ctrl && key.name === "n")) {
+      moveGateFocus(1, focusOrder);
+      return true;
+    }
+    if (key.name === "tab") {
+      const target = gateFocus();
+      if (target === "reject" || target === "confirm-summary") return true;
+      setGateFeedbackMode((previous) => previous === target ? null : target);
+      clearGateFeedback();
+      return true;
+    }
+    if (key.name === "return" || key.name === "enter") {
+      submitFocusedGate(gateResolutionFromState(gateFocus(), gateFeedback()));
+      return true;
+    }
+    if (key.name === "escape") {
+      setGateFeedbackMode(null);
+      clearGateFeedback();
+      setGateFocus("reject");
+      return true;
+    }
+    return false;
+  }
+
+  function submitFocusedGate(resolution: GateResolution): void {
+    if (pendingPermission()) options.submitPermission(permissionResolutionFromGate(resolution));
+    else if (pendingChildPermission()) options.submitChildPermission(permissionResolutionFromGate(resolution));
+    else if (pendingEngineSwitch()) options.submitEngineSwitch(resolution, { summarizeContext: gateFocus() === "confirm-summary" });
+    else options.submitGate(resolution);
+  }
+
+  function handleYoloKey(key: TuiKeyEvent): boolean {
+    if (key.name === "up" || key.name === "down" || (key.ctrl && (key.name === "p" || key.name === "n"))) {
+      setGateFocus((current) => current === "confirm" ? "reject" : "confirm");
+      return true;
+    }
+    if (key.name === "escape") {
+      setGateFocus("reject");
+      setYoloConfirmStage(null);
+      options.setStatus(`permission mode ${options.permissionMode()}`);
+      return true;
+    }
+    if (key.name !== "return" && key.name !== "enter") return false;
+    if (gateFocus() === "reject") {
+      setYoloConfirmStage(null);
+      options.setStatus(`permission mode ${options.permissionMode()}`);
+    } else if (yoloConfirmStage() === 1) {
+      setYoloConfirmStage(2);
+    } else {
+      void options.applyPermissionMode("YOLO");
+      setYoloConfirmStage(null);
+    }
+    return true;
+  }
+
+  function handleQuestionKey(key: TuiKeyEvent): boolean {
+    const pending = pendingUserQuestion();
+    if (!pending || options.busy()) return false;
+    const selectedOption = pending.question.options[questionSelected()];
+    if (questionComposerIsActive(selectedOption)) return handleQuestionComposerKey(key, pending.question.options.length, pending.question.header);
+    if (key.name === "up" || (key.ctrl && key.name === "p")) {
+      moveQuestionSelection(-1, pending.question.options.length);
+      return true;
+    }
+    if (key.name === "down" || (key.ctrl && key.name === "n")) {
+      moveQuestionSelection(1, pending.question.options.length);
+      return true;
+    }
+    if (key.name === "return" || key.name === "enter") {
+      options.submitQuestionOption(questionSelected());
+      return true;
+    }
+    return false;
+  }
+
+  function handleQuestionComposerKey(key: TuiKeyEvent, optionCount: number, header: string): boolean {
+    if (key.name === "escape") {
+      clearQuestionFreeform();
+      options.setStatus(`question pending: ${header}`);
+      return true;
+    }
+    const result = applyComposerKey(currentQuestionFreeformState(), key);
+    if (!result.handled) return false;
+    applyQuestionFreeformState(result.state);
+    if (result.action?.type === "submit") options.submitQuestionFreeform(result.action.value);
+    else if (result.action?.type === "history_up") moveQuestionSelection(-1, optionCount);
+    else if (result.action?.type === "history_down") moveQuestionSelection(1, optionCount);
+    return true;
+  }
+
+  function handlePaste(text: string): boolean {
+    if ((pendingGate() || pendingEngineSwitch() || pendingPermission() || pendingChildPermission())
+      && gateComposerIsActive(gateFocus(), gateFeedbackMode())) {
+      applyGateFeedbackState(insertComposerText(currentGateFeedbackState(), text));
+      return true;
+    }
+    if (pendingUserQuestion() && questionComposerIsActive(selectedQuestionOption())) {
+      applyQuestionFreeformState(insertComposerText(currentQuestionFreeformState(), text));
+      return true;
+    }
+    return false;
+  }
+
+  function currentGateFocusOrder(): GateFocusTarget[] {
+    return pendingEngineSwitch() ? engineSwitchGateFocusOrder : gateFocusOrder;
+  }
+
+  function moveGateFocus(delta: -1 | 1, order = currentGateFocusOrder()): void {
+    const current = gateFocus();
+    const index = Math.max(0, order.indexOf(current));
+    setGateFocus(order[(index + delta + order.length) % order.length]);
+  }
+
+  function moveQuestionSelection(delta: -1 | 1, count: number): void {
+    setQuestionSelected((previous) => (previous + delta + count) % count);
+  }
+
+  function selectedQuestionOption() {
+    const pending = pendingUserQuestion();
+    return pending?.question.options[questionSelected()];
+  }
+
+  function currentGateFeedbackState(): ComposerState {
+    return { value: gateFeedback(), cursor: gateFeedbackCursor(), killBuffer: gateFeedbackKillBuffer(), elements: [] };
+  }
+
+  function applyGateFeedbackState(state: ComposerState): void {
+    setGateFeedback(state.value);
+    setGateFeedbackCursor(state.cursor);
+    setGateFeedbackKillBuffer(state.killBuffer);
+  }
+
+  function currentQuestionFreeformState(): ComposerState {
+    return { value: questionFreeformText(), cursor: questionFreeformCursor(), killBuffer: questionFreeformKillBuffer(), elements: [] };
+  }
+
+  function applyQuestionFreeformState(state: ComposerState): void {
+    setQuestionFreeformText(state.value);
+    setQuestionFreeformCursor(state.cursor);
+    setQuestionFreeformKillBuffer(state.killBuffer);
+  }
+
+  function clearGateFeedback(): void {
+    setGateFeedback("");
+    setGateFeedbackCursor(0);
+    setGateFeedbackKillBuffer(undefined);
+  }
+
+  function clearQuestionFreeform(): void {
+    setQuestionFreeformText("");
+    setQuestionFreeformCursor(0);
+    setQuestionFreeformKillBuffer(undefined);
+  }
+
+  return {
+    activeGateRequest,
+    activePermissionRequest,
+    clearGateFeedback,
+    clearQuestionFreeform,
+    decisionPanelMinHeight,
+    gateFeedback,
+    gateFeedbackCursor,
+    gateFeedbackMode,
+    gateFocus,
+    handleGateKey,
+    handlePaste,
+    handleQuestionKey,
+    handleYoloKey,
+    pendingChildPermission,
+    pendingEngineSwitch,
+    pendingGate,
+    pendingPermission,
+    pendingUserQuestion,
+    questionFreeformCursor,
+    questionFreeformText,
+    questionSelected,
+    setGateFeedback,
+    setGateFeedbackCursor,
+    setGateFeedbackKillBuffer,
+    setGateFeedbackMode,
+    setGateFocus,
+    setPendingChildPermission,
+    setPendingEngineSwitch,
+    setPendingGate,
+    setPendingPermission,
+    setPendingUserQuestion,
+    setQuestionFreeformCursor,
+    setQuestionFreeformKillBuffer,
+    setQuestionFreeformText,
+    setQuestionSelected,
+    setYoloConfirmStage,
+    yoloConfirmStage,
+  };
+}

--- a/src/tui/decision-interaction.ts
+++ b/src/tui/decision-interaction.ts
@@ -1,0 +1,84 @@
+import type { RunPromptResult } from "../core/agent-loop/run";
+import type { EngineId } from "../core/engine/profile";
+import type { EngineSwitchRequest } from "../core/engine/switch";
+import type { GateRequest, GateResolution } from "../core/gate/types";
+import type { PermissionResolution } from "../core/permissions";
+import type { UserQuestionAnswer } from "../core/user-question/types";
+
+type PendingGate = Extract<RunPromptResult, { kind: "needs_user" }>;
+
+export type PendingGateState = Omit<PendingGate, "profile"> & {
+  engine: EngineId;
+  profile?: PendingGate["profile"];
+};
+
+type PendingEngineSwitch = Extract<RunPromptResult, { kind: "needs_engine_switch" }>;
+
+export type PendingEngineSwitchState = Omit<PendingEngineSwitch, "profile"> & {
+  profile?: PendingEngineSwitch["profile"];
+};
+
+type PendingUserQuestion = Extract<RunPromptResult, { kind: "needs_user_question" }>;
+
+export type PendingUserQuestionState = Omit<PendingUserQuestion, "profile"> & {
+  engine: EngineId;
+  profile?: PendingUserQuestion["profile"];
+};
+
+type PendingPermission = Extract<RunPromptResult, { kind: "needs_permission" }>;
+
+export type PendingPermissionState = Omit<PendingPermission, "profile"> & {
+  engine: EngineId;
+  profile?: PendingPermission["profile"];
+};
+
+export type TuiKeyEvent = {
+  name?: string;
+  ctrl?: boolean;
+  shift?: boolean;
+  meta?: boolean;
+  option?: boolean;
+  sequence?: string;
+  raw?: string;
+  preventDefault?: () => void;
+  stopPropagation?: () => void;
+};
+
+export function engineSwitchGateRequest(currentEngine: EngineId, request: EngineSwitchRequest): GateRequest {
+  const lines = [
+    `Current Engine: ${currentEngine}`,
+    `Target Engine: ${request.targetEngine}`,
+    "",
+    `Reason: ${request.reason}`,
+    "",
+    `Handoff Summary: ${request.handoffSummary}`,
+  ];
+  if (request.recommendedNextAction) {
+    lines.push("", `Recommended Next Action: ${request.recommendedNextAction}`);
+  }
+  return {
+    gate: "engine-switch",
+    summary: lines.join("\n"),
+    options: [
+      { label: `Confirm - switch to ${request.targetEngine}`, decision: "confirm" },
+      { label: `Reject - stay on ${currentEngine} and discuss`, decision: "reject" },
+    ],
+  };
+}
+
+export function permissionResolutionFromGate(resolution: GateResolution): PermissionResolution {
+  const resolvedAt = new Date().toISOString();
+  return resolution.decision === "confirm"
+    ? { decision: "allow_once", resolvedAt }
+    : {
+        decision: "reject",
+        resolvedAt,
+        ...(resolution.feedback ? { feedback: resolution.feedback } : {}),
+      };
+}
+
+export function displayUserQuestionAnswer(header: string, answer: UserQuestionAnswer): string {
+  if (answer.kind === "skip") return `[question:${header}] skipped`;
+  if (answer.kind === "freeform") return `[question:${header}] ${answer.freeformText ?? answer.label}`;
+  return `[question:${header}] ${answer.label}`;
+}

--- a/src/tui/input-routing.ts
+++ b/src/tui/input-routing.ts
@@ -1,0 +1,115 @@
+import { useKeyboard, usePaste, useRenderer } from "@opentui/solid";
+import type { Accessor, Setter } from "solid-js";
+import { copySelectionToClipboard } from "./clipboard";
+import { normalizeKeyName } from "./composer";
+import type { PendingEngineSwitchState, PendingGateState, PendingPermissionState, PendingUserQuestionState, TuiKeyEvent } from "./decision-interaction";
+import type { ModelPickerState } from "./views/BottomSurface";
+import type { RewindPickerState, SessionPickerState } from "./types";
+
+export type InputRoutingOptions = {
+  renderer: ReturnType<typeof useRenderer>;
+  setStatus: Setter<string>;
+  rewindPicker: Accessor<RewindPickerState | null>;
+  handleRewindKey: (key: TuiKeyEvent) => boolean;
+  modelPicker: Accessor<ModelPickerState | null>;
+  handleModelPickerKey: (key: TuiKeyEvent) => boolean;
+  sessionPicker: Accessor<SessionPickerState | null>;
+  handleSessionPickerKey: (key: TuiKeyEvent) => boolean;
+  yoloConfirmStage: Accessor<1 | 2 | null>;
+  handleYoloKey: (key: TuiKeyEvent) => boolean;
+  pendingUserQuestion: Accessor<PendingUserQuestionState | null>;
+  handleQuestionKey: (key: TuiKeyEvent) => boolean;
+  pendingGate: Accessor<PendingGateState | null>;
+  pendingEngineSwitch: Accessor<PendingEngineSwitchState | null>;
+  pendingPermission: Accessor<PendingPermissionState | null>;
+  pendingChildPermission: Accessor<unknown | null>;
+  handleGateKey: (key: TuiKeyEvent) => boolean;
+  pasteClipboardImage: () => Promise<void>;
+  handleComposerKey: (key: TuiKeyEvent) => boolean;
+  handlePromptEscape: () => void;
+  handleDecisionPaste: (text: string) => boolean;
+  insertComposerPaste: (text: string) => void;
+};
+
+export function registerInputRouting(options: InputRoutingOptions): void {
+  let lastCtrlCAt = 0;
+
+  useKeyboard((rawKey) => {
+    const key = { ...rawKey, name: normalizeKeyName(rawKey.name) };
+    if (key.ctrl && key.name === "c") {
+      void copySelectionToClipboard(options.renderer).then((copied) => {
+        if (copied) {
+          options.renderer.clearSelection();
+          options.setStatus("selection copied");
+          lastCtrlCAt = 0;
+          return;
+        }
+        const now = Date.now();
+        if (now - lastCtrlCAt < 3000) {
+          process.nextTick(() => options.renderer.destroy());
+          return;
+        }
+        lastCtrlCAt = now;
+        options.setStatus("press Ctrl+C again to exit");
+      });
+      return;
+    }
+    if (key.ctrl && key.name === "q") {
+      process.nextTick(() => options.renderer.destroy());
+      return;
+    }
+    if (options.rewindPicker()) {
+      if (options.handleRewindKey(key)) consumeKey(key);
+      return;
+    }
+    if (options.modelPicker()) {
+      if (options.handleModelPickerKey(key)) consumeKey(key);
+      return;
+    }
+    if (options.sessionPicker()) {
+      if (options.handleSessionPickerKey(key)) consumeKey(key);
+      return;
+    }
+    if (options.yoloConfirmStage()) {
+      if (options.handleYoloKey(key)) consumeKey(key);
+      return;
+    }
+    if (options.pendingUserQuestion()) {
+      if (options.handleQuestionKey(key)) consumeKey(key);
+      return;
+    }
+    if (options.pendingGate() || options.pendingEngineSwitch() || options.pendingPermission() || options.pendingChildPermission()) {
+      if (options.handleGateKey(key)) consumeKey(key);
+      return;
+    }
+    if (key.name?.toLowerCase() === "v" && (key.meta || key.option)) {
+      consumeKey(key);
+      void options.pasteClipboardImage();
+      return;
+    }
+    if (options.handleComposerKey(key)) {
+      consumeKey(key);
+      return;
+    }
+    if (key.name === "escape") {
+      options.handlePromptEscape();
+      consumeKey(key);
+    }
+  });
+
+  usePaste((event) => {
+    const text = new TextDecoder().decode(event.bytes);
+    if (options.handleDecisionPaste(text)) {
+      event.preventDefault();
+      return;
+    }
+    if (options.pendingGate() || options.pendingEngineSwitch() || options.pendingUserQuestion() || options.pendingPermission() || options.pendingChildPermission() || options.yoloConfirmStage() || options.sessionPicker() || options.rewindPicker()) return;
+    options.insertComposerPaste(text);
+    event.preventDefault();
+  });
+}
+
+function consumeKey(key: TuiKeyEvent): void {
+  key.preventDefault?.();
+  key.stopPropagation?.();
+}

--- a/src/tui/input-routing.ts
+++ b/src/tui/input-routing.ts
@@ -1,9 +1,11 @@
 import { useKeyboard, usePaste, useRenderer } from "@opentui/solid";
 import type { Accessor, Setter } from "solid-js";
+import type { GateRequest } from "../core/gate/types";
+import type { PermissionRequest } from "../core/permissions";
 import { copySelectionToClipboard } from "./clipboard";
 import { normalizeKeyName } from "./composer";
-import type { PendingEngineSwitchState, PendingGateState, PendingPermissionState, PendingUserQuestionState, TuiKeyEvent } from "./decision-interaction";
-import type { ModelPickerState } from "./views/BottomSurface";
+import type { PendingUserQuestionState, TuiKeyEvent } from "./decision-interaction";
+import { resolveBottomSurfaceMode, type ModelPickerState } from "./views/BottomSurface";
 import type { RewindPickerState, SessionPickerState } from "./types";
 
 export type InputRoutingOptions = {
@@ -17,12 +19,10 @@ export type InputRoutingOptions = {
   handleSessionPickerKey: (key: TuiKeyEvent) => boolean;
   yoloConfirmStage: Accessor<1 | 2 | null>;
   handleYoloKey: (key: TuiKeyEvent) => boolean;
+  activePermissionRequest: Accessor<PermissionRequest | undefined>;
   pendingUserQuestion: Accessor<PendingUserQuestionState | null>;
   handleQuestionKey: (key: TuiKeyEvent) => boolean;
-  pendingGate: Accessor<PendingGateState | null>;
-  pendingEngineSwitch: Accessor<PendingEngineSwitchState | null>;
-  pendingPermission: Accessor<PendingPermissionState | null>;
-  pendingChildPermission: Accessor<unknown | null>;
+  activeGateRequest: Accessor<GateRequest | null>;
   handleGateKey: (key: TuiKeyEvent) => boolean;
   pasteClipboardImage: () => Promise<void>;
   handleComposerKey: (key: TuiKeyEvent) => boolean;
@@ -31,8 +31,17 @@ export type InputRoutingOptions = {
   insertComposerPaste: (text: string) => void;
 };
 
-export function registerInputRouting(options: InputRoutingOptions): void {
+export function useInputRouting(options: InputRoutingOptions): void {
   let lastCtrlCAt = 0;
+  const bottomSurfaceMode = () => resolveBottomSurfaceMode({
+    yoloStage: options.yoloConfirmStage(),
+    permissionRequest: options.activePermissionRequest(),
+    question: options.pendingUserQuestion(),
+    gate: options.activeGateRequest(),
+    rewind: options.rewindPicker(),
+    session: options.sessionPicker(),
+    model: options.modelPicker(),
+  });
 
   useKeyboard((rawKey) => {
     const key = { ...rawKey, name: normalizeKeyName(rawKey.name) };
@@ -58,29 +67,29 @@ export function registerInputRouting(options: InputRoutingOptions): void {
       process.nextTick(() => options.renderer.destroy());
       return;
     }
-    if (options.rewindPicker()) {
-      if (options.handleRewindKey(key)) consumeKey(key);
-      return;
-    }
-    if (options.modelPicker()) {
-      if (options.handleModelPickerKey(key)) consumeKey(key);
-      return;
-    }
-    if (options.sessionPicker()) {
-      if (options.handleSessionPickerKey(key)) consumeKey(key);
-      return;
-    }
-    if (options.yoloConfirmStage()) {
-      if (options.handleYoloKey(key)) consumeKey(key);
-      return;
-    }
-    if (options.pendingUserQuestion()) {
-      if (options.handleQuestionKey(key)) consumeKey(key);
-      return;
-    }
-    if (options.pendingGate() || options.pendingEngineSwitch() || options.pendingPermission() || options.pendingChildPermission()) {
-      if (options.handleGateKey(key)) consumeKey(key);
-      return;
+    const mode = bottomSurfaceMode();
+    switch (mode.kind) {
+      case "yolo":
+        if (options.handleYoloKey(key)) consumeKey(key);
+        return;
+      case "permission":
+      case "gate":
+        if (options.handleGateKey(key)) consumeKey(key);
+        return;
+      case "question":
+        if (options.handleQuestionKey(key)) consumeKey(key);
+        return;
+      case "rewind":
+        if (options.handleRewindKey(key)) consumeKey(key);
+        return;
+      case "session":
+        if (options.handleSessionPickerKey(key)) consumeKey(key);
+        return;
+      case "model":
+        if (options.handleModelPickerKey(key)) consumeKey(key);
+        return;
+      case "composer":
+        break;
     }
     if (key.name?.toLowerCase() === "v" && (key.meta || key.option)) {
       consumeKey(key);
@@ -103,7 +112,10 @@ export function registerInputRouting(options: InputRoutingOptions): void {
       event.preventDefault();
       return;
     }
-    if (options.pendingGate() || options.pendingEngineSwitch() || options.pendingUserQuestion() || options.pendingPermission() || options.pendingChildPermission() || options.yoloConfirmStage() || options.sessionPicker() || options.rewindPicker()) return;
+    if (bottomSurfaceMode().kind !== "composer") {
+      event.preventDefault();
+      return;
+    }
     options.insertComposerPaste(text);
     event.preventDefault();
   });

--- a/src/tui/model-picker-controller.ts
+++ b/src/tui/model-picker-controller.ts
@@ -1,0 +1,94 @@
+import { createMemo, createSignal, type Accessor, type Setter } from "solid-js";
+import type { ProviderRegistry, ProviderSelection } from "../config/providers";
+import type { TuiKeyEvent } from "./decision-interaction";
+import { modelOptionItems, providerOptionItems } from "./commands/options";
+import type { Message, OptionItem } from "./types";
+import type { ModelPickerState } from "./views/BottomSurface";
+
+export type ModelPickerControllerOptions = {
+  providerRegistry: Accessor<ProviderRegistry | null>;
+  ensureProviderRegistry: () => Promise<ProviderRegistry>;
+  applyProviderSelection: (selection: Partial<ProviderSelection>) => Promise<ProviderSelection>;
+  persistProviderSwitch: (selection: ProviderSelection) => Promise<void>;
+  setStatus: Setter<string>;
+  setMessages: Setter<Message[]>;
+  reportError: (error: unknown) => void;
+};
+
+export function createModelPickerController(options: ModelPickerControllerOptions) {
+  const [modelPicker, setModelPicker] = createSignal<ModelPickerState | null>(null);
+  const [modelPickerBusy, setModelPickerBusy] = createSignal(false);
+  const modelPickerItems = createMemo<OptionItem[]>(() => {
+    const picker = modelPicker();
+    const registry = options.providerRegistry();
+    if (!picker || !registry) return [];
+    return picker.step === "provider"
+      ? providerOptionItems(registry)
+      : modelOptionItems(registry, picker.providerId ?? "");
+  });
+  const modelPickerTitle = createMemo(() => {
+    const picker = modelPicker();
+    return !picker || picker.step === "provider" ? "Select provider" : `Select model · ${picker.providerId}`;
+  });
+
+  function handleModelPickerKey(key: TuiKeyEvent): boolean {
+    const picker = modelPicker();
+    if (!picker) return false;
+    if (modelPickerBusy()) return true;
+    const items = modelPickerItems();
+    if (items.length === 0) return false;
+    if (key.name === "up" || (key.ctrl && key.name === "p")) {
+      setModelPicker({ ...picker, selected: (picker.selected - 1 + items.length) % items.length });
+      return true;
+    }
+    if (key.name === "down" || (key.ctrl && key.name === "n")) {
+      setModelPicker({ ...picker, selected: (picker.selected + 1) % items.length });
+      return true;
+    }
+    if (key.name === "return" || key.name === "enter") {
+      const item = items[picker.selected];
+      if (!item) return true;
+      if (picker.step === "provider") setModelPicker({ step: "model", providerId: item.id, selected: 0 });
+      else {
+        setModelPickerBusy(true);
+        options.setStatus("switching provider/model");
+        void commitModelPicker(picker.providerId ?? "", item.id);
+      }
+      return true;
+    }
+    if (key.name === "escape") {
+      if (picker.step === "model") setModelPicker({ step: "provider", providerId: null, selected: 0 });
+      else {
+        setModelPicker(null);
+        options.setStatus("model switch cancelled");
+      }
+      return true;
+    }
+    return false;
+  }
+
+  async function commitModelPicker(providerId: string, modelId: string): Promise<void> {
+    try {
+      const selection = await options.applyProviderSelection({ provider: providerId, model: modelId });
+      await options.persistProviderSwitch(selection);
+      options.setMessages((previous) => [...previous, { role: "system", content: `Using ${selection.provider}/${selection.model}.` }]);
+    } catch (error) {
+      options.reportError(error);
+    } finally {
+      setModelPicker(null);
+      setModelPickerBusy(false);
+    }
+  }
+
+  async function openModelPicker(): Promise<void> {
+    try {
+      await options.ensureProviderRegistry();
+      setModelPickerBusy(false);
+      setModelPicker({ step: "provider", providerId: null, selected: 0 });
+    } catch (error) {
+      options.reportError(error);
+    }
+  }
+
+  return { handleModelPickerKey, modelPicker, modelPickerItems, modelPickerTitle, openModelPicker };
+}

--- a/src/tui/provider-config-controller.ts
+++ b/src/tui/provider-config-controller.ts
@@ -1,0 +1,157 @@
+import { createSignal, type Accessor, type Setter } from "solid-js";
+import type { ModelCapabilities, ModelLimits } from "../config/env";
+import { loadPermissionSettings } from "../config/permissions";
+import { inspectProviderConfig, type ProviderRegistry, type ProviderSelection } from "../config/providers";
+import { inspectMcpConfig } from "../mcp/registry";
+import type { ReasoningTier } from "../providers/shared/types";
+import type { PermissionMode } from "../core/permissions";
+import type { ActivityEntry } from "./types";
+import type { SidebarMcpState } from "./views/Sidebar";
+
+export type ProviderConfigControllerOptions = {
+  dangerouslySkipPermissions: boolean;
+  providerRegistry: Accessor<ProviderRegistry | null>;
+  setProviderRegistry: Setter<ProviderRegistry | null>;
+  setActiveProvider: Setter<string>;
+  setActiveModel: Setter<string>;
+  setActiveModelLimits: Setter<ModelLimits | undefined>;
+  setActiveModelCapabilities: Setter<ModelCapabilities | undefined>;
+  setProviderHasApiKey: Setter<boolean>;
+  setProviderConfigReady: Setter<boolean>;
+  setMcpStatus: Setter<SidebarMcpState>;
+  setPermissionMode: Setter<PermissionMode>;
+  setShellExecEnabled: Setter<boolean>;
+  setPermissionSettingsReady: Setter<boolean>;
+  thinkingTier: Accessor<ReasoningTier | undefined>;
+  activeProvider: Accessor<string>;
+  activeModel: Accessor<string>;
+  setStatus: Setter<string>;
+  recordActivity: (entry: ActivityEntry) => void;
+};
+
+export function createProviderState(dangerouslySkipPermissions: boolean) {
+  const [providerRegistry, setProviderRegistry] = createSignal<ProviderRegistry | null>(null);
+  const [activeProvider, setActiveProvider] = createSignal("loading");
+  const [activeModel, setActiveModel] = createSignal("loading");
+  const [activeModelLimits, setActiveModelLimits] = createSignal<ModelLimits | undefined>();
+  const [activeModelCapabilities, setActiveModelCapabilities] = createSignal<ModelCapabilities | undefined>();
+  const [providerHasApiKey, setProviderHasApiKey] = createSignal(false);
+  const [providerConfigReady, setProviderConfigReady] = createSignal(false);
+  const [mcpStatus, setMcpStatus] = createSignal<SidebarMcpState>({ loading: true, configured: false, enabled: false, servers: [] });
+  const [permissionMode, setPermissionMode] = createSignal<PermissionMode>(dangerouslySkipPermissions ? "YOLO" : "MOMENTUM");
+  const [shellExecEnabled, setShellExecEnabled] = createSignal(dangerouslySkipPermissions);
+  const [permissionSettingsReady, setPermissionSettingsReady] = createSignal(dangerouslySkipPermissions);
+  return {
+    activeModel,
+    activeModelCapabilities,
+    activeModelLimits,
+    activeProvider,
+    mcpStatus,
+    permissionMode,
+    permissionSettingsReady,
+    providerConfigReady,
+    providerHasApiKey,
+    providerRegistry,
+    setActiveModel,
+    setActiveModelCapabilities,
+    setActiveModelLimits,
+    setActiveProvider,
+    setMcpStatus,
+    setPermissionMode,
+    setPermissionSettingsReady,
+    setProviderConfigReady,
+    setProviderHasApiKey,
+    setProviderRegistry,
+    setShellExecEnabled,
+    shellExecEnabled,
+  };
+}
+
+export function createProviderConfigController(options: ProviderConfigControllerOptions) {
+  let providerConfigLoad: Promise<void> | null = null;
+  let permissionSettingsLoad: Promise<void> | null = null;
+
+  async function refreshProviderConfig(selection?: Partial<ProviderSelection>): Promise<void> {
+    const inspected = await inspectProviderConfig(selection);
+    applyInspectedProvider(inspected);
+    options.recordActivity({ kind: "provider", text: `active ${inspected.providerId}/${inspected.model} (${inspected.registry.source})` });
+  }
+
+  async function applyProviderSelection(selection: Partial<ProviderSelection>): Promise<ProviderSelection> {
+    const inspected = await inspectProviderConfig(selection);
+    applyInspectedProvider(inspected);
+    options.recordActivity({ kind: "provider", text: `switched to ${inspected.providerId}/${inspected.model}` });
+    return { provider: inspected.providerId, model: inspected.model };
+  }
+
+  function applyInspectedProvider(inspected: Awaited<ReturnType<typeof inspectProviderConfig>>): void {
+    options.setProviderRegistry(inspected.registry);
+    options.setActiveProvider(inspected.providerId);
+    options.setActiveModel(inspected.model);
+    options.setActiveModelLimits(inspected.limits);
+    options.setActiveModelCapabilities(inspected.capabilities);
+    options.setProviderHasApiKey(inspected.hasApiKey);
+    options.setProviderConfigReady(true);
+    options.setStatus(inspected.hasApiKey ? "ready" : `missing API key for ${inspected.providerId}`);
+  }
+
+  async function refreshMcpStatus(): Promise<void> {
+    options.setMcpStatus((current) => ({ ...current, loading: true }));
+    const inspected = await inspectMcpConfig();
+    options.setMcpStatus({
+      loading: false,
+      configured: inspected.configured,
+      enabled: inspected.enabled,
+      servers: inspected.statuses.map((status) => ({
+        id: status.id,
+        enabled: status.enabled,
+        connected: status.connected,
+        toolCount: status.toolCount,
+        ...(status.error ? { error: status.error } : {}),
+      })),
+    });
+  }
+
+  async function ensureProviderRegistry(): Promise<ProviderRegistry> {
+    const existing = options.providerRegistry();
+    if (existing) return existing;
+    await loadProviderConfigOnce();
+    const loaded = options.providerRegistry();
+    if (!loaded) throw new Error("Provider registry did not load.");
+    return loaded;
+  }
+
+  function loadProviderConfigOnce(): Promise<void> {
+    providerConfigLoad ??= refreshProviderConfig().finally(() => { providerConfigLoad = null; });
+    return providerConfigLoad;
+  }
+
+  function loadPermissionSettingsOnce(): Promise<void> {
+    permissionSettingsLoad ??= loadPermissionSettings().then((settings) => {
+      options.setShellExecEnabled(options.dangerouslySkipPermissions || settings.shellExec);
+      if (!options.dangerouslySkipPermissions) options.setPermissionMode(settings.defaultMode);
+      options.setPermissionSettingsReady(true);
+    }).finally(() => { permissionSettingsLoad = null; });
+    return permissionSettingsLoad;
+  }
+
+  function activeProviderSelection(): ProviderSelection {
+    return { provider: options.activeProvider(), model: options.activeModel() };
+  }
+
+  function activeGeneration(): { reasoningTier: ReasoningTier } | undefined {
+    const reasoningTier = options.thinkingTier();
+    return reasoningTier ? { reasoningTier } : undefined;
+  }
+
+  return {
+    activeGeneration,
+    activeProviderSelection,
+    applyProviderSelection,
+    ensureProviderRegistry,
+    loadPermissionSettingsOnce,
+    loadProviderConfigOnce,
+    refreshMcpStatus,
+    refreshProviderConfig,
+  };
+}

--- a/src/tui/session-actions-controller.ts
+++ b/src/tui/session-actions-controller.ts
@@ -1,0 +1,169 @@
+import type { Accessor, Setter } from "solid-js";
+import type { ProviderSelection } from "../config/providers";
+import { compactConversation } from "../core/compact/service";
+import type { EngineId } from "../core/engine/profile";
+import type { ReasoningDisplayMode, SessionSummary } from "../core/session/store";
+import type { ConversationRewind } from "../core/rewind/service";
+import type { ReasoningTier, VesicleImageAttachment, VesicleMessage } from "../providers/shared/types";
+import type { ComposerElement, ComposerState } from "./composer";
+import { composerElementsForImages } from "./composer-history";
+import type { PendingEngineSwitchState, PendingGateState, PendingPermissionState, PendingUserQuestionState, TuiKeyEvent } from "./decision-interaction";
+import { displayTranscriptFromSnapshot, vesicleMessagesFromResumed } from "./session-presenter";
+import { latestTurnUsage, sumSessionUsage, type TokenUsageSummary } from "./telemetry";
+import type { ActivityEntry, AgentCardState, Message, SessionPickerState } from "./types";
+
+export type SessionActionsControllerOptions = {
+  rootDir: string;
+  sessionId: Accessor<string | undefined>;
+  activeEngine: Accessor<EngineId>;
+  setActiveEngine: Setter<EngineId>;
+  activeProviderSelection: () => ProviderSelection;
+  activeGeneration: () => { reasoningTier: ReasoningTier } | undefined;
+  providerConfigReady: Accessor<boolean>;
+  loadProviderConfig: () => Promise<void>;
+  pendingGate: Accessor<PendingGateState | null>;
+  setPendingGate: Setter<PendingGateState | null>;
+  pendingEngineSwitch: Accessor<PendingEngineSwitchState | null>;
+  setPendingEngineSwitch: Setter<PendingEngineSwitchState | null>;
+  pendingUserQuestion: Accessor<PendingUserQuestionState | null>;
+  setPendingUserQuestion: Setter<PendingUserQuestionState | null>;
+  pendingPermission: Accessor<PendingPermissionState | null>;
+  setPendingPermission: Setter<PendingPermissionState | null>;
+  pendingChildPermission: Accessor<unknown | null>;
+  agentCards: Accessor<AgentCardState[]>;
+  setConversation: Setter<VesicleMessage[]>;
+  setMessages: Setter<Message[]>;
+  setThinkingTier: Setter<ReasoningTier | undefined>;
+  setReasoningDisplayMode: Setter<ReasoningDisplayMode>;
+  applyProviderSelection: (selection: Partial<ProviderSelection>) => Promise<ProviderSelection>;
+  setOutput: Setter<string>;
+  setNextSessionParent: Setter<{ uuid: string | null } | null>;
+  applyComposerState: (state: ComposerState) => void;
+  clearComposer: () => void;
+  setInputImages: Setter<VesicleImageAttachment[]>;
+  setHistoryIndex: Setter<number | null>;
+  setLastTurnUsage: Setter<TokenUsageSummary | undefined>;
+  setSessionUsage: Setter<TokenUsageSummary>;
+  sessionPicker: Accessor<SessionPickerState | null>;
+  setSessionPicker: Setter<SessionPickerState | null>;
+  setBusy: Setter<boolean>;
+  setStatus: Setter<string>;
+  recordActivity: (entry: ActivityEntry) => void;
+  runCancellable: <T>(operation: (signal: AbortSignal) => Promise<T>) => Promise<{ kind: "complete"; value: T } | { kind: "interrupted" }>;
+  rewindReset: () => void;
+  refreshArtifacts: () => Promise<unknown>;
+  resumeSession: (target: SessionSummary) => Promise<void>;
+};
+
+export function createSessionActionsController(options: SessionActionsControllerOptions) {
+  function resetRewindState(): void {
+    options.rewindReset();
+    options.setNextSessionParent(null);
+  }
+
+  async function applyConversationRewind(result: ConversationRewind): Promise<void> {
+    const snapshot = result.snapshot;
+    options.setConversation(vesicleMessagesFromResumed(snapshot.messages));
+    options.setMessages(displayTranscriptFromSnapshot(snapshot.messages, options.agentCards()));
+    options.setActiveEngine(snapshot.engine ?? "etl");
+    options.setThinkingTier(snapshot.reasoningTier);
+    options.setReasoningDisplayMode(snapshot.reasoningDisplayMode ?? "collapsed");
+    if (snapshot.providerSelection) {
+      try {
+        await options.applyProviderSelection(snapshot.providerSelection);
+      } catch (error) {
+        options.recordActivity({ kind: "system", text: `rewind kept current provider: ${error instanceof Error ? error.message : String(error)}` });
+      }
+    }
+    clearPendingInteractions();
+    options.setOutput("");
+    options.setNextSessionParent({ uuid: result.parentUuid });
+    const images = result.images ?? [];
+    options.applyComposerState({
+      value: result.prompt,
+      cursor: result.prompt.length,
+      elements: composerElementsForImages(result.prompt, images),
+    });
+    options.setInputImages(images.map((image) => ({ ...image })));
+    options.setHistoryIndex(null);
+    await options.refreshArtifacts();
+    options.setStatus("conversation rewound");
+  }
+
+  async function compactSession(instructions?: string): Promise<{ summary: string; messagesSummarized: number }> {
+    const id = options.sessionId();
+    if (!id) throw new Error("No active session to compact.");
+    if (hasPendingInteraction()) throw new Error("Resolve the pending gate, engine switch, question, or permission before compacting.");
+    if (!options.providerConfigReady()) await options.loadProviderConfig();
+    options.setBusy(true);
+    options.setStatus("compacting conversation");
+    options.recordActivity({ kind: "provider", text: "compacting conversation" });
+    try {
+      const outcome = await options.runCancellable((signal) => compactConversation({
+        rootDir: options.rootDir,
+        sessionId: id,
+        engine: options.activeEngine(),
+        providerSelection: options.activeProviderSelection(),
+        generation: options.activeGeneration(),
+        instructions,
+        signal,
+      }));
+      if (outcome.kind === "interrupted") throw new Error("Compaction canceled.");
+      const result = outcome.value;
+      const snapshot = result.snapshot;
+      options.setConversation(vesicleMessagesFromResumed(snapshot.messages));
+      options.setMessages(displayTranscriptFromSnapshot(snapshot.messages, options.agentCards()));
+      options.setLastTurnUsage(latestTurnUsage(snapshot.messages));
+      options.setSessionUsage(sumSessionUsage(snapshot.messages));
+      options.setOutput("");
+      options.setNextSessionParent({ uuid: result.parentUuid });
+      clearPendingInteractions();
+      options.setSessionPicker(null);
+      options.rewindReset();
+      options.clearComposer();
+      options.setHistoryIndex(null);
+      options.setStatus(`compacted ${result.messagesSummarized} messages`);
+      options.recordActivity({ kind: "system", text: `compacted ${result.messagesSummarized} messages` });
+      return { summary: result.summary, messagesSummarized: result.messagesSummarized };
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
+  function handleSessionPickerKey(key: TuiKeyEvent): boolean {
+    const picker = options.sessionPicker();
+    if (!picker) return false;
+    if (key.name === "up" || (key.ctrl && key.name === "p")) {
+      options.setSessionPicker({ ...picker, selected: (picker.selected - 1 + picker.sessions.length) % picker.sessions.length });
+      return true;
+    }
+    if (key.name === "down" || (key.ctrl && key.name === "n")) {
+      options.setSessionPicker({ ...picker, selected: (picker.selected + 1) % picker.sessions.length });
+      return true;
+    }
+    if (key.name === "return" || key.name === "enter") {
+      const target = picker.sessions[picker.selected];
+      if (target) void options.resumeSession(target);
+      return true;
+    }
+    if (key.name === "escape") {
+      options.setSessionPicker(null);
+      options.setStatus("resume cancelled");
+      return true;
+    }
+    return false;
+  }
+
+  function clearPendingInteractions(): void {
+    options.setPendingGate(null);
+    options.setPendingEngineSwitch(null);
+    options.setPendingUserQuestion(null);
+    options.setPendingPermission(null);
+  }
+
+  function hasPendingInteraction(): boolean {
+    return Boolean(options.pendingGate() || options.pendingEngineSwitch() || options.pendingUserQuestion() || options.pendingPermission() || options.pendingChildPermission());
+  }
+
+  return { applyConversationRewind, compactSession, handleSessionPickerKey, resetRewindState };
+}

--- a/src/tui/session-preferences-controller.ts
+++ b/src/tui/session-preferences-controller.ts
@@ -1,0 +1,122 @@
+import type { Accessor, Setter } from "solid-js";
+import type { ProviderSelection } from "../config/providers";
+import { ENGINE_HANDOFF_KIND, renderEngineHandoffPacket, type EngineTransition } from "../core/engine/transition";
+import type { PermissionMode } from "../core/permissions";
+import { createSessionStore } from "../core/session/store";
+import type { ReasoningDisplayMode } from "../core/session/store";
+import type { ReasoningTier, VesicleMessage } from "../providers/shared/types";
+import type { Message } from "./types";
+import type { GateFocusTarget } from "./GatePrompt";
+
+export type SessionPreferencesControllerOptions = {
+  rootDir: string;
+  dangerouslySkipPermissions: boolean;
+  sessionId: Accessor<string | undefined>;
+  nextSessionParent: Accessor<{ uuid: string | null } | null>;
+  setNextSessionParent: Setter<{ uuid: string | null } | null>;
+  permissionMode: Accessor<PermissionMode>;
+  setPermissionMode: Setter<PermissionMode>;
+  setGateFocus: Setter<GateFocusTarget>;
+  setYoloConfirmStage: Setter<1 | 2 | null>;
+  setStatus: Setter<string>;
+  setMessages: Setter<Message[]>;
+  setConversation: Setter<VesicleMessage[]>;
+};
+
+export function createSessionPreferencesController(options: SessionPreferencesControllerOptions) {
+  async function persistProviderSwitch(selection: ProviderSelection): Promise<void> {
+    await appendHostSessionRecord({
+      role: "system",
+      content: `Provider switched to ${selection.provider}/${selection.model}.`,
+      metadata: { kind: "provider-switch", providerId: selection.provider, model: selection.model },
+    });
+  }
+
+  async function persistEngineSwitch(transition: EngineTransition): Promise<void> {
+    await appendHostSessionRecord({
+      role: "system",
+      content: `Engine switched to ${transition.toEngine}.`,
+      metadata: {
+        kind: "engine-switch",
+        engine: transition.toEngine,
+        targetEngine: transition.toEngine,
+        reason: transition.reason,
+        handoffSummary: transition.handoffSummary,
+        ...(transition.recommendedNextAction ? { recommendedNextAction: transition.recommendedNextAction } : {}),
+        transition,
+      },
+    });
+    const packet = renderEngineHandoffPacket(transition);
+    const appended = await appendHostSessionRecord({
+      role: "user",
+      content: packet,
+      metadata: { kind: ENGINE_HANDOFF_KIND, engine: transition.toEngine, transition },
+    });
+    if (appended) options.setConversation((previous) => [...previous, { role: "user", content: packet }]);
+  }
+
+  async function persistThinkingSwitch(tier: ReasoningTier | undefined): Promise<void> {
+    await appendHostSessionRecord({
+      role: "system",
+      content: tier ? `Thinking effort switched to ${tier}.` : "Thinking effort reset to provider default.",
+      metadata: { kind: "thinking-switch", reasoningTier: tier ?? null },
+    });
+  }
+
+  async function persistReasoningSwitch(mode: ReasoningDisplayMode): Promise<void> {
+    await appendHostSessionRecord({
+      role: "system",
+      content: `Reasoning display switched to ${mode}.`,
+      metadata: { kind: "reasoning-switch", reasoningDisplayMode: mode },
+    });
+  }
+
+  async function changePermissionMode(mode: PermissionMode): Promise<void> {
+    if (mode === "YOLO" && options.permissionMode() !== "YOLO" && !options.dangerouslySkipPermissions) {
+      options.setGateFocus("confirm");
+      options.setYoloConfirmStage(1);
+      options.setStatus("confirm YOLO permission mode");
+      return;
+    }
+    await applyPermissionMode(mode);
+  }
+
+  async function applyPermissionMode(mode: PermissionMode): Promise<void> {
+    options.setPermissionMode(mode);
+    options.setStatus(`permission mode ${mode}`);
+    await appendHostSessionRecord({
+      role: "system",
+      content: `Permission mode switched to ${mode}.`,
+      metadata: { kind: "permission-mode-switch", permissionMode: mode },
+    });
+    options.setMessages((previous) => [...previous, {
+      role: "system",
+      content: mode === "YOLO"
+        ? "DANGER: YOLO enabled for this process. All tool approvals are bypassed; runtime hard guards remain active."
+        : `Permission mode switched to ${mode}.`,
+    }]);
+  }
+
+  async function appendHostSessionRecord(record: {
+    role: "system" | "user";
+    content: string;
+    metadata: Record<string, unknown>;
+  }) {
+    const id = options.sessionId();
+    if (!id) return undefined;
+    const branch = options.nextSessionParent();
+    const store = await createSessionStore(options.rootDir, id, branch ? { parentUuid: branch.uuid } : {});
+    const appended = await store.append(record);
+    if (branch) options.setNextSessionParent({ uuid: appended.uuid });
+    return appended;
+  }
+
+  return {
+    applyPermissionMode,
+    changePermissionMode,
+    persistEngineSwitch,
+    persistProviderSwitch,
+    persistReasoningSwitch,
+    persistThinkingSwitch,
+  };
+}

--- a/src/tui/session-presenter.ts
+++ b/src/tui/session-presenter.ts
@@ -1,0 +1,141 @@
+import { ENGINE_HANDOFF_KIND } from "../core/engine/transition";
+import type { ResumedMessage } from "../core/session/store";
+import type { VesicleMessage } from "../providers/shared/types";
+import { displayTextFromThinkingBlocks } from "../providers/shared/thinking";
+import { renderResumedToolResultSummary } from "./tool-summary";
+import type { AgentCardState, Message } from "./types";
+
+export function unresolvedToolCalls(messages: ResumedMessage[], activeToolCallId: string) {
+  const answered = new Set(messages.flatMap((message) => message.toolCallId ? [message.toolCallId] : []));
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const calls = messages[index].toolCalls;
+    if (!calls?.some((call) => call.id === activeToolCallId)) continue;
+    return calls.filter((call) => call.id !== activeToolCallId && !answered.has(call.id));
+  }
+  return [];
+}
+
+export function vesicleMessagesFromResumed(messages: ResumedMessage[]): VesicleMessage[] {
+  return messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+    ...(message.reasoningContent ? { reasoningContent: message.reasoningContent } : {}),
+    ...(message.thinkingBlocks ? { thinkingBlocks: message.thinkingBlocks.map((block) => ({ ...block })) } : {}),
+    ...(message.toolCallId ? { toolCallId: message.toolCallId } : {}),
+    ...(message.toolCalls ? { toolCalls: message.toolCalls.map((call) => ({ ...call })) } : {}),
+    ...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
+  }));
+}
+
+export function displayTranscriptFromSnapshot(messages: ResumedMessage[], agents: AgentCardState[] = []): Message[] {
+  const argsByCallId = new Map<string, { name: string; arguments: string }>();
+  for (const message of messages) {
+    for (const call of message.toolCalls ?? []) {
+      argsByCallId.set(call.id, { name: call.name, arguments: call.arguments });
+    }
+  }
+  const agentsByToolCallId = new Map(agents.map((agent) => [agent.parentToolCallId, agent]));
+  return messages.flatMap((message) => displayMessagesFromResumed(message, argsByCallId, agentsByToolCallId));
+}
+
+export function displayMessagesFromResumed(
+  message: ResumedMessage,
+  argsByCallId: Map<string, { name: string; arguments: string }>,
+  agentsByToolCallId: Map<string, AgentCardState> = new Map(),
+): Message[] {
+  if (message.kind === ENGINE_HANDOFF_KIND) {
+    return [{
+      role: "system",
+      content: message.content
+        .replace(/^\[engine_handoff\]\s*/i, "Engine handoff\n")
+        .replace(/\s*\[\/engine_handoff\]\s*$/i, ""),
+    }];
+  }
+  if (message.kind === "compact-summary") {
+    return [{ role: "system", content: message.content.replace(/^\[conversation summary\]\s*/i, "Conversation summary\n") }];
+  }
+  if (message.role === "assistant") {
+    const reasoningText = displayTextFromThinkingBlocks(message.thinkingBlocks) ?? message.reasoningContent;
+    const out: Message[] = [];
+    if (reasoningText?.trim()) out.push({ role: "system", content: reasoningText, kind: "reasoning" });
+    if (message.content.trim()) {
+      out.push({
+        role: "assistant",
+        content: message.content,
+        ...(message.engine ? { engine: message.engine } : {}),
+        ...(message.model ? { model: message.model } : {}),
+      });
+    }
+    return out;
+  }
+  if (message.role === "tool") {
+    const lookup = message.toolCallId ? argsByCallId.get(message.toolCallId) : undefined;
+    if (lookup?.name === "spawn_agent") {
+      const agent = message.toolCallId ? agentsByToolCallId.get(message.toolCallId) : undefined;
+      return agent ? [{ role: "system", content: "", kind: "agent", agentRunId: agent.runId }] : [];
+    }
+    if (lookup) {
+      const ok = message.toolOk ?? true;
+      return [
+        {
+          role: "tool",
+          toolStage: "call",
+          toolName: lookup.name,
+          toolArgs: lookup.arguments,
+          toolCallId: message.toolCallId,
+          toolFileEvent: message.toolFileEvent,
+          toolWebEvent: message.toolWebEvent,
+          toolMcpEvent: message.toolMcpEvent,
+          toolProcessEvent: message.toolProcessEvent,
+          toolOk: ok,
+          images: message.images,
+          content: "",
+        },
+        {
+          role: "tool",
+          toolStage: "result",
+          toolName: lookup.name,
+          toolCallId: message.toolCallId,
+          toolOk: ok,
+          toolFileEvent: message.toolFileEvent,
+          toolWebEvent: message.toolWebEvent,
+          toolMcpEvent: message.toolMcpEvent,
+          toolProcessEvent: message.toolProcessEvent,
+          images: message.images,
+          content: ok ? "" : extractResultContent(message.content),
+        },
+      ];
+    }
+    return [{ role: "tool", content: renderResumedToolResultSummary(message.content), images: message.images }];
+  }
+  if (message.role === "user" && message.kind === "subagent-results") {
+    return [{ role: "system", content: "Background SubAgent results were delivered to the parent Engine." }];
+  }
+  if (message.role === "user" && message.kind === "background-process-results") {
+    return [{ role: "system", content: "Background shell completion was delivered to the active Engine." }];
+  }
+  if (message.role === "user") {
+    return [{
+      role: message.role,
+      content: message.content,
+      ...(message.images ? { images: message.images.map((image) => ({ ...image })) } : {}),
+    }];
+  }
+  return [{ role: "system", content: message.content }];
+}
+
+export function joinSessionPath(sessionId: string): string {
+  return `.vesicle/sessions/${sessionId}.jsonl`;
+}
+
+function extractResultContent(raw: string): string {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && typeof (parsed as { result?: unknown }).result === "string") {
+      return (parsed as { result: string }).result;
+    }
+  } catch {
+    // Preserve the original stored text when it is not a structured result.
+  }
+  return raw;
+}

--- a/src/tui/session-resume-controller.ts
+++ b/src/tui/session-resume-controller.ts
@@ -1,0 +1,292 @@
+import type { Accessor, Setter } from "solid-js";
+import type { ProviderSelection } from "../config/providers";
+import type { EngineId } from "../core/engine/profile";
+import { inspectEngineAssetDrift } from "../core/runtime/engine-assets";
+import { loadSessionSnapshot } from "../core/session/store";
+import type { ReasoningDisplayMode, SessionSnapshot, SessionSummary } from "../core/session/store";
+import type { AgentStore } from "../core/agents/store";
+import type { ProcessManager } from "../core/process/manager";
+import { processEventFromTask } from "../core/tools/shell";
+import type { PermissionMode } from "../core/permissions";
+import type { ReasoningTier, VesicleMessage } from "../providers/shared/types";
+import { agentCardFromMetadata, mergeRestoredAgentCards } from "./agent-view";
+import type { GateFocusTarget } from "./GatePrompt";
+import type {
+  PendingEngineSwitchState,
+  PendingGateState,
+  PendingPermissionState,
+  PendingUserQuestionState,
+} from "./decision-interaction";
+import {
+  displayTranscriptFromSnapshot,
+  joinSessionPath,
+  unresolvedToolCalls,
+  vesicleMessagesFromResumed,
+} from "./session-presenter";
+import { latestTurnUsage, sumSessionUsage, type TokenUsageSummary } from "./telemetry";
+import type { AgentCardState, Message, SessionPickerState } from "./types";
+
+type InteractionState = {
+  setPendingGate: Setter<PendingGateState | null>;
+  setPendingEngineSwitch: Setter<PendingEngineSwitchState | null>;
+  setPendingUserQuestion: Setter<PendingUserQuestionState | null>;
+  setPendingPermission: Setter<PendingPermissionState | null>;
+  setGateFocus: Setter<GateFocusTarget>;
+  setGateFeedbackMode: Setter<GateFocusTarget | null>;
+  setGateFeedback: Setter<string>;
+  setGateFeedbackCursor: Setter<number>;
+  setGateFeedbackKillBuffer: Setter<string | undefined>;
+  setQuestionSelected: Setter<number>;
+  setQuestionFreeformText: Setter<string>;
+  setQuestionFreeformCursor: Setter<number>;
+  setQuestionFreeformKillBuffer: Setter<string | undefined>;
+};
+
+export type SessionResumeControllerOptions = InteractionState & {
+  rootDir: string;
+  dangerouslySkipPermissions: boolean;
+  permissionSettingsReady: Accessor<boolean>;
+  loadPermissionSettings: () => Promise<void>;
+  processManager: ProcessManager;
+  agentStore: AgentStore;
+  agentCards: Accessor<AgentCardState[]>;
+  setAgentCards: Setter<AgentCardState[]>;
+  permissionMode: Accessor<PermissionMode>;
+  setPermissionMode: Setter<PermissionMode>;
+  applyProviderSelection: (selection: Partial<ProviderSelection>) => Promise<ProviderSelection>;
+  setRestoringSession: Setter<boolean>;
+  setSessionId: Setter<string | undefined>;
+  setNextSessionParent: Setter<{ uuid: string | null } | null>;
+  setSessionPath: Setter<string>;
+  setActiveEngine: Setter<EngineId>;
+  setConversation: Setter<VesicleMessage[]>;
+  setLastTurnUsage: Setter<TokenUsageSummary | undefined>;
+  setSessionUsage: Setter<TokenUsageSummary>;
+  setOutput: Setter<string>;
+  setSessionPicker: Setter<SessionPickerState | null>;
+  setThinkingTier: Setter<ReasoningTier | undefined>;
+  setReasoningDisplayMode: Setter<ReasoningDisplayMode>;
+  setStatus: Setter<string>;
+  setMessages: Setter<Message[]>;
+  setAssetDriftKey: (key: string) => void;
+  refreshArtifacts: () => Promise<unknown>;
+  reportError: (error: unknown) => void;
+};
+
+export function createSessionResumeController(options: SessionResumeControllerOptions) {
+  async function resumeSession(target: SessionSummary, commandEcho?: string): Promise<void> {
+    options.setRestoringSession(true);
+    try {
+      if (!options.permissionSettingsReady()) await options.loadPermissionSettings();
+      const snapshot = await loadSessionSnapshot(options.rootDir, target.sessionId, {
+        synthesizeDanglingToolResults: false,
+      });
+      await hydrateLiveProcessEvents(snapshot, target.sessionId);
+      const resumedMessages = vesicleMessagesFromResumed(snapshot.messages);
+      const restoredCards = await restoreAgentCards(target.sessionId);
+      applyBaseSnapshot(target, snapshot, resumedMessages);
+      const hostMessages = await buildHostMessages(target, snapshot, commandEcho);
+      restorePendingInteraction(target, snapshot, resumedMessages, hostMessages);
+      options.setMessages([...displayTranscriptFromSnapshot(snapshot.messages, restoredCards), ...hostMessages]);
+      await options.refreshArtifacts();
+    } catch (error) {
+      options.reportError(error);
+    } finally {
+      options.setRestoringSession(false);
+    }
+  }
+
+  async function hydrateLiveProcessEvents(snapshot: SessionSnapshot, sessionId: string): Promise<void> {
+    const liveProcesses = await options.processManager.list(sessionId);
+    const liveByTaskId = new Map(liveProcesses.map((process) => [process.taskId, process]));
+    for (const message of snapshot.messages) {
+      const taskId = message.toolProcessEvent?.taskId;
+      const live = taskId ? liveByTaskId.get(taskId) : undefined;
+      if (live) message.toolProcessEvent = processEventFromTask(live);
+    }
+  }
+
+  async function restoreAgentCards(sessionId: string): Promise<AgentCardState[]> {
+    const [storedAgents, storedInbox] = await Promise.all([
+      options.agentStore.listByParent(sessionId),
+      options.agentStore.listInbox(sessionId),
+    ]);
+    const restored = storedAgents.map((agent) => agentCardFromMetadata(agent, storedInbox));
+    options.setAgentCards((current) => mergeRestoredAgentCards(current, sessionId, restored));
+    return restored;
+  }
+
+  function applyBaseSnapshot(target: SessionSummary, snapshot: SessionSnapshot, messages: VesicleMessage[]): void {
+    const restoredEngine = snapshot.engine ?? "etl";
+    options.setSessionId(target.sessionId);
+    options.setNextSessionParent(null);
+    options.setSessionPath(joinSessionPath(target.sessionId));
+    options.setActiveEngine(restoredEngine);
+    options.setConversation(messages);
+    options.setLastTurnUsage(latestTurnUsage(snapshot.messages));
+    options.setSessionUsage(sumSessionUsage(snapshot.messages));
+    options.setOutput(snapshot.pendingGate?.assistantContent ?? snapshot.pendingEngineSwitch?.assistantContent ?? snapshot.pendingUserQuestion?.assistantContent ?? "");
+    options.setSessionPicker(null);
+  }
+
+  async function buildHostMessages(
+    target: SessionSummary,
+    snapshot: SessionSnapshot,
+    commandEcho?: string,
+  ): Promise<Message[]> {
+    const restoredEngine = snapshot.engine ?? "etl";
+    const hostMessages: Message[] = [];
+    if (commandEcho) hostMessages.push({ role: "user", content: commandEcho });
+    hostMessages.push({ role: "system", content: `Restored engine ${restoredEngine} from session.` });
+    restorePermissionMode(snapshot, hostMessages);
+    await reportAssetDrift(target.sessionId, snapshot, restoredEngine, hostMessages);
+    await restoreProvider(snapshot, hostMessages);
+    if (snapshot.reasoningTier) {
+      options.setThinkingTier(snapshot.reasoningTier);
+      hostMessages.push({ role: "system", content: `Restored thinking effort ${snapshot.reasoningTier} from session.` });
+    }
+    if (snapshot.reasoningDisplayMode) {
+      options.setReasoningDisplayMode(snapshot.reasoningDisplayMode);
+      hostMessages.push({ role: "system", content: `Restored reasoning display ${snapshot.reasoningDisplayMode} from session.` });
+    }
+    return hostMessages;
+  }
+
+  function restorePermissionMode(snapshot: SessionSnapshot, hostMessages: Message[]): void {
+    const restored = options.dangerouslySkipPermissions
+      ? "YOLO"
+      : snapshot.permissionMode === "YOLO"
+        ? "MOMENTUM"
+        : snapshot.permissionMode ?? options.permissionMode();
+    options.setPermissionMode(restored);
+    hostMessages.push({
+      role: "system",
+      content: snapshot.permissionMode === "YOLO" && !options.dangerouslySkipPermissions
+        ? "Previous YOLO permission mode was downgraded to MOMENTUM on resume. Re-enable YOLO explicitly if needed."
+        : `Restored permission mode ${restored}.`,
+    });
+  }
+
+  async function reportAssetDrift(
+    sessionId: string,
+    snapshot: SessionSnapshot,
+    engine: EngineId,
+    hostMessages: Message[],
+  ): Promise<void> {
+    const drift = await inspectEngineAssetDrift(snapshot.assets, engine, options.rootDir);
+    if (!drift) return;
+    options.setAssetDriftKey(`${sessionId}:${drift.current.sha256}`);
+    const changed = drift.changedPaths.length > 0 ? drift.changedPaths.join(", ") : "effective profile/prompt assets";
+    hostMessages.push({
+      role: "system",
+      content: `Asset drift detected since this session began: ${changed}. Continued turns use the current effective assets.`,
+    });
+  }
+
+  async function restoreProvider(snapshot: SessionSnapshot, hostMessages: Message[]): Promise<void> {
+    if (!snapshot.providerSelection) return;
+    try {
+      const selection = await options.applyProviderSelection(snapshot.providerSelection);
+      hostMessages.push({ role: "system", content: `Restored provider ${selection.provider}/${selection.model} from session.` });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      hostMessages.push({ role: "system", content: `Session provider was not restored: ${message}` });
+    }
+  }
+
+  function restorePendingInteraction(
+    target: SessionSummary,
+    snapshot: SessionSnapshot,
+    messages: VesicleMessage[],
+    hostMessages: Message[],
+  ): void {
+    const engine = snapshot.engine ?? "etl";
+    resetInteractionDrafts();
+    if (snapshot.pendingPermission) {
+      restorePendingPermission(target, snapshot, messages, engine, hostMessages);
+    } else if (snapshot.pendingGate) {
+      options.setPendingGate({
+        kind: "needs_user",
+        sessionId: target.sessionId,
+        sessionPath: joinSessionPath(target.sessionId),
+        engine,
+        gate: snapshot.pendingGate.gate,
+        toolCallId: snapshot.pendingGate.toolCallId,
+        assistantContent: snapshot.pendingGate.assistantContent,
+        messages,
+      });
+      options.setGateFocus("confirm");
+      options.setStatus(`gate pending: ${snapshot.pendingGate.gate.gate}`);
+      hostMessages.push({ role: "system", content: `Resumed pending gate ${snapshot.pendingGate.gate.gate}. Use the gate controls below to continue.` });
+    } else if (snapshot.pendingEngineSwitch) {
+      options.setPendingEngineSwitch({
+        kind: "needs_engine_switch",
+        sessionId: target.sessionId,
+        sessionPath: joinSessionPath(target.sessionId),
+        request: snapshot.pendingEngineSwitch.request,
+        toolCallId: snapshot.pendingEngineSwitch.toolCallId,
+        assistantContent: snapshot.pendingEngineSwitch.assistantContent,
+        messages,
+      });
+      options.setGateFocus("confirm");
+      options.setStatus(`engine switch pending: ${snapshot.pendingEngineSwitch.request.targetEngine}`);
+      hostMessages.push({ role: "system", content: `Resumed pending engine switch to ${snapshot.pendingEngineSwitch.request.targetEngine}. Use the gate controls below to continue.` });
+    } else if (snapshot.pendingUserQuestion) {
+      options.setPendingUserQuestion({
+        kind: "needs_user_question",
+        sessionId: target.sessionId,
+        sessionPath: joinSessionPath(target.sessionId),
+        engine,
+        question: snapshot.pendingUserQuestion.question,
+        toolCallId: snapshot.pendingUserQuestion.toolCallId,
+        assistantContent: snapshot.pendingUserQuestion.assistantContent,
+        messages,
+      });
+      options.setStatus(`question pending: ${snapshot.pendingUserQuestion.question.header}`);
+      hostMessages.push({ role: "system", content: `Resumed pending question ${snapshot.pendingUserQuestion.question.header}. Choose an option below to continue.` });
+    } else {
+      options.setStatus(`resumed ${target.sessionId.slice(11)}`);
+      hostMessages.push({ role: "system", content: `Resumed session ${target.sessionId} with ${snapshot.messages.length} prior turns. Continue below.` });
+    }
+  }
+
+  function restorePendingPermission(
+    target: SessionSummary,
+    snapshot: SessionSnapshot,
+    messages: VesicleMessage[],
+    engine: EngineId,
+    hostMessages: Message[],
+  ): void {
+    const request = snapshot.pendingPermission!;
+    options.setPendingPermission({
+      kind: "needs_permission",
+      sessionId: target.sessionId,
+      sessionPath: joinSessionPath(target.sessionId),
+      engine,
+      request,
+      remainingToolCalls: unresolvedToolCalls(snapshot.messages, request.toolCallId),
+      assistantContent: "",
+      messages,
+    });
+    options.setGateFocus("confirm");
+    options.setStatus(`permission pending: ${request.toolName}`);
+    hostMessages.push({ role: "system", content: `Resumed pending permission for ${request.toolName}.` });
+  }
+
+  function resetInteractionDrafts(): void {
+    options.setPendingGate(null);
+    options.setPendingEngineSwitch(null);
+    options.setPendingUserQuestion(null);
+    options.setPendingPermission(null);
+    options.setQuestionSelected(0);
+    options.setQuestionFreeformText("");
+    options.setQuestionFreeformCursor(0);
+    options.setQuestionFreeformKillBuffer(undefined);
+    options.setGateFeedbackMode(null);
+    options.setGateFeedback("");
+    options.setGateFeedbackCursor(0);
+    options.setGateFeedbackKillBuffer(undefined);
+  }
+
+  return { resumeSession };
+}

--- a/src/tui/telemetry.ts
+++ b/src/tui/telemetry.ts
@@ -1,0 +1,281 @@
+import type { ModelLimits } from "../config/env";
+import type { BackgroundProcessState } from "../core/process/manager";
+import { ENGINE_HANDOFF_KIND } from "../core/engine/transition";
+import type { ResumedMessage } from "../core/session/store";
+import type { ResponseUsage } from "../providers/shared/types";
+import { truncateLine } from "./format";
+import { engineDisplayName } from "./theme";
+import type { EngineId } from "../core/engine/profile";
+import { createSignal } from "solid-js";
+
+export type TokenUsageSummary = {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  contextInputTokens: number;
+};
+
+export function createUsageController() {
+  const [lastTurnUsage, setLastTurnUsage] = createSignal<TokenUsageSummary | undefined>();
+  const [sessionUsage, setSessionUsage] = createSignal<TokenUsageSummary>(emptyUsageSummary());
+  let activeTurnUsage = emptyUsageSummary();
+  let activeTurnAgentUsage = emptyUsageSummary();
+  let activeTurnUsagePublished = false;
+
+  function beginTurn(): void {
+    activeTurnUsage = emptyUsageSummary();
+    activeTurnAgentUsage = emptyUsageSummary();
+    activeTurnUsagePublished = false;
+    setLastTurnUsage(undefined);
+  }
+
+  function recordResponse(usage: ResponseUsage): void {
+    activeTurnUsage = addResponseUsageToTurn(activeTurnUsage, usage);
+    activeTurnUsagePublished = false;
+  }
+
+  function recordIndependent(usage: ResponseUsage): void {
+    activeTurnAgentUsage = addIndependentUsageToTurn(activeTurnAgentUsage, usage);
+    activeTurnUsagePublished = false;
+  }
+
+  function publishTurn(): void {
+    const combined = mergeLogicalTurnUsage(activeTurnUsage, activeTurnAgentUsage);
+    const usage = hasUsageSummary(combined) ? combined : undefined;
+    setLastTurnUsage(usage);
+    if (usage && !activeTurnUsagePublished) {
+      setSessionUsage((current) => addTurnUsageToSession(current, usage));
+      activeTurnUsagePublished = true;
+    }
+  }
+
+  return {
+    beginTurn,
+    lastTurnUsage,
+    publishTurn,
+    recordIndependent,
+    recordResponse,
+    sessionUsage,
+    setLastTurnUsage,
+    setSessionUsage,
+  };
+}
+
+export function headerLine(engine: EngineId, width: number, agents?: string, processes?: string): string {
+  const left = `Prism Vesicle · ${engineDisplayName(engine)}`;
+  const content = [left, ...(agents ? [`Agents ${agents}`] : []), ...(processes ? [`Shell ${processes}`] : [])].join(" · ");
+  return truncateLine(content, Math.max(20, width - 4));
+}
+
+export function backgroundProcessActivitySummary(processes: BackgroundProcessState[]): string | undefined {
+  const running = processes.filter((process) => process.status === "running").length;
+  return running > 0 ? `${running} running` : undefined;
+}
+
+/**
+ * Bottom telemetry line: connection identity plus current-turn and session
+ * token counters. A turn is one logical user/gate/question input through the
+ * provider tool loop that follows. Repeated provider requests inside the same
+ * turn reuse most of the same context, so upstream/cache counters use the
+ * latest request's context occupancy while downstream output still sums newly
+ * generated tokens. Pricing intentionally stays out of this layer; adapters
+ * only normalize runtime usage facts.
+ */
+export function footerLine(
+  provider: string,
+  model: string,
+  hasKey: boolean,
+  width: number,
+  turnUsage?: TokenUsageSummary,
+  sessionUsage?: TokenUsageSummary,
+  modelLimits?: ModelLimits,
+): string {
+  const turnTelemetry = turnUsageTelemetryLine(turnUsage);
+  const sessionTelemetry = sessionUsageTelemetryLine(sessionUsage);
+  const contextTelemetry = contextUsageTelemetryLine(turnUsage, modelLimits);
+  const left = `${provider}/${model} · key ${hasKey ? "ok" : "missing"}${turnTelemetry ? ` · ${turnTelemetry}` : ""}${sessionTelemetry ? ` · ${sessionTelemetry}` : ""}`;
+  return footerWithRightTelemetry(left, contextTelemetry, Math.max(20, width - 2));
+}
+
+export function turnUsageTelemetryLine(usage: TokenUsageSummary | undefined): string | undefined {
+  if (!usage || !hasUsageSummary(usage)) return undefined;
+  const parts: string[] = [];
+  parts.push("turn", tokenArrowPair(usage));
+  const cached = formatTokenCount(usage.cachedInputTokens);
+  if (cached && usage.cachedInputTokens > 0) parts.push(`↻ ${cached}`);
+  return parts.join(" ");
+}
+
+export function sessionUsageTelemetryLine(usage: TokenUsageSummary | undefined): string | undefined {
+  if (!usage || !hasUsageSummary(usage)) return undefined;
+  return `session ${tokenArrowPair(usage)} ↻ ${formatTokenCount(usage.cachedInputTokens) ?? "0"}`;
+}
+
+export function contextUsageTelemetryLine(usage: TokenUsageSummary | undefined, modelLimits: ModelLimits | undefined): string | undefined {
+  const contextWindow = modelLimits?.contextWindow;
+  if (!usage || !contextWindow || contextWindow <= 0 || usage.contextInputTokens <= 0) return undefined;
+  return `ctx ${formatTokenCount(usage.contextInputTokens)}/${formatTokenCount(contextWindow)} ${formatContextPercent(usage.contextInputTokens, contextWindow)}`;
+}
+
+export function emptyUsageSummary(): TokenUsageSummary {
+  return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, contextInputTokens: 0 };
+}
+
+export function addResponseUsageToTurn(current: TokenUsageSummary, usage: ResponseUsage): TokenUsageSummary {
+  const contextInputTokens = contextInputTokensForDisplay(usage);
+  return {
+    inputTokens: latestNonZero(current.inputTokens, contextInputTokens),
+    outputTokens: current.outputTokens + finiteOrZero(usage.outputTokens),
+    cachedInputTokens: latestNonZero(current.cachedInputTokens, cachedInputTokens(usage)),
+    contextInputTokens: latestNonZero(current.contextInputTokens, contextInputTokens),
+  };
+}
+
+export function addIndependentUsageToTurn(current: TokenUsageSummary, usage: ResponseUsage): TokenUsageSummary {
+  const input = contextInputTokensForDisplay(usage);
+  return {
+    inputTokens: current.inputTokens + input,
+    outputTokens: current.outputTokens + finiteOrZero(usage.outputTokens),
+    cachedInputTokens: current.cachedInputTokens + cachedInputTokens(usage),
+    contextInputTokens: latestNonZero(current.contextInputTokens, input),
+  };
+}
+
+export function combineIndependentUsage(usages: Array<ResponseUsage | undefined>): ResponseUsage | undefined {
+  const present = usages.filter((usage): usage is ResponseUsage => Boolean(usage));
+  if (present.length === 0) return undefined;
+  const sum = (read: (usage: ResponseUsage) => number | undefined) => present.reduce((total, usage) => total + finiteOrZero(read(usage)), 0);
+  const inputTokens = sum((usage) => usage.inputTokens ?? usage.contextInputTokens);
+  const outputTokens = sum((usage) => usage.outputTokens);
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    cacheReadInputTokens: sum((usage) => usage.cacheReadInputTokens),
+    cacheWriteInputTokens: sum((usage) => usage.cacheWriteInputTokens),
+    cacheHitInputTokens: sum((usage) => usage.cacheHitInputTokens),
+    cacheMissInputTokens: sum((usage) => usage.cacheMissInputTokens),
+    reasoningTokens: sum((usage) => usage.reasoningTokens),
+    effectiveTokens: sum((usage) => usage.effectiveTokens),
+  };
+}
+
+export function mergeLogicalTurnUsage(parent: TokenUsageSummary, agents: TokenUsageSummary): TokenUsageSummary {
+  return {
+    inputTokens: parent.inputTokens + agents.inputTokens,
+    outputTokens: parent.outputTokens + agents.outputTokens,
+    cachedInputTokens: parent.cachedInputTokens + agents.cachedInputTokens,
+    contextInputTokens: parent.contextInputTokens || agents.contextInputTokens,
+  };
+}
+
+export function addTurnUsageToSession(current: TokenUsageSummary, turn: TokenUsageSummary): TokenUsageSummary {
+  return {
+    inputTokens: current.inputTokens + turn.inputTokens,
+    outputTokens: current.outputTokens + turn.outputTokens,
+    cachedInputTokens: current.cachedInputTokens + turn.cachedInputTokens,
+    contextInputTokens: latestNonZero(current.contextInputTokens, turn.contextInputTokens),
+  };
+}
+
+export function sumSessionUsage(messages: ResumedMessage[]): TokenUsageSummary {
+  let session = emptyUsageSummary();
+  let turn = emptyUsageSummary();
+  let agents = emptyUsageSummary();
+  for (const message of messages) {
+    if (message.role === "user" && isAuthoredUserMessage(message)) {
+      const combined = mergeLogicalTurnUsage(turn, agents);
+      if (hasUsageSummary(combined)) session = addTurnUsageToSession(session, combined);
+      turn = emptyUsageSummary();
+      agents = emptyUsageSummary();
+      continue;
+    }
+    if (!message.usage) continue;
+    if (message.kind === "subagent-result" || message.kind === "subagent-results") {
+      agents = addIndependentUsageToTurn(agents, message.usage);
+    } else {
+      turn = addResponseUsageToTurn(turn, message.usage);
+    }
+  }
+  const combined = mergeLogicalTurnUsage(turn, agents);
+  if (hasUsageSummary(combined)) session = addTurnUsageToSession(session, combined);
+  return session;
+}
+
+export function latestTurnUsage(messages: ResumedMessage[]): TokenUsageSummary | undefined {
+  let lastUserIndex = -1;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].role === "user" && isAuthoredUserMessage(messages[index])) {
+      lastUserIndex = index;
+      break;
+    }
+  }
+  if (lastUserIndex < 0) return undefined;
+  let summary = emptyUsageSummary();
+  let agents = emptyUsageSummary();
+  for (const message of messages.slice(lastUserIndex + 1)) {
+    if (!message.usage) continue;
+    if (message.kind === "subagent-result" || message.kind === "subagent-results") {
+      agents = addIndependentUsageToTurn(agents, message.usage);
+    } else {
+      summary = addResponseUsageToTurn(summary, message.usage);
+    }
+  }
+  const combined = mergeLogicalTurnUsage(summary, agents);
+  return hasUsageSummary(combined) ? combined : undefined;
+}
+
+export function hasUsageSummary(usage: TokenUsageSummary): boolean {
+  return usage.inputTokens > 0 || usage.outputTokens > 0 || usage.cachedInputTokens > 0 || usage.contextInputTokens > 0;
+}
+
+function footerWithRightTelemetry(left: string, right: string | undefined, width: number): string {
+  if (!right) return truncateLine(left, width);
+  const gap = 4;
+  if (right.length + gap >= width) return truncateLine(right, width);
+  const leftWidth = width - right.length - gap;
+  const leftText = truncateLine(left, leftWidth);
+  const padding = Math.max(gap, width - leftText.length - right.length);
+  return `${leftText}${" ".repeat(padding)}${right}`;
+}
+
+function tokenArrowPair(usage: TokenUsageSummary): string {
+  return `↑${formatTokenCount(usage.inputTokens) ?? "0"} ↓${formatTokenCount(usage.outputTokens) ?? "0"}`;
+}
+
+function formatTokenCount(value: number | undefined): string | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (Math.abs(value) >= 1000) return `${(value / 1000).toFixed(1)}k`;
+  return String(value);
+}
+
+function formatContextPercent(used: number, total: number): string {
+  const percent = (used / total) * 100;
+  return percent < 1 && percent > 0 ? "<1%" : `${Math.round(percent)}%`;
+}
+
+function isAuthoredUserMessage(message: ResumedMessage): boolean {
+  return message.kind !== "gate-resolution"
+    && message.kind !== "user-question-answer"
+    && message.kind !== "compact-summary"
+    && message.kind !== "subagent-results"
+    && message.kind !== "background-process-results"
+    && message.kind !== ENGINE_HANDOFF_KIND;
+}
+
+function cachedInputTokens(usage: ResponseUsage): number {
+  return finiteOrZero(usage.cacheReadInputTokens ?? usage.cacheHitInputTokens);
+}
+
+function contextInputTokensForDisplay(usage: ResponseUsage): number {
+  return finiteOrZero(usage.contextInputTokens ?? usage.inputTokens);
+}
+
+function latestNonZero(current: number, next: number): number {
+  return next > 0 ? next : current;
+}
+
+function finiteOrZero(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/src/tui/turn-controller-options.ts
+++ b/src/tui/turn-controller-options.ts
@@ -1,0 +1,132 @@
+import type { Accessor, Setter } from "solid-js";
+import type { ProviderSelection } from "../config/providers";
+import type { AgentLoopEvent, RunPromptResult } from "../core/agent-loop/run";
+import type { AgentManager } from "../core/agents/manager";
+import type { AgentInboxEntry } from "../core/agents/types";
+import type { EngineId } from "../core/engine/profile";
+import type { PermissionMode, ToolPermissionBroker } from "../core/permissions";
+import type { ConversationRewind } from "../core/rewind/service";
+import type { ReasoningTier, VesicleImageAttachment, VesicleMessage } from "../providers/shared/types";
+import type { ComposerElement, ComposerState } from "./composer";
+import type { PromptHistoryEntry } from "./composer-history";
+import type { GateFocusTarget } from "./GatePrompt";
+import type { PendingEngineSwitchState, PendingGateState, PendingPermissionState, PendingUserQuestionState } from "./decision-interaction";
+import type { ActivityEntry, AgentCardState, Message, SessionPickerState } from "./types";
+
+type GenerationSelection = { reasoningTier: ReasoningTier } | undefined;
+
+export type TurnControllerOptions = {
+  rootDir: string;
+  dangerouslySkipPermissions: boolean;
+  busy: Accessor<boolean>;
+  setBusy: Setter<boolean>;
+  providerConfigReady: Accessor<boolean>;
+  setProviderConfigReady: Setter<boolean>;
+  loadProviderConfig: () => Promise<void>;
+  permissionSettingsReady: Accessor<boolean>;
+  loadPermissionSettings: () => Promise<void>;
+  activeModelCapabilities: Accessor<{ vision?: boolean } | undefined>;
+  activeEngine: Accessor<EngineId>;
+  setActiveEngine: Setter<EngineId>;
+  activeModel: Accessor<string>;
+  activeProviderSelection: () => ProviderSelection;
+  activeGeneration: () => GenerationSelection;
+  permissionMode: Accessor<PermissionMode>;
+  shellExecEnabled: Accessor<boolean>;
+  sessionId: Accessor<string | undefined>;
+  setSessionId: Setter<string | undefined>;
+  sessionPath: Accessor<string>;
+  setSessionPath: Setter<string>;
+  conversation: Accessor<VesicleMessage[]>;
+  setConversation: Setter<VesicleMessage[]>;
+  nextSessionParent: Accessor<{ uuid: string | null } | null>;
+  setNextSessionParent: Setter<{ uuid: string | null } | null>;
+  setOutput: Setter<string>;
+  setStatus: Setter<string>;
+  messages: Accessor<Message[]>;
+  setMessages: Setter<Message[]>;
+  agentCards: Accessor<AgentCardState[]>;
+  setAgentCards: Setter<AgentCardState[]>;
+  setStreamingAssistant: Setter<string>;
+  setStreamingReasoning: Setter<string>;
+  lastDisplayedToolAssistantContent: Accessor<string | null>;
+  setLastDisplayedToolAssistantContent: Setter<string | null>;
+  pendingGate: Accessor<PendingGateState | null>;
+  setPendingGate: Setter<PendingGateState | null>;
+  pendingEngineSwitch: Accessor<PendingEngineSwitchState | null>;
+  setPendingEngineSwitch: Setter<PendingEngineSwitchState | null>;
+  pendingUserQuestion: Accessor<PendingUserQuestionState | null>;
+  setPendingUserQuestion: Setter<PendingUserQuestionState | null>;
+  pendingPermission: Accessor<PendingPermissionState | null>;
+  setPendingPermission: Setter<PendingPermissionState | null>;
+  pendingChildPermission: Accessor<unknown | null>;
+  setQuestionSelected: Setter<number>;
+  questionSelected: Accessor<number>;
+  questionFreeformText: Accessor<string>;
+  clearQuestionFreeform: () => void;
+  setGateFocus: Setter<GateFocusTarget>;
+  setGateFeedbackMode: Setter<GateFocusTarget | null>;
+  clearGateFeedback: () => void;
+  setSessionPicker: Setter<SessionPickerState | null>;
+  pausedAgentDeliveries: Set<string>;
+  agentManager: () => AgentManager;
+  permissionBroker: ToolPermissionBroker;
+  runCancellable: <T>(operation: (signal: AbortSignal) => Promise<T>) => Promise<{ kind: "complete"; value: T } | { kind: "interrupted" }>;
+  handleAgentEvent: (event: AgentLoopEvent) => void;
+  beginUsageTurn: () => void;
+  publishTurnUsage: () => void;
+  recordIndependentAgentUsage: (usage: NonNullable<AgentInboxEntry["usage"]>) => void;
+  recordActivity: (entry: ActivityEntry) => void;
+  refreshArtifacts: () => Promise<unknown>;
+  compactSession: (instructions?: string) => Promise<{ summary: string; messagesSummarized: number }>;
+  executeLocalCommand: (prompt: string) => Promise<void>;
+  recordPromptHistory: (value: string, elements: ComposerElement[], images: VesicleImageAttachment[]) => void;
+  applyComposerState: (state: ComposerState) => void;
+  setInputImages: Setter<VesicleImageAttachment[]>;
+  setHistoryIndex: Setter<number | null>;
+  setPromptHistory: Setter<PromptHistoryEntry[]>;
+  applyConversationRewind: (result: ConversationRewind) => Promise<void>;
+};
+
+export type DecisionContinuationOptions = Pick<TurnControllerOptions,
+  | "activeEngine"
+  | "activeGeneration"
+  | "activeProviderSelection"
+  | "agentCards"
+  | "agentManager"
+  | "beginUsageTurn"
+  | "busy"
+  | "clearGateFeedback"
+  | "clearQuestionFreeform"
+  | "compactSession"
+  | "handleAgentEvent"
+  | "pendingChildPermission"
+  | "pendingEngineSwitch"
+  | "pendingGate"
+  | "pendingPermission"
+  | "pendingUserQuestion"
+  | "permissionBroker"
+  | "questionFreeformText"
+  | "questionSelected"
+  | "recordActivity"
+  | "rootDir"
+  | "runCancellable"
+  | "setActiveEngine"
+  | "setBusy"
+  | "setConversation"
+  | "setGateFeedbackMode"
+  | "setMessages"
+  | "setPendingEngineSwitch"
+  | "setPendingGate"
+  | "setPendingPermission"
+  | "setPendingUserQuestion"
+  | "setQuestionSelected"
+  | "setSessionId"
+  | "setSessionPath"
+  | "setStatus"
+> & {
+  handleResult: (result: RunPromptResult) => void;
+  handleInterruptedTurn: () => void;
+  permissionContext: () => { mode: PermissionMode; dangerouslySkipPermissions?: true; shellExecEnabled: boolean };
+  reportError: (error: unknown) => void;
+};

--- a/src/tui/turn-controller.ts
+++ b/src/tui/turn-controller.ts
@@ -1,0 +1,268 @@
+import type { Accessor, Setter } from "solid-js";
+import type { ProviderSelection } from "../config/providers";
+import {
+  resolveEngineSwitch,
+  resolveGate,
+  resolvePermission,
+  resolveUserQuestion,
+  runPrompt,
+  type EngineSwitchConfirmedResult,
+  type RunPromptResult,
+} from "../core/agent-loop/run";
+import type { AgentManager } from "../core/agents/manager";
+import { AgentDeliveryDeferred } from "../core/agents/scheduler";
+import type { AgentInboxEntry } from "../core/agents/types";
+import type { EngineId } from "../core/engine/profile";
+import type { GateResolution } from "../core/gate/types";
+import type { PermissionMode, PermissionResolution, ToolPermissionBroker } from "../core/permissions";
+import { loadSessionSnapshot } from "../core/session/store";
+import type { UserQuestionAnswer } from "../core/user-question/types";
+import { listRewindPoints, rewindConversation, type ConversationRewind } from "../core/rewind/service";
+import { displayTextFromThinkingBlocks } from "../providers/shared/thinking";
+import type { ReasoningTier, VesicleImageAttachment, VesicleMessage } from "../providers/shared/types";
+import { renderValidationNotice } from "./commands/render";
+import type { ComposerElement, ComposerState } from "./composer";
+import { sameInboxIds } from "./agent-delivery";
+import { setAgentDeliveryState } from "./agent-view";
+import {
+  displayUserQuestionAnswer,
+  type PendingEngineSwitchState,
+  type PendingGateState,
+  type PendingPermissionState,
+  type PendingUserQuestionState,
+} from "./decision-interaction";
+import { displayTranscriptFromSnapshot, vesicleMessagesFromResumed } from "./session-presenter";
+import { combineIndependentUsage } from "./telemetry";
+import type { ActivityEntry, AgentCardState, Message, SessionPickerState } from "./types";
+import { createTurnResultController } from "./turn-result-controller";
+import { createDecisionContinuations } from "./decision-continuations";
+
+export type { TurnControllerOptions } from "./turn-controller-options";
+import type { TurnControllerOptions } from "./turn-controller-options";
+export function createTurnController(options: TurnControllerOptions) {
+  let activeTurnSawResponse = false;
+  const { handleResult } = createTurnResultController(options);
+  const decisionContinuations = createDecisionContinuations({
+    ...options,
+    handleResult,
+    handleInterruptedTurn,
+    permissionContext,
+    reportError,
+  });
+
+  function markTurnSawResponse(): void {
+    activeTurnSawResponse = true;
+  }
+
+  async function submitPrompt(
+    value: string,
+    images: VesicleImageAttachment[] = [],
+    elements: ComposerElement[] = [],
+  ): Promise<void> {
+    const prompt = value.trim();
+    if (!prompt || options.busy()) return;
+    if (prompt.startsWith("/") && images.length === 0) {
+      try {
+        await options.executeLocalCommand(prompt);
+      } catch (error) {
+        reportError(error);
+      }
+      return;
+    }
+    if (!await ensureRuntimeReady()) return;
+    if (images.length > 0 && options.activeModelCapabilities()?.vision !== true) {
+      options.applyComposerState({ value, cursor: value.length, elements: elements.map((element) => ({ ...element })) });
+      options.setInputImages(images.map((image) => ({ ...image })));
+      options.setStatus("current model does not declare vision support; draft restored");
+      return;
+    }
+    await runUserPrompt(prompt, value, images, elements);
+  }
+
+  async function ensureRuntimeReady(): Promise<boolean> {
+    if (!options.providerConfigReady()) {
+      options.setStatus("loading provider config");
+      try {
+        await options.loadProviderConfig();
+      } catch (error) {
+        options.setProviderConfigReady(true);
+        reportError(error);
+        return false;
+      }
+    }
+    if (!options.permissionSettingsReady()) {
+      options.setStatus("loading permission settings");
+      try {
+        await options.loadPermissionSettings();
+      } catch (error) {
+        reportError(error);
+        return false;
+      }
+    }
+    return true;
+  }
+
+  async function runUserPrompt(
+    prompt: string,
+    originalValue: string,
+    images: VesicleImageAttachment[],
+    elements: ComposerElement[],
+  ): Promise<void> {
+    options.recordPromptHistory(originalValue, elements, images);
+    const id = options.sessionId();
+    if (id) options.pausedAgentDeliveries.delete(id);
+    options.setHistoryIndex(null);
+    options.setSessionPicker(null);
+    options.setLastDisplayedToolAssistantContent(null);
+    options.setBusy(true);
+    options.setStatus("sending request");
+    options.recordActivity({ kind: "provider", text: "sending provider request" });
+    const requestMessages: VesicleMessage[] = [...options.conversation(), { role: "user", content: prompt, ...(images.length ? { images } : {}) }];
+    options.setMessages((previous) => [...previous, { role: "user", content: prompt, ...(images.length ? { images } : {}) }]);
+    const branchParent = options.nextSessionParent();
+    options.setNextSessionParent(null);
+    activeTurnSawResponse = false;
+    options.beginUsageTurn();
+    try {
+      const outcome = await options.runCancellable((signal) => runPrompt({
+        input: prompt,
+        engine: options.activeEngine(),
+        sessionId: options.sessionId(),
+        ...(branchParent ? { sessionParentUuid: branchParent.uuid } : {}),
+        messages: requestMessages,
+        ...(images.length ? { images } : {}),
+        providerSelection: options.activeProviderSelection(),
+        generation: options.activeGeneration(),
+        permission: permissionContext(),
+        signal,
+        onEvent: options.handleAgentEvent,
+        agentManager: options.agentManager(),
+        permissionBroker: options.permissionBroker,
+      }));
+      if (outcome.kind === "interrupted") {
+        if (!activeTurnSawResponse) await restoreInterruptedPrompt(originalValue, images, elements);
+        handleInterruptedTurn();
+      } else {
+        handleResult(outcome.value);
+      }
+    } catch (error) {
+      if (!activeTurnSawResponse) await restoreInterruptedPrompt(originalValue, images, elements).catch(() => undefined);
+      reportError(error);
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
+  async function deliverAgentResults(parentSessionId: string, entries: AgentInboxEntry[], packet: string): Promise<void> {
+    if (options.sessionId() !== parentSessionId || options.busy() || hasPendingInteraction()) throw new AgentDeliveryDeferred();
+    options.setBusy(true);
+    try {
+      beginAgentDelivery(entries);
+      const requestMessages: VesicleMessage[] = [...options.conversation(), { role: "user", content: packet }];
+      activeTurnSawResponse = false;
+      options.beginUsageTurn();
+      for (const entry of entries) if (entry.usage) options.recordIndependentAgentUsage(entry.usage);
+      const inboxIds = entries.map((entry) => entry.inboxId).sort();
+      const persistedDelivery = await findPersistedAgentDelivery(parentSessionId, inboxIds);
+      const childUsage = combineIndependentUsage(entries.map((entry) => entry.usage));
+      const outcome = await options.runCancellable((signal) => runPrompt({
+        input: packet,
+        engine: options.activeEngine(),
+        sessionId: parentSessionId,
+        messages: requestMessages,
+        inputMetadata: { kind: "subagent-results", inboxIds, ...(childUsage ? { usage: childUsage } : {}) },
+        ...(persistedDelivery ? { prePersistedInputUuid: persistedDelivery.uuid } : {}),
+        providerSelection: options.activeProviderSelection(),
+        generation: options.activeGeneration(),
+        permission: permissionContext(),
+        signal,
+        onEvent: options.handleAgentEvent,
+        agentManager: options.agentManager(),
+        permissionBroker: options.permissionBroker,
+      }));
+      if (outcome.kind === "interrupted") {
+        handleInterruptedTurn();
+        throw new Error("SubAgent result delivery was interrupted.");
+      }
+      handleResult(outcome.value);
+      options.setAgentCards((cards) => setAgentDeliveryState(cards, entries.map((entry) => entry.runId), "integrated", "result integrated"));
+    } catch (error) {
+      options.setAgentCards((cards) => setAgentDeliveryState(cards, entries.map((entry) => entry.runId), "pending", "integration paused; use /agents retry or send input"));
+      options.pausedAgentDeliveries.add(parentSessionId);
+      throw error;
+    } finally {
+      options.setBusy(false);
+    }
+  }
+
+  function beginAgentDelivery(entries: AgentInboxEntry[]): void {
+    options.setAgentCards((cards) => setAgentDeliveryState(cards, entries.map((entry) => entry.runId), "integrating", "integrating result into parent"));
+    options.setStatus(`integrating ${entries.length} SubAgent result${entries.length === 1 ? "" : "s"}`);
+    options.recordActivity({ kind: "agent", text: `delivering ${entries.length} background result${entries.length === 1 ? "" : "s"}` });
+    options.setMessages((current) => [...current, {
+      role: "system",
+      content: `Background SubAgent${entries.length === 1 ? "" : "s"} completed: ${entries.map((entry) => `${entry.description} (${entry.status})`).join(", ")}.`,
+    }]);
+  }
+
+  async function findPersistedAgentDelivery(parentSessionId: string, inboxIds: string[]) {
+    const snapshot = await loadSessionSnapshot(options.rootDir, parentSessionId, { synthesizeDanglingToolResults: false });
+    return snapshot.records.find((record) => record.role === "user"
+      && record.metadata?.kind === "subagent-results"
+      && sameInboxIds(record.metadata?.inboxIds, inboxIds));
+  }
+
+  function reportError(error: unknown): void {
+    const message = error instanceof Error ? error.message : String(error);
+    options.setStatus("error");
+    options.setOutput(message);
+    options.setStreamingAssistant("");
+    options.setStreamingReasoning("");
+    options.recordActivity({ kind: "system", text: `error: ${message}` });
+    options.setMessages((previous) => [...previous, { role: "assistant", content: `Error: ${message}` }]);
+  }
+
+  function handleInterruptedTurn(): void {
+    options.setStatus("Interrupted");
+    options.setStreamingAssistant("");
+    options.setStreamingReasoning("");
+    options.setLastDisplayedToolAssistantContent(null);
+    options.recordActivity({ kind: "system", text: "request interrupted" });
+  }
+
+  async function restoreInterruptedPrompt(
+    prompt: string,
+    images: VesicleImageAttachment[] = [],
+    elements: ComposerElement[] = [],
+  ): Promise<void> {
+    const id = options.sessionId();
+    if (!id) return;
+    const points = await listRewindPoints(options.rootDir, id);
+    const point = [...points].reverse().find((entry) => entry.content.trim() === prompt.trim());
+    if (!point) return;
+    await options.applyConversationRewind(await rewindConversation(options.rootDir, id, point));
+    options.setPromptHistory((previous) => previous.at(-1)?.value === prompt ? previous.slice(0, -1) : previous);
+    options.applyComposerState({ value: prompt, cursor: prompt.length, elements: elements.map((element) => ({ ...element })) });
+    options.setInputImages(images.map((image) => ({ ...image })));
+  }
+
+  function permissionContext() {
+    return {
+      mode: options.permissionMode(),
+      ...(options.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true as const } : {}),
+      shellExecEnabled: options.shellExecEnabled(),
+    };
+  }
+
+  function hasPendingInteraction(): boolean {
+    return Boolean(options.pendingGate() || options.pendingEngineSwitch() || options.pendingUserQuestion() || options.pendingPermission() || options.pendingChildPermission());
+  }
+
+  return {
+    ...decisionContinuations,
+    deliverAgentResults,
+    markTurnSawResponse,
+    reportError,
+    submitPrompt,
+  };
+}

--- a/src/tui/turn-controller.ts
+++ b/src/tui/turn-controller.ts
@@ -70,6 +70,8 @@ export function createTurnController(options: TurnControllerOptions) {
       return;
     }
     if (!await ensureRuntimeReady()) return;
+    // Keep the turn boundary safe for non-composer callers and capabilities
+    // that become available only after provider configuration loads.
     if (images.length > 0 && options.activeModelCapabilities()?.vision !== true) {
       options.applyComposerState({ value, cursor: value.length, elements: elements.map((element) => ({ ...element })) });
       options.setInputImages(images.map((image) => ({ ...image })));

--- a/src/tui/turn-result-controller.ts
+++ b/src/tui/turn-result-controller.ts
@@ -99,11 +99,11 @@ export function createTurnResultController(options: ResultOptions) {
     options.setOutput(result.assistantContent);
   }
 
-  function appendPendingAssistant(content: string, notice: string, requireContent = false): void {
+  function appendPendingAssistant(content: string, notice: string, showAssistant = true): void {
     const alreadyDisplayed = options.lastDisplayedToolAssistantContent() === content;
     options.setMessages((previous) => [
       ...previous,
-      ...(!alreadyDisplayed && (!requireContent || content) ? [{ role: "assistant" as const, content }] : []),
+      ...(!alreadyDisplayed && showAssistant ? [{ role: "assistant" as const, content }] : []),
       { role: "system", content: notice },
     ]);
   }

--- a/src/tui/turn-result-controller.ts
+++ b/src/tui/turn-result-controller.ts
@@ -1,0 +1,141 @@
+import type { RunPromptResult } from "../core/agent-loop/run";
+import { displayTextFromThinkingBlocks } from "../providers/shared/thinking";
+import { renderValidationNotice } from "./commands/render";
+import type { TurnControllerOptions } from "./turn-controller-options";
+import type { Message } from "./types";
+
+type ResultOptions = Pick<TurnControllerOptions,
+  | "activeEngine"
+  | "activeModel"
+  | "clearGateFeedback"
+  | "clearQuestionFreeform"
+  | "lastDisplayedToolAssistantContent"
+  | "publishTurnUsage"
+  | "refreshArtifacts"
+  | "setConversation"
+  | "setGateFeedbackMode"
+  | "setGateFocus"
+  | "setLastDisplayedToolAssistantContent"
+  | "setMessages"
+  | "setOutput"
+  | "setPendingEngineSwitch"
+  | "setPendingGate"
+  | "setPendingPermission"
+  | "setPendingUserQuestion"
+  | "setQuestionSelected"
+  | "setSessionId"
+  | "setSessionPath"
+  | "setSessionPicker"
+  | "setStatus"
+>;
+
+export function createTurnResultController(options: ResultOptions) {
+  function handleResult(result: RunPromptResult): void {
+    options.publishTurnUsage();
+    switch (result.kind) {
+      case "needs_user":
+        applyPendingGateResult(result);
+        return;
+      case "needs_engine_switch":
+        applyPendingEngineSwitchResult(result);
+        return;
+      case "needs_user_question":
+        applyPendingQuestionResult(result);
+        return;
+      case "needs_permission":
+        applyPendingPermissionResult(result);
+        return;
+      case "complete":
+        applyCompleteResult(result);
+        return;
+    }
+  }
+
+  function applyPendingGateResult(result: Extract<RunPromptResult, { kind: "needs_user" }>): void {
+    applyPendingResultBase(result);
+    options.setPendingGate({ ...result, engine: result.profile.id });
+    options.setGateFocus("confirm");
+    options.setGateFeedbackMode(null);
+    options.clearGateFeedback();
+    appendPendingAssistant(result.assistantContent, `Stop gate pending: ${result.gate.gate}. Use ↑/↓ + Enter, or type into the amend box (Tab).`);
+    options.setStatus(`gate pending: ${result.gate.gate}`);
+  }
+
+  function applyPendingEngineSwitchResult(result: Extract<RunPromptResult, { kind: "needs_engine_switch" }>): void {
+    applyPendingResultBase(result);
+    options.setPendingEngineSwitch(result);
+    options.setGateFocus("confirm");
+    options.setGateFeedbackMode(null);
+    options.clearGateFeedback();
+    appendPendingAssistant(result.assistantContent, `Engine switch requested: ${result.profile.id} -> ${result.request.targetEngine}. Confirm below to switch future turns.`);
+    options.setStatus(`engine switch pending: ${result.request.targetEngine}`);
+  }
+
+  function applyPendingQuestionResult(result: Extract<RunPromptResult, { kind: "needs_user_question" }>): void {
+    applyPendingResultBase(result);
+    options.setPendingUserQuestion({ ...result, engine: result.profile.id });
+    options.setQuestionSelected(0);
+    options.clearQuestionFreeform();
+    appendPendingAssistant(result.assistantContent, `Question pending: ${result.question.header}. Choose an option below to continue.`);
+    options.setStatus(`question pending: ${result.question.header}`);
+  }
+
+  function applyPendingPermissionResult(result: Extract<RunPromptResult, { kind: "needs_permission" }>): void {
+    applyPendingResultBase(result);
+    options.setPendingPermission({ ...result, engine: result.profile.id });
+    appendPendingAssistant(result.assistantContent, `Permission pending: ${result.request.toolName}.`, Boolean(result.assistantContent));
+    options.setStatus(`permission pending: ${result.request.toolName}`);
+  }
+
+  function applyPendingResultBase(result: Exclude<RunPromptResult, { kind: "complete" }>): void {
+    options.setConversation([...result.messages]);
+    options.setSessionId(result.sessionId);
+    options.setSessionPath(result.sessionPath);
+    options.setPendingGate(null);
+    options.setPendingEngineSwitch(null);
+    options.setPendingUserQuestion(null);
+    options.setPendingPermission(null);
+    options.setSessionPicker(null);
+    options.setOutput(result.assistantContent);
+  }
+
+  function appendPendingAssistant(content: string, notice: string, requireContent = false): void {
+    const alreadyDisplayed = options.lastDisplayedToolAssistantContent() === content;
+    options.setMessages((previous) => [
+      ...previous,
+      ...(!alreadyDisplayed && (!requireContent || content) ? [{ role: "assistant" as const, content }] : []),
+      { role: "system", content: notice },
+    ]);
+  }
+
+  function applyCompleteResult(result: Extract<RunPromptResult, { kind: "complete" }>): void {
+    clearPendingInteractions();
+    options.setLastDisplayedToolAssistantContent(null);
+    options.setConversation([...result.messages]);
+    options.setSessionId(result.sessionId);
+    options.setSessionPath(result.sessionPath);
+    options.setOutput(result.response.content);
+    void options.refreshArtifacts();
+    const appended: Message[] = [];
+    const reasoningText = displayTextFromThinkingBlocks(result.response.thinkingBlocks) ?? result.response.reasoningContent;
+    if (!result.response.toolCalls?.length && reasoningText?.trim()) appended.push({ role: "system", content: reasoningText, kind: "reasoning" });
+    if (!result.response.toolCalls?.length && result.response.content.trim()) {
+      appended.push({ role: "assistant", content: result.response.content, engine: options.activeEngine(), model: options.activeModel() });
+    }
+    if (result.validation) appended.push({ role: "system", content: renderValidationNotice(result.validation) });
+    options.setMessages((previous) => [...previous, ...appended]);
+    options.setStatus(result.validation?.ok === false ? "complete with validation findings" : "complete");
+  }
+
+  function clearPendingInteractions(): void {
+    options.setPendingGate(null);
+    options.setPendingEngineSwitch(null);
+    options.setPendingUserQuestion(null);
+    options.setPendingPermission(null);
+    options.clearQuestionFreeform();
+    options.setGateFeedbackMode(null);
+    options.clearGateFeedback();
+  }
+
+  return { handleResult };
+}

--- a/src/tui/views/BottomSurface.tsx
+++ b/src/tui/views/BottomSurface.tsx
@@ -1,0 +1,214 @@
+import { Match, Switch } from "solid-js";
+import type { GateRequest } from "../../core/gate/types";
+import type { PermissionRequest } from "../../core/permissions";
+import type { ResponsiveTuiLayout } from "../layout";
+import type { AgentArgumentDraft, FixedArgumentDraft, ModelArgumentDraft } from "../commands/argument-completion";
+import type { Command } from "../commands/types";
+import { commandArgumentHint } from "../commands/options";
+import type { GateFocusTarget } from "../GatePrompt";
+import { GatePrompt, gateComposerIsActive, gateSummaryLineBudget } from "../GatePrompt";
+import { PermissionPrompt } from "../PermissionPrompt";
+import { PromptComposer } from "../PromptComposer";
+import { QuestionPrompt } from "../QuestionPrompt";
+import { RewindPicker } from "../RewindPicker";
+import { SessionPicker } from "../SessionPicker";
+import { YoloPrompt } from "../YoloPrompt";
+import type { PendingUserQuestionState } from "../decision-interaction";
+import { palette } from "../theme";
+import type { OptionItem, RewindPickerState, SessionPickerState } from "../types";
+import { ArgumentMenu } from "../widgets/ArgumentMenu";
+import { CommandMenu } from "../widgets/CommandMenu";
+import { OptionPicker } from "../widgets/OptionPicker";
+
+export type ModelPickerState = {
+  step: "provider" | "model";
+  providerId: string | null;
+  selected: number;
+};
+
+export type BottomSurfaceMode =
+  | { kind: "yolo"; stage: 1 | 2 }
+  | { kind: "permission"; request: PermissionRequest }
+  | { kind: "question"; pending: PendingUserQuestionState }
+  | { kind: "gate"; gate: GateRequest }
+  | { kind: "rewind"; picker: RewindPickerState }
+  | { kind: "session"; picker: SessionPickerState }
+  | { kind: "model"; picker: ModelPickerState }
+  | { kind: "composer" };
+
+export type BottomSurfaceState = {
+  yoloStage: 1 | 2 | null;
+  permissionRequest?: PermissionRequest;
+  question: PendingUserQuestionState | null;
+  gate: GateRequest | null;
+  rewind: RewindPickerState | null;
+  session: SessionPickerState | null;
+  model: ModelPickerState | null;
+};
+
+export function resolveBottomSurfaceMode(state: BottomSurfaceState): BottomSurfaceMode {
+  if (state.yoloStage) return { kind: "yolo", stage: state.yoloStage };
+  if (state.permissionRequest) return { kind: "permission", request: state.permissionRequest };
+  if (state.question) return { kind: "question", pending: state.question };
+  if (state.gate) return { kind: "gate", gate: state.gate };
+  if (state.rewind) return { kind: "rewind", picker: state.rewind };
+  if (state.session) return { kind: "session", picker: state.session };
+  if (state.model) return { kind: "model", picker: state.model };
+  return { kind: "composer" };
+}
+
+export type BottomSurfaceProps = BottomSurfaceState & {
+  layout: ResponsiveTuiLayout;
+  gateFocus: GateFocusTarget;
+  gateFeedbackMode: GateFocusTarget | null;
+  gateFeedback: string;
+  gateFeedbackCursor: number;
+  engineSwitchPending: boolean;
+  questionSelected: number;
+  questionFreeformText: string;
+  questionFreeformCursor: number;
+  modelItems: OptionItem[];
+  modelTitle: string;
+  commandMenuOpen: boolean;
+  commandItems: Command[];
+  commandSelected: number;
+  commandArgumentMenuOpen: boolean;
+  commandArgumentItems: OptionItem[];
+  commandArgumentSelected: number;
+  modelArgumentDraft: ModelArgumentDraft | null;
+  fixedArgumentDraft: FixedArgumentDraft | null;
+  agentArgumentDraft: AgentArgumentDraft | null;
+  composerPopupMaxRows: number;
+  composerPopupOpen: boolean;
+  inputNeedsExpandedBottom: boolean;
+  inputValue: string;
+  inputCursor: number;
+  inputWidth: number;
+  busy: boolean;
+  providerConfigReady: boolean;
+};
+
+export function BottomSurface(props: BottomSurfaceProps) {
+  const mode = () => resolveBottomSurfaceMode(props);
+  return (
+    <Switch>
+      <Match when={mode().kind === "yolo" && mode() as Extract<BottomSurfaceMode, { kind: "yolo" }> }>
+        {(current) => (
+          <box height={props.layout.bottomHeight}>
+            <YoloPrompt stage={current().stage} focused={props.gateFocus} width={props.layout.width} />
+          </box>
+        )}
+      </Match>
+      <Match when={mode().kind === "permission" && mode() as Extract<BottomSurfaceMode, { kind: "permission" }> }>
+        {(current) => (
+          <box height={props.layout.bottomHeight}>
+            <PermissionPrompt
+              request={current().request}
+              focused={props.gateFocus}
+              feedbackMode={props.gateFeedbackMode}
+              feedback={props.gateFeedback}
+              feedbackCursor={props.gateFeedbackCursor}
+              width={props.layout.width}
+            />
+          </box>
+        )}
+      </Match>
+      <Match when={mode().kind === "question" && mode() as Extract<BottomSurfaceMode, { kind: "question" }> }>
+        {(current) => (
+          <box height={props.layout.bottomHeight}>
+            <QuestionPrompt
+              question={current().pending.question}
+              selected={props.questionSelected}
+              width={props.layout.width}
+              freeformValue={props.questionFreeformText}
+              freeformCursor={props.questionFreeformCursor}
+            />
+          </box>
+        )}
+      </Match>
+      <Match when={mode().kind === "gate" && mode() as Extract<BottomSurfaceMode, { kind: "gate" }> }>
+        {(current) => (
+          <box height={props.layout.bottomHeight}>
+            <GatePrompt
+              gate={current().gate}
+              focused={props.gateFocus}
+              feedbackMode={props.gateFeedbackMode}
+              feedback={props.gateFeedback}
+              feedbackCursor={props.gateFeedbackCursor}
+              width={props.layout.width}
+              maxSummaryLines={gateSummaryLineBudget(
+                props.layout.summaryLines,
+                gateComposerIsActive(props.gateFocus, props.gateFeedbackMode),
+                props.engineSwitchPending ? 1 : 0,
+              )}
+              showSummaryOption={props.engineSwitchPending}
+            />
+          </box>
+        )}
+      </Match>
+      <Match when={mode().kind === "rewind" && mode() as Extract<BottomSurfaceMode, { kind: "rewind" }> }>
+        {(current) => (
+          <box height={props.layout.bottomHeight}>
+            <RewindPicker state={current().picker} width={props.layout.width} />
+          </box>
+        )}
+      </Match>
+      <Match when={mode().kind === "session" && mode() as Extract<BottomSurfaceMode, { kind: "session" }> }>
+        {(current) => (
+          <box height={props.layout.bottomHeight}>
+            <SessionPicker sessions={current().picker.sessions} selected={current().picker.selected} width={props.layout.width} />
+          </box>
+        )}
+      </Match>
+      <Match when={mode().kind === "model" && mode() as Extract<BottomSurfaceMode, { kind: "model" }> }>
+        {(current) => (
+          <box height={props.layout.bottomHeight}>
+            <OptionPicker
+              title={props.modelTitle}
+              items={props.modelItems}
+              selected={current().picker.selected}
+              width={props.layout.width}
+              hint="↑/↓ choose · Enter select · Esc back"
+              maxVisible={Math.max(1, props.layout.bottomHeight - 3)}
+            />
+          </box>
+        )}
+      </Match>
+      <Match when={mode().kind === "composer"}>
+        <box height={props.inputNeedsExpandedBottom ? props.layout.bottomHeight : 3} border borderColor={palette.panelBorder} paddingX={1} flexDirection="column">
+          <Switch fallback={<box height={0} />}>
+            <Match when={props.commandMenuOpen}>
+              <box flexDirection="column">
+                <CommandMenu
+                  commands={props.commandItems}
+                  selected={props.commandSelected}
+                  width={props.layout.width - 4}
+                  maxVisible={props.composerPopupMaxRows}
+                />
+                <text content="↑/↓ choose · Tab/Enter complete · Esc cancel" fg={palette.textDim} />
+              </box>
+            </Match>
+            <Match when={props.commandArgumentMenuOpen}>
+              <box flexDirection="column">
+                <ArgumentMenu
+                  items={props.commandArgumentItems}
+                  selected={props.commandArgumentSelected}
+                  width={props.layout.width - 4}
+                  maxVisible={props.composerPopupMaxRows}
+                />
+                <text content={commandArgumentHint(props.modelArgumentDraft, props.fixedArgumentDraft, props.agentArgumentDraft)} fg={palette.textDim} />
+              </box>
+            </Match>
+          </Switch>
+          <PromptComposer
+            value={props.inputValue}
+            cursor={props.inputCursor}
+            placeholder={props.busy ? "Request in flight..." : !props.providerConfigReady ? "Loading provider config..." : "Type prompt, Enter send, Ctrl+Enter newline, /help commands"}
+            width={props.inputWidth}
+            maxLines={Math.max(1, props.layout.bottomHeight - (props.composerPopupOpen ? props.composerPopupMaxRows + 3 : 2))}
+          />
+        </box>
+      </Match>
+    </Switch>
+  );
+}

--- a/tests/anthropic-provider.test.ts
+++ b/tests/anthropic-provider.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { AnthropicMessagesAdapter, toAnthropicMessagesBody } from "../src/providers/anthropic-messages/adapter";
+import { AnthropicMessagesAdapter } from "../src/providers/anthropic-messages/adapter";
+import { toAnthropicMessagesBody } from "../src/providers/anthropic-messages/request";
 import type { VesicleRequest } from "../src/providers/shared/types";
 
 const originalFetch = globalThis.fetch;
@@ -306,6 +307,45 @@ describe("Anthropic Messages adapter", () => {
       name: "ProviderError",
       kind: "stream_error",
       providerId: "anthropic",
+    });
+  });
+
+  test("reconstructs indexed thinking and tool blocks in block order", async () => {
+    globalThis.fetch = (async () => new Response(rawSse([
+      'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_indexed","model":"claude-test"}}',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":3,"content_block":{"type":"tool_use","id":"toolu_second","name":"second_tool","input":{}}}',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":3,"delta":{"type":"input_json_delta","partial_json":"{\\"order\\":2}"}}',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":4,"content_block":{"type":"redacted_thinking","data":"opaque"}}',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"first","signature":"sig"}}',
+      'event: content_block_start\ndata: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_first","name":"first_tool","input":{}}}',
+      'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\\"order\\":1}"}}',
+      'event: message_stop\ndata: {"type":"message_stop"}',
+    ]))) as unknown as typeof fetch;
+
+    const adapter = new AnthropicMessagesAdapter({
+      provider: "anthropic-messages",
+      providerId: "anthropic",
+      baseUrl: "https://api.anthropic.com/v1",
+      model: "claude-test",
+      apiKey: "test-key",
+    });
+
+    const events = await collect(adapter.stream!(request()));
+
+    expect(events).toContainEqual({ type: "tool_call_delta", index: 3, id: "toolu_second", name: "second_tool" });
+    expect(events).toContainEqual({ type: "tool_call_delta", index: 2, id: "toolu_first", name: "first_tool" });
+    expect(events.at(-1)).toMatchObject({
+      type: "complete",
+      response: {
+        thinkingBlocks: [
+          { type: "thinking", thinking: "first", signature: "sig" },
+          { type: "redacted_thinking", data: "opaque" },
+        ],
+        toolCalls: [
+          { id: "toolu_first", name: "first_tool", arguments: "{\"order\":1}" },
+          { id: "toolu_second", name: "second_tool", arguments: "{\"order\":2}" },
+        ],
+      },
     });
   });
 

--- a/tests/tui-reactivity.test.ts
+++ b/tests/tui-reactivity.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
+import { resolveBottomSurfaceMode } from "../src/tui/views/BottomSurface";
 
 /**
  * Static regression guard for the gate-box rendering bug.
@@ -19,19 +20,28 @@ import { describe, expect, test } from "bun:test";
  * directly in JSX, preventing the snapshot pattern from sneaking back in.
  */
 describe("TUI reactivity static guard", () => {
-  test("Show reads activeGateRequest() directly in JSX (not via a frozen local)", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
+  test("bottom surface receives the reactive active gate accessor directly", async () => {
+    const appSource = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
+    const surfaceSource = await readFile(join(import.meta.dir, "..", "src", "tui", "views", "BottomSurface.tsx"), "utf8");
 
     // The fix reads a reactive memo directly in the JSX when= prop so Solid
     // tracks the dependency and re-renders the Show branch when a gate or
     // engine switch request is set. Assert the positive pattern is present.
-    expect(source).toMatch(/when=\{activeGateRequest\(\)\}/);
+    expect(appSource).toContain("gate={activeGateRequest()}");
+    expect(surfaceSource).toContain("resolveBottomSurfaceMode(props)");
 
     // And the buggy pattern — Show reading a bare `gate` local captured at
     // render-body scope — must be absent. The status header used to read
     // `gate ?` off the same snapshot; assert both now reference the signal.
-    expect(source).not.toMatch(/when=\{gate\}/);
-    expect(source).not.toMatch(/pendingGate\(\) \? palette\.gateAccent : gate \?/);
+    expect(appSource).not.toMatch(/when=\{gate\}/);
+    expect(appSource).not.toMatch(/pendingGate\(\) \? palette\.gateAccent : gate \?/);
+  });
+
+  test("bottom surface priority is explicit and modal-first", () => {
+    const empty = { yoloStage: null, permissionRequest: undefined, question: null, gate: null, rewind: null, session: null, model: null };
+    expect(resolveBottomSurfaceMode(empty).kind).toBe("composer");
+    expect(resolveBottomSurfaceMode({ ...empty, gate: { gate: "phase", summary: "summary", options: [] }, rewind: { points: [], selected: 0, restoreSelected: 0, summaryFeedback: "", summaryCursor: 0, busy: false } }).kind).toBe("gate");
+    expect(resolveBottomSurfaceMode({ ...empty, yoloStage: 1, gate: { gate: "phase", summary: "summary", options: [] } }).kind).toBe("yolo");
   });
 
   test("main layout does not depend on every prompt character", async () => {
@@ -57,68 +67,70 @@ describe("TUI reactivity static guard", () => {
   });
 
   test("slash-command query changes reset the selected row", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
+    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "command-completion-controller.ts"), "utf8");
 
     expect(source).toContain("const query = commandMenuOpen() ? commandMenuQuery() : null");
     expect(source).toContain("if (query !== previousCommandMenuQuery) setCommandMenuSelected(0)");
   });
 
   test("Ctrl+Q exits before modal keyboard routing", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
+    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "input-routing.ts"), "utf8");
     const ctrlQ = source.indexOf('if (key.ctrl && key.name === "q")');
-    const modelPickerRouting = source.indexOf("if (modelPicker())");
+    const modelPickerRouting = source.indexOf("if (options.modelPicker())");
 
     expect(ctrlQ).toBeGreaterThan(-1);
     expect(modelPickerRouting).toBeGreaterThan(ctrlQ);
   });
 
   test("image paste is owned by the main composer after modal routing", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
-    const gateRouting = source.indexOf("if (pendingGate() || pendingEngineSwitch())");
+    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "input-routing.ts"), "utf8");
+    const gateRouting = source.indexOf("if (options.pendingGate() || options.pendingEngineSwitch()");
     const imagePaste = source.indexOf('key.name?.toLowerCase() === "v" && (key.meta || key.option)');
-    const composerRouting = source.indexOf("if (handleComposerKey(key))");
+    const composerRouting = source.indexOf("if (options.handleComposerKey(key))");
 
     expect(imagePaste).toBeGreaterThan(gateRouting);
     expect(composerRouting).toBeGreaterThan(imagePaste);
   });
 
   test("gate Reject composer owns both keyboard and paste routing", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
-    const activeChecks = source.match(/gateComposerIsActive\(gateFocus\(\), gateFeedbackMode\(\)\)/g) ?? [];
+    const controller = await readFile(join(import.meta.dir, "..", "src", "tui", "decision-controller.ts"), "utf8");
+    const surface = await readFile(join(import.meta.dir, "..", "src", "tui", "views", "BottomSurface.tsx"), "utf8");
+    const activeChecks = `${controller}\n${surface}`.match(/gateComposerIsActive\((?:gateFocus\(\), gateFeedbackMode\(\)|props\.gateFocus, props\.gateFeedbackMode)\)/g) ?? [];
 
     // Keyboard, paste, and gate summary-height budgeting share the predicate.
     expect(activeChecks).toHaveLength(3);
   });
 
   test("question freeform composer owns both keyboard and paste routing", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
+    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "decision-controller.ts"), "utf8");
     const activeChecks = source.match(/questionComposerIsActive\(/g) ?? [];
 
     expect(activeChecks).toHaveLength(2);
   });
 
   test("SubAgent lifecycle events do not overwrite the parent STATUS line", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
-    const handler = source.match(/function handleAgentEvent\(event: AgentLoopEvent\) \{[\s\S]*?\n  \}\n\n  function recordActivity/)?.[0] ?? "";
+    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "agent-process-controller.ts"), "utf8");
+    const handler = source.match(/function handleAgentLifecycle\(event: AgentLoopEvent\): boolean \{[\s\S]*?\n  \}/)?.[0] ?? "";
     const lifecycleCases = handler.match(/case "agent_created":[\s\S]*?case "agent_completed":/)?.[0] ?? "";
 
     expect(lifecycleCases).not.toContain("setStatus(");
-    expect(handler).toContain("setAgentCards((cards) => applyAgentEvent(cards, event))");
+    expect(source).toContain("setAgentCards((cards) => applyAgentEvent(cards, event))");
     expect(handler).toContain("recordActivity({ kind: \"agent\"");
   });
 
   test("session restoration blocks background delivery until restored state is coherent", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
+    const appSource = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
+    const resumeSource = await readFile(join(import.meta.dir, "..", "src", "tui", "session-resume-controller.ts"), "utf8");
 
-    expect(source).toContain("&& !restoringSession()");
-    expect(source).toContain("const ready = !restoringSession()");
-    expect(source).toMatch(/async function resumeSession[\s\S]*?setRestoringSession\(true\);[\s\S]*?finally \{\n\s+setRestoringSession\(false\);/);
+    expect(appSource).toContain("&& !restoringSession()");
+    expect(appSource).toContain("const ready = !restoringSession()");
+    expect(resumeSource).toMatch(/async function resumeSession[\s\S]*?options\.setRestoringSession\(true\);[\s\S]*?finally \{\n\s+options\.setRestoringSession\(false\);/);
   });
 
   test("background continuation scheduler is initialized before AgentManager callbacks can use it", async () => {
     const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
     const scheduler = source.indexOf("const continuationScheduler = new AgentContinuationScheduler");
-    const manager = source.indexOf("const agentManager = new AgentManager");
+    const manager = source.indexOf("agentManager = new AgentManager");
 
     expect(scheduler).toBeGreaterThan(-1);
     expect(manager).toBeGreaterThan(scheduler);
@@ -126,16 +138,17 @@ describe("TUI reactivity static guard", () => {
   });
 
   test("permission submission resolves the same parent-first request that the panel displays", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
-    expect(source).toContain("pendingPermission()?.request ?? pendingChildPermission()");
-    expect(source.match(/if \(pendingPermission\(\)\) \{[\s\S]*?submitPermissionResolution/g)).toHaveLength(2);
+    const decisionSource = await readFile(join(import.meta.dir, "..", "src", "tui", "decision-controller.ts"), "utf8");
+    expect(decisionSource).toContain("pendingPermission()?.request ?? pendingChildPermission()");
+    expect(decisionSource).toContain("if (pendingPermission()) options.submitPermission");
+    expect(decisionSource).toContain("else if (pendingChildPermission()) options.submitChildPermission");
   });
 
   test("permission errors consult durable session state before restoring the modal", async () => {
-    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "app.tsx"), "utf8");
-    const handler = source.match(/const submitPermissionResolution[\s\S]*?function submitChildPermissionResolution/)?.[0] ?? "";
+    const source = await readFile(join(import.meta.dir, "..", "src", "tui", "decision-continuations.ts"), "utf8");
+    const handler = source.match(/async function submitPermissionResolution[\s\S]*?function submitChildPermissionResolution/)?.[0] ?? "";
     expect(handler.match(/reconcilePermissionAfterContinuationFailure\(pending\)/g)).toHaveLength(2);
-    expect(handler).toContain("loadSessionSnapshot(process.cwd(), pending.sessionId");
+    expect(handler).toContain("loadSessionSnapshot(options.rootDir, pending.sessionId");
     expect(handler).toContain("snapshot.pendingPermission?.id === pending.request.id");
     expect(handler).toContain("setPendingPermission(null)");
   });

--- a/tests/tui-reactivity.test.ts
+++ b/tests/tui-reactivity.test.ts
@@ -1,7 +1,8 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
-import { resolveBottomSurfaceMode } from "../src/tui/views/BottomSurface";
+import type { PermissionRequest } from "../src/core/permissions";
+import { resolveBottomSurfaceMode, type BottomSurfaceState } from "../src/tui/views/BottomSurface";
 
 /**
  * Static regression guard for the gate-box rendering bug.
@@ -38,9 +39,12 @@ describe("TUI reactivity static guard", () => {
   });
 
   test("bottom surface priority is explicit and modal-first", () => {
-    const empty = { yoloStage: null, permissionRequest: undefined, question: null, gate: null, rewind: null, session: null, model: null };
+    const empty: BottomSurfaceState = { yoloStage: null, permissionRequest: undefined, question: null, gate: null, rewind: null, session: null, model: null };
+    const rewind = { points: [], selected: 0, restoreSelected: 0, summaryFeedback: "", summaryCursor: 0, busy: false };
+    const permission = { toolName: "read_file" } as PermissionRequest;
     expect(resolveBottomSurfaceMode(empty).kind).toBe("composer");
-    expect(resolveBottomSurfaceMode({ ...empty, gate: { gate: "phase", summary: "summary", options: [] }, rewind: { points: [], selected: 0, restoreSelected: 0, summaryFeedback: "", summaryCursor: 0, busy: false } }).kind).toBe("gate");
+    expect(resolveBottomSurfaceMode({ ...empty, gate: { gate: "phase", summary: "summary", options: [] }, rewind }).kind).toBe("gate");
+    expect(resolveBottomSurfaceMode({ ...empty, permissionRequest: permission, rewind }).kind).toBe("permission");
     expect(resolveBottomSurfaceMode({ ...empty, yoloStage: 1, gate: { gate: "phase", summary: "summary", options: [] } }).kind).toBe("yolo");
   });
 
@@ -76,19 +80,21 @@ describe("TUI reactivity static guard", () => {
   test("Ctrl+Q exits before modal keyboard routing", async () => {
     const source = await readFile(join(import.meta.dir, "..", "src", "tui", "input-routing.ts"), "utf8");
     const ctrlQ = source.indexOf('if (key.ctrl && key.name === "q")');
-    const modelPickerRouting = source.indexOf("if (options.modelPicker())");
+    const modalRouting = source.indexOf("const mode = bottomSurfaceMode()");
 
     expect(ctrlQ).toBeGreaterThan(-1);
-    expect(modelPickerRouting).toBeGreaterThan(ctrlQ);
+    expect(modalRouting).toBeGreaterThan(ctrlQ);
   });
 
-  test("image paste is owned by the main composer after modal routing", async () => {
+  test("input routing shares bottom-surface priority and blocks hidden-composer paste", async () => {
     const source = await readFile(join(import.meta.dir, "..", "src", "tui", "input-routing.ts"), "utf8");
-    const gateRouting = source.indexOf("if (options.pendingGate() || options.pendingEngineSwitch()");
+    const modeResolution = source.indexOf("resolveBottomSurfaceMode({");
     const imagePaste = source.indexOf('key.name?.toLowerCase() === "v" && (key.meta || key.option)');
     const composerRouting = source.indexOf("if (options.handleComposerKey(key))");
 
-    expect(imagePaste).toBeGreaterThan(gateRouting);
+    expect(modeResolution).toBeGreaterThan(-1);
+    expect(source).toContain('if (bottomSurfaceMode().kind !== "composer")');
+    expect(imagePaste).toBeGreaterThan(modeResolution);
     expect(composerRouting).toBeGreaterThan(imagePaste);
   });
 

--- a/tests/tui-turn-result-controller.test.ts
+++ b/tests/tui-turn-result-controller.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test";
+import type { RunPromptResult } from "../src/core/agent-loop/run";
+import type { EngineProfile } from "../src/core/engine/profile";
+import type { PermissionRequest } from "../src/core/permissions";
+import { createTurnResultController } from "../src/tui/turn-result-controller";
+import type { Message } from "../src/tui/types";
+
+describe("TUI turn result controller", () => {
+  test("does not render an empty assistant message for a pending permission", () => {
+    const harness = createHarness();
+
+    harness.handle(permissionResult(""));
+
+    expect(harness.messages()).toEqual([
+      { role: "system", content: "Permission pending: read_file." },
+    ]);
+  });
+
+  test("renders non-empty pending permission content before the host notice", () => {
+    const harness = createHarness();
+
+    harness.handle(permissionResult("I need permission to inspect the file."));
+
+    expect(harness.messages()).toEqual([
+      { role: "assistant", content: "I need permission to inspect the file." },
+      { role: "system", content: "Permission pending: read_file." },
+    ]);
+  });
+
+  test("does not render pending assistant content already shown by a tool response", () => {
+    const content = "I need permission to inspect the file.";
+    const harness = createHarness(content);
+
+    harness.handle(permissionResult(content));
+
+    expect(harness.messages()).toEqual([
+      { role: "system", content: "Permission pending: read_file." },
+    ]);
+  });
+});
+
+function createHarness(lastDisplayedContent: string | null = null) {
+  let messages: Message[] = [];
+  const noop = () => undefined;
+  const controller = createTurnResultController({
+    activeEngine: () => "etl",
+    activeModel: () => "test-model",
+    clearGateFeedback: noop,
+    clearQuestionFreeform: noop,
+    lastDisplayedToolAssistantContent: () => lastDisplayedContent,
+    publishTurnUsage: noop,
+    refreshArtifacts: async () => [],
+    setConversation: noop,
+    setGateFeedbackMode: noop,
+    setGateFocus: noop,
+    setLastDisplayedToolAssistantContent: noop,
+    setMessages: (next) => {
+      messages = typeof next === "function" ? next(messages) : next;
+      return messages;
+    },
+    setOutput: noop,
+    setPendingEngineSwitch: noop,
+    setPendingGate: noop,
+    setPendingPermission: noop,
+    setPendingUserQuestion: noop,
+    setQuestionSelected: noop,
+    setSessionId: noop,
+    setSessionPath: noop,
+    setSessionPicker: noop,
+    setStatus: noop,
+  });
+  return {
+    handle: controller.handleResult,
+    messages: () => messages,
+  };
+}
+
+function permissionResult(assistantContent: string): RunPromptResult {
+  const profile: EngineProfile = {
+    id: "etl",
+    displayName: "ETL",
+    protocolVersion: "test",
+    systemPrompt: ["assets/prompts/base.md"],
+    defaultTools: [],
+    validators: [],
+    stopGates: [],
+    stateRoots: [],
+    asset: { path: "assets/engines/etl.profile.yaml", source: "project" },
+  };
+  const request: PermissionRequest = {
+    id: "permission-test",
+    sessionId: "session-test",
+    toolCallId: "call-test",
+    toolName: "read_file",
+    arguments: "{}",
+    permissionClass: "observe",
+    mode: "MANUAL",
+    createdAt: "2026-07-13T00:00:00.000Z",
+  };
+  return {
+    kind: "needs_permission",
+    sessionId: "session-test",
+    sessionPath: ".vesicle/sessions/session-test.jsonl",
+    profile,
+    request,
+    remainingToolCalls: [],
+    messages: [],
+    assistantContent,
+  };
+}


### PR DESCRIPTION
## Summary

- split the Anthropic Messages adapter into focused request, response, streaming, type, and usage modules
- reduce the TUI application composition root by extracting controllers, presenters, routing, telemetry, and the bottom-surface view
- preserve pending-permission transcript behavior and make rendered bottom-surface priority authoritative for keyboard and paste routing
- add direct turn-result controller coverage for empty, non-empty, and already-rendered permission content

## Verification

- `bun run typecheck`
- `bun test` (460 passed, 0 failed)
- `bun run doctor` (`Missing: none`)
- `git diff --check`
- 80x24 TUI startup, provider-config load, and Ctrl+Q exit smoke

## Review Follow-up

- fixed the confirmed empty assistant bubble regression in pending permission results
- retained the turn-controller vision check as a boundary guard for non-composer callers and post-load capabilities
- unified bottom-surface rendering and input ownership without expanding the controller initialization refactor
