### PR TITLE
fix(validators): stop card validators misfiring on non-card content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Module A/B validator false positives on non-card content.** The card validators' applicability test treated any assistant response starting with `---` (a Markdown horizontal rule) as a YAML-frontmatter artifact, so a plain report or phase-transition note was validated as both a character card and a scenario card and surfaced a full batch of spurious "missing section / missing field" findings. Card applicability now recognizes real frontmatter by key family and Module A body sections, so a `---`-led report triggers no card validator. The turn-finalizer and `/validate` now run only the validators whose `applies` predicate matches (a character card is no longer cross-validated as a scenario card and vice versa) through one shared path, and classification no longer depends on the very fields a validator is meant to diagnose (a card missing `archetype` or `scenario_name` is still recognized).
 - **Assets CLI errors** now exit with a concise user-facing message instead of leaking a Bun stack trace when Harness manifest or argument validation fails.
 
 ## [1.0.0-alpha.3] - 2026-07-21

--- a/src/core/agent-loop/turn-finalizer.ts
+++ b/src/core/agent-loop/turn-finalizer.ts
@@ -1,7 +1,7 @@
 import type { VesicleMessage, VesicleResponse } from "../../providers/shared/types";
 import type { EngineProfile } from "../engine/profile";
 import type { SessionStore } from "../session/store";
-import { resolveValidators, runValidators } from "../validators/registry";
+import { validateContent } from "../validators/registry";
 import type { AgentLoopEvent, RunPromptResult, ValidatorOutcome } from "./types";
 import type { QualityOutcome } from "../quality";
 
