### PR TITLE
chore(deps): patch brace expansion audit finding

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
   },
   "overrides": {
     "@babel/core": "7.29.7",
+    "brace-expansion": "2.1.2",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.29.7.tgz", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -148,7 +149,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.42", "https://registry.npmmirror.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q=="],
 
-    "brace-expansion": ["brace-expansion@2.1.1", "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-2.1.1.tgz", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA=="],
+    "brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
 
     "browserslist": ["browserslist@4.28.5", "https://registry.npmmirror.com/browserslist/-/browserslist-4.28.5.tgz", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001800", "electron-to-chromium": "^1.5.387", "node-releases": "^2.0.50", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "access": "public"
   },
   "overrides": {
-    "@babel/core": "7.29.7"
+    "@babel/core": "7.29.7",
+    "brace-expansion": "2.1.2"
   },
   "files": [
     "assets/",


### PR DESCRIPTION
## Summary

- pin the transitive `brace-expansion` dependency to patched version `2.1.2`
- restore the repository-wide `bun audit` gate after GHSA-3jxr-9vmj-r5cp began flagging the unchanged `develop` lockfile
- keep the security maintenance separate from docs PR #47

## Verification

- `bun audit`
- `bun run lint`
- `bun run typecheck`
- `bun test` (711 pass, 0 fail)
- `bun run doctor`
- `bun run pack:check`
- `git diff --check`

No tests were added; this is an exact compatible transitive override.