### PR TITLE
test(stage): cover frozen session lifecycle

### DIFF
--- a/tests/stage.test.ts
+++ b/tests/stage.test.ts
@@ -6,6 +6,7 @@ import { loadConfigForSelection } from "../src/config/providers";
 import { resolveToolSurface } from "../src/core/agent-loop/tool-surface";
 import { loadEngineProfile } from "../src/core/engine/profile";
 import { runPrompt } from "../src/core/agent-loop/run";
+import { listRewindPoints, rewindConversation } from "../src/core/rewind/service";
 import { stageSourceDrift, startStageSession } from "../src/core/stage/bootstrap";
 import { loadSessionSnapshot } from "../src/core/session/store";
 import { createProvider } from "../src/providers";
@@ -170,6 +171,47 @@ describe("Stage bootstrap", () => {
     try {
       await expect(runPrompt({ input: "start", engine: "stage", rootDir: root }))
         .rejects.toThrow("Stage sessions must start with /stage");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("resumes frozen context after source drift and retains bootstrap metadata across rewind", async () => {
+    const root = await stageRoot();
+    try {
+      const started = await startStageSession({
+        rootDir: root,
+        characterPath: "workspace/character.md",
+        scenarioPath: "workspace/scenario.md",
+        provider: "test",
+        providerId: "test",
+        model: "test-model",
+        permissionMode: "MOMENTUM",
+      });
+      await writeFile(join(root, "workspace", "character.md"), `${characterCard}\nChanged after bootstrap.\n`, "utf8");
+      const beforeResume = await loadSessionSnapshot(root, started.sessionId);
+      expect(await stageSourceDrift(root, beforeResume.stageBootstrap!)).toEqual(["workspace/character.md"]);
+
+      const requests: Array<{ messages: Array<{ role: string; content: string }> }> = [];
+      globalThis.fetch = (async (_input: unknown, init: RequestInit & { body?: unknown }) => {
+        requests.push(JSON.parse(String(init.body)));
+        return Response.json({ id: "stage-resume", choices: [{ message: { content: stagePacket } }] });
+      }) as unknown as typeof fetch;
+
+      await expect(runPrompt({
+        input: "I wait for the train.",
+        engine: "stage",
+        rootDir: root,
+        sessionId: started.sessionId,
+        messages: [...beforeResume.messages, { role: "user", content: "I wait for the train." }],
+      })).resolves.toMatchObject({ kind: "complete" });
+
+      expect(requests[0]?.messages[0]?.content).toContain("Rain-dark hair and a worn coat.");
+      expect(requests[0]?.messages[0]?.content).not.toContain("Changed after bootstrap.");
+      const point = (await listRewindPoints(root, started.sessionId))[0]!;
+      const rewound = await rewindConversation(root, started.sessionId, point);
+      expect(rewound.snapshot.stageBootstrap).toEqual(beforeResume.stageBootstrap);
+      expect(rewound.snapshot.messages).toEqual([{ role: "assistant", content: started.opening, engine: "stage", kind: "stage-bootstrap-opening" }]);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/tui-engine-command.test.ts
+++ b/tests/tui-engine-command.test.ts
@@ -47,6 +47,26 @@ describe("/engine command", () => {
     expect(messages.at(-1)?.content).toContain("Start another Stage narrative with /stage");
   });
 
+  test("/engine stage preserves the current engine and directs the user to /stage", async () => {
+    const command = builtinCommands.find((entry) => entry.name === "engine");
+    if (!command) throw new Error("Missing /engine command.");
+    let activeEngine = "runtime";
+    let switched = false;
+    let messages: Message[] = [];
+    const ctx = {
+      activeEngine: () => activeEngine,
+      setActiveEngine(engine: typeof activeEngine) { activeEngine = engine; },
+      async persistEngineSwitch() { switched = true; },
+      setMessages(updater: (previous: Message[]) => Message[]) { messages = updater(messages); },
+    } as unknown as CommandContext;
+
+    await command.run(ctx, "stage", "/engine stage");
+
+    expect(activeEngine).toBe("runtime");
+    expect(switched).toBe(false);
+    expect(messages.at(-1)?.content).toContain("Stage requires /stage");
+  });
+
   test("persists manual switches as direct engine transitions", async () => {
     const command = builtinCommands.find((entry) => entry.name === "engine");
     if (!command) throw new Error("Missing /engine command.");


### PR DESCRIPTION
Adds the remaining Stage-specific regression evidence required by the delivery specification.

- continues a Stage session after card source drift and proves the provider receives frozen bootstrap context
- rewinds that session and proves the Stage opening and bootstrap metadata remain intact
- verifies slash-engine Stage preserves the current engine and directs users to slash-stage

Verified locally: bun test (678 passed), bun run typecheck, bun run doctor, and git diff --check.