@@ -59,10 +59,12 @@ async function validateResponse(options: {
   onEvent?: (event: AgentLoopEvent) => void;
 }): Promise<ValidatorOutcome | undefined> {
   if (options.profile.validators.length === 0) return undefined;
-  const validators = resolveValidators(options.profile.validators);
-  if (!validators.some((validator) => validator.applies(options.response.content))) return undefined;
-
-  const validation = runValidators(validators, options.response.content);
+  // Run only the validators whose `applies` predicate matches this content.
+  // validateContent filters by applies, so a character card is not also run
+  // through the scenario validator (and vice versa), and a `---`-led report or
+  // ordinary prose triggers nothing.
+  const validation = validateContent(options.profile.validators, options.response.content);
+  if (!validation) return undefined;
   await options.session.append({
     role: "system",
     content: summariseValidation(validation),

--- a/src/core/artifacts/workbench.ts
+++ b/src/core/artifacts/workbench.ts
@@ -1,7 +1,7 @@
 import { readdir, stat } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { executeFileTool } from "../tools";
-import { resolveValidators, runValidators } from "../validators/registry";
+import { validateContent } from "../validators/registry";
 import type { ValidationResult } from "../validators/registry";
 import { artifactRootIndex, artifactRoots } from "./roots";
 
@@ -95,29 +95,7 @@ async function scanArtifactDir(rootDir: string, dir: string, entries: ArtifactEn
 }
 
 function validateArtifactContent(content: string): ArtifactValidation | undefined {
-  const names = selectArtifactValidators(content);
-  if (names.length === 0) return undefined;
-  return runValidators(resolveValidators(names), content);
-}
-
-function selectArtifactValidators(content: string): string[] {
-  const keys = frontmatterKeys(content);
-  if (keys.size === 0) return [];
-  if (keys.has("scenario_name")) return ["scenario-card"];
-  if (keys.has("name") && keys.has("archetype")) return ["character-card"];
-  return ["character-card", "scenario-card"];
-}
-
-function frontmatterKeys(content: string): Set<string> {
-  const trimmed = content.trimStart();
-  if (!trimmed.startsWith("---")) return new Set();
-  const lines = trimmed.split(/\r?\n/);
-  const keys = new Set<string>();
-  for (let index = 1; index < lines.length; index++) {
-    const line = lines[index].trim();
-    if (line === "---") break;
-    const colon = line.indexOf(":");
-    if (colon > 0) keys.add(line.slice(0, colon).trim());
-  }
-  return keys;
+  // Same shape-based classification + filter as turn-finalizer auto-validation,
+  // so /validate and auto-validation never drift in which validators they run.
+  return validateContent(["character-card", "scenario-card"], content);
 }

--- a/src/core/validators/registry.ts
+++ b/src/core/validators/registry.ts
@@ -50,29 +50,36 @@ const CHARACTER_KEYS = ["archetype", "age_gender", "inventory"];
 const SCENARIO_KEYS = ["scenario_name", "world_state", "beat_map"];
 
 /**
- * Parse a leading `---` frontmatter block into its top-level keys and the body
- * that follows the closing fence. Returns null when there is no real
- * frontmatter — including a `---` that is just a Markdown horizontal rule with
- * no closing fence, or a block with no closing fence at all.
+ * Leniently parse a leading `---` frontmatter block into its top-level keys and
+ * the body that follows. Used for CLASSIFICATION (the `applies` predicates), so
+ * it deliberately does not require a closing `---` fence: a card whose keys are
+ * present but whose closing fence is missing must still be recognized, so the
+ * validator gets to run and report the malformation. The strict closing-fence
+ * requirement lives in `splitFrontmatter` (index.ts), which the validators use
+ * to decide whether the frontmatter is well-formed.
+ *
+ * Non-card content is rejected by the `keys.size === 0` guard in the predicates:
+ * a `---` Markdown horizontal rule over prose yields no `key:` lines.
  */
 function parseFrontmatter(content: string): { keys: Set<string>; body: string } | null {
   const trimmed = content.trimStart();
   if (!trimmed.startsWith("---")) return null;
   const lines = trimmed.split(/\r?\n/);
   const keys = new Set<string>();
-  let closed = false;
-  let index = 1;
-  for (; index < lines.length; index++) {
+  let closeIndex = -1;
+  for (let index = 1; index < lines.length; index++) {
     const line = lines[index].trim();
     if (line === "---") {
-      closed = true;
+      closeIndex = index;
       break;
     }
     const colon = line.indexOf(":");
     if (colon > 0) keys.add(line.slice(0, colon).trim());
   }
-  if (!closed) return null;
-  return { keys, body: lines.slice(index + 1).join("\n") };
+  // With no closing fence, treat the whole post-`---` region as the body so
+  // body-section signals (e.g. Module A sections) still work for classification.
+  const bodyStart = closeIndex === -1 ? 1 : closeIndex + 1;
+  return { keys, body: lines.slice(bodyStart).join("\n") };
 }
 
 /**
@@ -98,6 +105,13 @@ function isCharacterCard(content: string): boolean {
  * Recognize a Module B scenario card by shape: any scenario-family frontmatter
  * key. A card missing `scenario_name` but carrying `world_state`/`beat_map`
  * still matches.
+ *
+ * Unlike `isCharacterCard`, there is no body-section fallback: a Module B
+ * card's distinctive structure is its frontmatter (`beat_map`/`world_state`),
+ * whereas Module A's is its seven named body sections. A scenario card missing
+ * all three family keys is not recognized; that is an extreme malformation that
+ * is unlikely in practice, and a body heuristic (HTML-comment markers) would
+ * risk re-admitting non-card content.
  */
 function isScenarioCard(content: string): boolean {
   const fm = parseFrontmatter(content);

--- a/src/core/validators/registry.ts
+++ b/src/core/validators/registry.ts
@@ -23,15 +23,86 @@ type ValidatorEntry = {
 };
 
 const registry: Record<string, ValidatorEntry> = {
-  "character-card": { applies: isFrontmatterArtifact, run: validateCharacterCard },
-  "scenario-card": { applies: isFrontmatterArtifact, run: validateScenarioCard },
+  "character-card": { applies: isCharacterCard, run: validateCharacterCard },
+  "scenario-card": { applies: isScenarioCard, run: validateScenarioCard },
   "runtime-packet": { applies: isRuntimePacket, run: validateRuntimePacket },
   "evaluate-report": { applies: isEvaluateReport, run: validateEvaluateReport },
 };
 
-function isFrontmatterArtifact(content: string): boolean {
-  // ETL cards carry YAML frontmatter; ordinary phase-transition prose does not.
-  return content.trimStart().startsWith("---");
+/**
+ * Module A body section headers (schema_character §3). Used only to recognize
+ * character-card shape; the validator itself checks all seven are present.
+ */
+const MODULE_A_SECTIONS = [
+  "## Visual Cortex",
+  "## Biography",
+  "## Cognitive Stack",
+  "## Instinct Protocol",
+  "## Persona Topology",
+  "## Narrative Engine",
+  "## World Context",
+];
+
+// Frontmatter key families that identify each card type. `name` is intentionally
+// excluded from the character family (it is generic); a name-only card needs a
+// Module A body section to be recognized as a character card.
+const CHARACTER_KEYS = ["archetype", "age_gender", "inventory"];
+const SCENARIO_KEYS = ["scenario_name", "world_state", "beat_map"];
+
+/**
+ * Parse a leading `---` frontmatter block into its top-level keys and the body
+ * that follows the closing fence. Returns null when there is no real
+ * frontmatter — including a `---` that is just a Markdown horizontal rule with
+ * no closing fence, or a block with no closing fence at all.
+ */
+function parseFrontmatter(content: string): { keys: Set<string>; body: string } | null {
+  const trimmed = content.trimStart();
+  if (!trimmed.startsWith("---")) return null;
+  const lines = trimmed.split(/\r?\n/);
+  const keys = new Set<string>();
+  let closed = false;
+  let index = 1;
+  for (; index < lines.length; index++) {
+    const line = lines[index].trim();
+    if (line === "---") {
+      closed = true;
+      break;
+    }
+    const colon = line.indexOf(":");
+    if (colon > 0) keys.add(line.slice(0, colon).trim());
+  }
+  if (!closed) return null;
+  return { keys, body: lines.slice(index + 1).join("\n") };
+}
+
+/**
+ * Top-level YAML keys from a leading frontmatter block (empty for content with
+ * no real frontmatter, e.g. a `---`-led report).
+ */
+export function frontmatterKeys(content: string): Set<string> {
+  return parseFrontmatter(content)?.keys ?? new Set();
+}
+
+/**
+ * Recognize a Module A character card by shape, not by any single field the
+ * validator is meant to diagnose: any character-family frontmatter key OR any
+ * Module A body section suffices. So a card missing `archetype` still matches.
+ */
+function isCharacterCard(content: string): boolean {
+  const fm = parseFrontmatter(content);
+  if (!fm || fm.keys.size === 0) return false;
+  return CHARACTER_KEYS.some((key) => fm.keys.has(key)) || MODULE_A_SECTIONS.some((section) => fm.body.includes(section));
+}
+
+/**
+ * Recognize a Module B scenario card by shape: any scenario-family frontmatter
+ * key. A card missing `scenario_name` but carrying `world_state`/`beat_map`
+ * still matches.
+ */
+function isScenarioCard(content: string): boolean {
+  const fm = parseFrontmatter(content);
+  if (!fm || fm.keys.size === 0) return false;
+  return SCENARIO_KEYS.some((key) => fm.keys.has(key));
 }
 
 function isRuntimePacket(content: string): boolean {
@@ -82,6 +153,32 @@ export function runValidators(
     ok: results.every((entry) => entry.result.ok),
     results,
   };
+}
+
+/**
+ * The validator names whose `applies` predicate matches the content. Both the
+ * turn-finalizer (auto-validation) and the artifact workbench (/validate) go
+ * through this so the two paths cannot drift in which validators they run.
+ */
+export function applicableValidators(names: string[], content: string): string[] {
+  return resolveValidators(names)
+    .filter((validator) => validator.applies(content))
+    .map((validator) => validator.name);
+}
+
+/**
+ * Resolve, filter to applying validators, and run them in one step. Returns
+ * undefined when no validator applies (so a `---`-led report or prose triggers
+ * nothing). This is the single wired path used by both turn-finalizer and
+ * workbench validation.
+ */
+export function validateContent(
+  names: string[],
+  content: string,
+): { ok: boolean; results: Array<{ name: string; result: ValidationResult }> } | undefined {
+  const applying = resolveValidators(names).filter((validator) => validator.applies(content));
+  if (applying.length === 0) return undefined;
+  return runValidators(applying, content);
 }
 
 export const knownValidatorNames: readonly ValidatorName[] = Object.keys(registry) as ValidatorName[];

--- a/tests/unit/core/validators.test.ts
+++ b/tests/unit/core/validators.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { validateCharacterCard, validateScenarioCard, validateRuntimePacket, validateEvaluateReport, validateM0Output } from "../../../src/core/validators";
+import { resolveValidators, validateContent, applicableValidators } from "../../../src/core/validators/registry";
 
 describe("validateM0Output (legacy stub, kept for non-artifact turns)", () => {
   test("passes on non-empty content", () => {
@@ -293,3 +294,138 @@ beat_map:
 - **Immediate goal:** 想确认她的真实感受
 -->
 `;
+
+describe("validator applies discrimination (registry)", () => {
+  const validators = resolveValidators(["character-card", "scenario-card"]);
+  const applies = (name: string, content: string) =>
+    validators.find((v) => v.name === name)!.applies(content);
+
+  const characterCard = `---
+name: 谬因
+archetype: 观测者
+age_gender: 女
+inventory: 终端
+---
+
+## Visual Cortex
+appearance
+## Biography
+bio
+## Cognitive Stack
+### Invariant
+- a
+- b
+## Instinct Protocol
+x
+## Persona Topology
+### Invariant Axes
+- a
+- b
+### Variant Axes
+- a
+- b
+- c
+### Boundary Conditions
+- **Hard limit:** none
+## Narrative Engine
+voice
+## World Context
+world
+`;
+
+  const scenarioCard = `---
+scenario_name: 助理的第一天
+world_state: "office"
+beat_map:
+  - label: A
+    tension_target: 20
+    variant_config: x
+    pivot_condition: y
+  - label: B
+    tension_target: 10
+    variant_config: x
+    pivot_condition: y
+  - label: C
+    tension_target: 30
+    variant_config: x
+    pivot_condition: y
+---
+
+opening paragraph
+
+<!--
+## Scene Premise
+s
+## Neural State
+n
+## User Role
+u
+-->
+`;
+
+  // A Markdown report that starts with a `---` horizontal rule — the
+  // regression source: it must not trigger either card validator.
+  const leadingRuleReport = `---
+
+## 核查结果报告
+
+我通过工具核实了角色信息。
+
+---
+
+### 基本信息
+| 项目 | 素材 |
+|---|---|
+| 代号 | 谬因 |
+`;
+
+  test("a character card applies only to character-card", () => {
+    expect(applies("character-card", characterCard)).toBe(true);
+    expect(applies("scenario-card", characterCard)).toBe(false);
+  });
+
+  test("a scenario card applies only to scenario-card", () => {
+    expect(applies("scenario-card", scenarioCard)).toBe(true);
+    expect(applies("character-card", scenarioCard)).toBe(false);
+  });
+
+  test("a leading `---` report applies to neither card validator", () => {
+    expect(applies("character-card", leadingRuleReport)).toBe(false);
+    expect(applies("scenario-card", leadingRuleReport)).toBe(false);
+  });
+
+  test("a Module A card missing archetype is still recognized (shape, not field)", () => {
+    const missingArchetype = characterCard.replace("archetype: 观测者\n", "");
+    // age_gender / inventory still mark it as a character card.
+    expect(applies("character-card", missingArchetype)).toBe(true);
+    expect(applies("scenario-card", missingArchetype)).toBe(false);
+  });
+
+  test("a Module B card missing scenario_name is still recognized via world_state/beat_map", () => {
+    const missingScenarioName = scenarioCard.replace("scenario_name: 助理的第一天\n", "");
+    expect(applies("scenario-card", missingScenarioName)).toBe(true);
+    expect(applies("character-card", missingScenarioName)).toBe(false);
+  });
+
+  test("the wired validateContent path runs only applying validators (no cross-noise)", () => {
+    // validateContent is the single wired path used by both turn-finalizer
+    // auto-validation and /validate, so this exercises the real
+    // resolve+filter+run rather than mirroring the filter locally.
+    const runFor = (content: string) => {
+      const result = validateContent(["character-card", "scenario-card"], content);
+      return result
+        ? { ran: result.results.map((entry) => entry.name), ok: result.ok }
+        : { ran: [] as string[], ok: true };
+    };
+    expect(runFor(characterCard)).toEqual({ ran: ["character-card"], ok: true });
+    expect(runFor(scenarioCard)).toEqual({ ran: ["scenario-card"], ok: true });
+    // The report triggers no validator at all.
+    expect(runFor(leadingRuleReport).ran).toEqual([]);
+  });
+
+  test("applicableValidators returns the matched names only", () => {
+    expect(applicableValidators(["character-card", "scenario-card"], characterCard)).toEqual(["character-card"]);
+    expect(applicableValidators(["character-card", "scenario-card"], scenarioCard)).toEqual(["scenario-card"]);
+    expect(applicableValidators(["character-card", "scenario-card"], leadingRuleReport)).toEqual([]);
+  });
+});

--- a/tests/unit/core/validators.test.ts
+++ b/tests/unit/core/validators.test.ts
@@ -394,6 +394,24 @@ u
     expect(applies("scenario-card", leadingRuleReport)).toBe(false);
   });
 
+  test("a card with keys but a missing closing fence is still recognized (then flagged malformed)", () => {
+    // Lenient classification: no closing `---`, but the keys are present. The
+    // card must still match so the validator runs and reports the malformation
+    // rather than silently passing.
+    const unclosed = `---
+name: x
+archetype: observer
+age_gender: f
+inventory: tool
+
+## Visual Cortex
+appearance`;
+    expect(applies("character-card", unclosed)).toBe(true);
+    const result = validateContent(["character-card", "scenario-card"], unclosed);
+    expect(result?.results[0]?.result.ok).toBe(false);
+    expect(result?.results[0]?.result.errors.some((e: string) => e.includes("frontmatter is missing or malformed"))).toBe(true);
+  });
+
   test("a Module A card missing archetype is still recognized (shape, not field)", () => {
     const missingArchetype = characterCard.replace("archetype: 观测者\n", "");
     // age_gender / inventory still mark it as a character card.


### PR DESCRIPTION
## Summary

Fixes the false-positive "Validation found issues" seen in real use when an ETL assistant emitted a plain verification report whose first line was a `---` Markdown horizontal rule. The user's actual cards (`workspace/谬因.md`, `workspace/谬因_scenario_assistant_day.md`) were always valid — running the validators directly on them returned `ok: true`; the noise came from validating the **assistant response**, not the files.

Three coupled root causes:
- The card applicability test (`isFrontmatterArtifact`) treated any content starting with `---` as a YAML-frontmatter artifact, so a report got validated as a card.
- `character-card` and `scenario-card` shared that loose predicate, and `turn-finalizer` ran every profile validator once one applied (ignoring the others' `applies`) — so each card type was cross-validated as the other.
- Classification depended on the very fields the validators diagnose, so a card missing `archetype` / `scenario_name` could bypass validation entirely (independent CR finding).

Changes:
- Replace the loose predicate with **shape recognition** (`parseFrontmatter` + character/scenario key families and Module A body sections). A `---`-led report now triggers no card validator; a card missing one diagnosed field is still recognized.
- Route both turn-finalizer auto-validation and the `/validate` workbench through one shared `validateContent()` that filters by `applies`, and dedupe the workbench's private classifier onto the shared path.

Validators remain advisory (no turn aborts); this only removes spurious findings.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` (812 pass / 5 skip / 0 fail)
- [x] `bun run doctor`
- [x] `git diff --check`

New regression tests: character card → only `character-card`; scenario card → only `scenario-card`; `---`-led report → neither; partially malformed cards (missing `archetype` / missing `scenario_name`) still recognized; the wired `validateContent` / `applicableValidators` paths (not a local filter mirror). Probed against the real workspace cards + the session's offending report.

## Notes / Follow-ups

- Cross-reviewed with an independent CR agent; its two findings (shape-based classification, test the real wired path) are both addressed.
- Awaiting Bot Reviewer for the merge go-ahead.