### PR TITLE
Drop hardcoded release version gate; source MCP version from package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
         run: |
           VERSION="$(jq -r '.version' package.json)"
           [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]
-          test "$VERSION" = "1.0.0-alpha.2"
           test "$TAG" = "v$VERSION"
           test "$(git cat-file -t "refs/tags/$TAG")" = "tag"
           TAG_SHA="$(git rev-list -n 1 "$TAG")"
@@ -75,9 +74,9 @@ jobs:
           body: |
             ## Windows code-signing status / Windows 代码签名状态
 
-            The Windows executable and installer in `1.0.0-alpha.2` are not Authenticode-signed. Windows signing is deferred until the project has a stronger basis for a signing provider, with no version deadline. Download only from this official GitHub Release and verify the file against `SHA256SUMS.txt`. Do not disable Windows security features globally.
+            The Windows executable and installer in `${{ needs.metadata.outputs.version }}` are not Authenticode-signed. Windows signing is deferred until the project has a stronger basis for a signing provider, with no version deadline. Download only from this official GitHub Release and verify the file against `SHA256SUMS.txt`. Do not disable Windows security features globally.
 
-            `1.0.0-alpha.2` 中的 Windows 可执行文件和安装器没有 Authenticode 签名。Windows 签名推迟到项目具备引入签名服务的条件后再考虑，不设版本截止期限。请只从本 GitHub Release 官方页面下载，并使用 `SHA256SUMS.txt` 核对文件；不要在系统范围内关闭 Windows 安全功能。
+            `${{ needs.metadata.outputs.version }}` 中的 Windows 可执行文件和安装器没有 Authenticode 签名。Windows 签名推迟到项目具备引入签名服务的条件后再考虑，不设版本截止期限。请只从本 GitHub Release 官方页面下载，并使用 `SHA256SUMS.txt` 核对文件；不要在系统范围内关闭 Windows 安全功能。
 
             See the [Code Signing Policy](https://github.com/3aKHP/prism-vesicle/blob/main/CODE_SIGNING_POLICY.md) / 参见[代码签名政策](https://github.com/3aKHP/prism-vesicle/blob/main/CODE_SIGNING_POLICY.zh-CN.md)。
           prerelease: ${{ contains(needs.metadata.outputs.version, '-') }}

--- a/docs/dev/WORKFLOW.md
+++ b/docs/dev/WORKFLOW.md
@@ -164,15 +164,15 @@ The empty-project smoke runs `debug markdown-runtime`, `assets status`, asset ma
 6. The tag workflow rejects a lightweight tag, a tag/version mismatch, or a tag whose commit is outside the remote `main` history. If validation succeeds, it reruns every shared gate, uploads the versioned artifacts, creates the GitHub Release and checksums, then publishes npm through Trusted Publishing.
 7. Verify the public GitHub assets, checksums, npm version/dist-tag, bin launcher, provenance attestation, and a clean installed invocation before announcing the release.
 
-For `1.0.0-alpha.2`, the complete normal publication command sequence after the release PR is merged is:
+The complete normal publication command sequence after the release PR is merged is (substitute the intended `<version>`, e.g. `1.0.0-alpha.3`):
 
 ```bash
 git switch main
 git pull --ff-only origin main
 test "$(git branch --show-current)" = "main"
-test "$(bun -e 'console.log((await Bun.file("package.json").json()).version)')" = "1.0.0-alpha.2"
-git tag -a v1.0.0-alpha.2 -m "Prism Vesicle v1.0.0-alpha.2"
-git push origin v1.0.0-alpha.2
+test "$(bun -e 'console.log((await Bun.file("package.json").json()).version)')" = "<version>"
+git tag -a "v<version>" -m "Prism Vesicle v<version>"
+git push origin "v<version>"
 ```
 
 The push is sufficient to start publication. Git cannot inspect Actions or registry state, so use the read-only CLI checks below when you want to observe and verify the result without opening a browser:
@@ -180,8 +180,8 @@ The push is sufficient to start publication. Git cannot inspect Actions or regis
 ```bash
 gh run list --workflow release.yml --limit 5
 gh run watch <run-id> --exit-status
-gh release view v1.0.0-alpha.2 --json tagName,isPrerelease,assets
-npm view prism-vesicle@1.0.0-alpha.2 version dist-tags bin --json
+gh release view "v<version>" --json tagName,isPrerelease,assets
+npm view "prism-vesicle@<version>" version dist-tags bin --json
 ```
 
 Do not tag `develop` or a release branch. After publication, forward-sync the released `main` commit back to `develop` through the normal reviewed branch flow when the histories differ.
@@ -190,13 +190,13 @@ Do not tag `develop` or a release branch. After publication, forward-sync the re
 
 The public [Code Signing Policy](../../CODE_SIGNING_POLICY.md) defines the intended Windows signing scope, maintainer roles, user verification, and incident handling. The [Privacy Policy](../../PRIVACY.md) documents the local and external-service data behavior required for public distribution. Windows signing is deferred until a viable signing provider is in place, with no version deadline.
 
-`1.0.0-alpha.2` is an explicit unsigned exception for the small, informed alpha test group. Its generated GitHub Release notes must prepend a bilingual warning that identifies both Windows artifacts as unsigned, links the code-signing policy, points to `SHA256SUMS.txt`, and tells users not to disable Windows security globally. While this exception is active, release metadata validation pins the only publishable package version to exactly `1.0.0-alpha.2`; every later version requires a reviewed workflow change that either integrates signing or records another explicit alpha decision. There is no version deadline for adding signing; whenever it is taken up, a release candidate must reuse a signing path already exercised during earlier releases rather than introducing signing for the first time.
+Until a signing provider is in place, every release is an explicitly disclosed unsigned release for the informed alpha test group. The generated GitHub Release notes prepend a bilingual warning that identifies both Windows artifacts as unsigned, links the code-signing policy, points to `SHA256SUMS.txt`, and tells users not to disable Windows security globally. Release metadata validation authorizes publication through an annotated `v<version>` tag whose commit is on the `main` history and whose version matches `package.json`; it does not pin individual versions, so each new release is a normal tag push rather than a workflow edit. There is no version deadline for adding signing; whenever it is taken up, a release candidate must reuse a signing path already exercised during earlier releases rather than introducing signing for the first time.
 
 If signing is taken up later, tag push remains the maintainer's command-line publication authorization, but every production signing request must also be manually inspected and approved through the signing provider. The signing implementation must sign and verify the portable PE before installer staging, enable and verify the generated signed uninstaller, then sign and verify the final installer. A failed or unapproved signing request must block publication of the affected Windows artifact; it must never silently fall back to an unsigned file.
 
 ### First-Time Bootstrap
 
-The tag-triggered workflow must exist on `main` before the release tag is pushed. The first release-readiness PR installs this control plane and validates it through PR CI; merging that PR does not publish anything. Do not push `v1.0.0-alpha.2` until this workflow and the release content are both present on the accepted `main` commit.
+The tag-triggered workflow must exist on `main` before the release tag is pushed. The first release-readiness PR installs this control plane and validates it through PR CI; merging that PR does not publish anything. Do not push the release tag until this workflow and the release content are both present on the accepted `main` commit.
 
 ### Required GitHub Settings
 

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,3 +1,4 @@
+import packageJson from "../../package.json";
 import type { McpServerConfig, McpToolCallResult, McpRawTool } from "./types";
 import { formatMcpToolResult, isRecord, McpError } from "./types";
 
@@ -24,7 +25,7 @@ export class McpStreamableHttpClient {
     const result = await this.request("initialize", {
       protocolVersion: this.config.protocolVersion,
       capabilities: {},
-      clientInfo: { name: "Prism Vesicle", version: "0.1.0" },
+      clientInfo: { name: "Prism Vesicle", version: packageJson.version },
     });
     this.serverInfo = isRecord(result.serverInfo) ? result.serverInfo : {};
     await this.notify("notifications/initialized", {});

--- a/tests/release-workflow.test.ts
+++ b/tests/release-workflow.test.ts
@@ -46,7 +46,6 @@ describe("release workflow contract", () => {
 
     expect(Object.keys(publish.on)).toEqual(["push"]);
     expect(publish.on.push).toEqual({ tags: ["v*"] });
-    expect(metadataScript).toContain('test "$VERSION" = "1.0.0-alpha.2"');
     expect(metadataScript).toContain('test "$TAG" = "v$VERSION"');
     expect(metadataScript).toContain('git cat-file -t "refs/tags/$TAG"');
     expect(metadataScript).toContain("git merge-base --is-ancestor");
@@ -64,7 +63,6 @@ describe("release workflow contract", () => {
     const body = String(releaseStep?.with?.body ?? "");
 
     expect(releaseStep?.with?.generate_release_notes).toBe(true);
-    expect(body).toContain("1.0.0-alpha.2");
     expect(body).toContain("not Authenticode-signed");
     expect(body).toContain("没有 Authenticode 签名");
     expect(body).toContain("SHA256SUMS.txt");


### PR DESCRIPTION
## Summary

Two related cleanups that remove hardcoded version literals blocking rapid iteration. Both are instances of "a version that should track `package.json` was written as a stale literal."

**1. Release pipeline is now version-agnostic** (`ci(release)`)
- `release.yml`: removed `test "$VERSION" = "1.0.0-alpha.2"` — the gate that forced a workflow edit + PR for every release. Also parameterized the release body version via `${{ needs.metadata.outputs.version }}` so release notes auto-fill instead of hardcoding the literal.
- `tests/release-workflow.test.ts`: dropped the two assertions that locked the gate and the body literal in place. Unsigned-status disclosure stays covered by the remaining body assertions.
- `docs/dev/WORKFLOW.md`: publication policy and command examples no longer pin a specific version; authorization is described as an annotated main-history tag rather than a pinned version.

The remaining gates (semver regex, `tag = v$VERSION`, annotated tag, main-history ancestor, `v*` tag ruleset, main branch protection, Trusted Publishing, artifact digest check) already prevent misrelease — the pin was pure friction. Unblocks the planned alpha.3 / alpha.4 / beta.1 / beta.2 / rc.1 / 1.0.0 sequence.

**2. MCP `clientInfo.version` now sourced from `package.json`** (`fix(mcp)`)
- `src/mcp/client.ts`: was hardcoded `"0.1.0"` (stale since well before 1.0.0-alpha.2); now uses the same build-time static import (`import packageJson from "../../package.json"`) already used by `scripts/build-installer.ts` and `src/providers/shared/headers.ts`. Resolves at compile time, so the standalone binary carries the correct version and tracks future bumps automatically.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — 710 pass / 0 fail
- [x] `bun audit` — no vulnerabilities
- [x] `bun test tests/release-workflow.test.ts` — 5 pass; confirms the gate removal + body parameterization validate against the modified workflow
- [ ] `bun run doctor` — skipped; change does not touch provider/runtime/asset paths (also not part of the CI reusable build)

## Notes / Follow-ups

- `release.yml` still publishes with `npm publish --tag latest` unconditionally. Fine while there is no stable release yet; after 1.0.0 ships, prereleases should move to `--tag next` (via `contains(version, '-')`) so they don't steal `latest` from stable. Not yet filed.
- CLI still lacks `vesicle --version` / `-v` — filed as #49.
- Verified the release version-bump checklist: `package.json` is the single source; installer `AppVersion`/filename, binary filename, and npm version all derive automatically. Only docs prose and CHANGELOG carry manual references.
