### PR TITLE
refactor(agent-loop): separate quality round boundaries

### DIFF
--- a/src/core/agent-loop/quality-round-evaluation.ts
+++ b/src/core/agent-loop/quality-round-evaluation.ts
@@ -1,0 +1,67 @@
+import type { ExperimentalQualityProfile } from "../../config/quality";
+import type { VesicleResponse } from "../../providers/shared/types";
+import type { EngineId } from "../engine/profile";
+import {
+  evaluateBoundQuality,
+  evaluateBoundQualityTargets,
+  isQualityArtifactMutationCall,
+  isQualityBoundary,
+  observeBoundQualityWithJudge,
+  qualityModeForEngine,
+  readQualityArtifactTargets,
+  type BoundQualityEvaluation,
+  type QualityRuntimeContext,
+} from "../quality";
+import type { AgentLoopEvent } from "./types";
+import { qualityDeliveryParts, qualityFindingCount, type QualityRoundState } from "./quality-round-state";
+
+export async function evaluateQualityRoundBoundary(options: {
+  rootDir: string;
+  runtime?: QualityRuntimeContext;
+  producer: EngineId;
+  experimentalQuality?: ExperimentalQualityProfile;
+  response: VesicleResponse;
+  phase: "before-mutations" | "after-mutations";
+  state: QualityRoundState;
+  signal?: AbortSignal;
+  onEvent?: (event: AgentLoopEvent) => void;
+}): Promise<BoundQualityEvaluation | undefined> {
+  if (!options.runtime || !isQualityBoundary(options.response)) return undefined;
+  const hasArtifactMutation = (options.response.toolCalls ?? [])
+    .some((call) => isQualityArtifactMutationCall(call, options.producer));
+  if ((options.phase === "before-mutations" && hasArtifactMutation)
+    || (options.phase === "after-mutations" && !hasArtifactMutation)) return undefined;
+  const mode = qualityModeForEngine(options.runtime, options.producer);
+  if (mode === "off" || mode === "analyze") return undefined;
+  options.onEvent?.({ type: "quality_status", phase: "checking", attempt: options.state.attempts, findingCount: 0 });
+  const deterministic = options.state.targets.length > 0
+    ? evaluateBoundQualityTargets({
+      runtime: options.runtime,
+      producer: options.producer,
+      mode,
+      targets: await readQualityArtifactTargets(options.rootDir, options.state.targets),
+      attempt: options.state.attempts,
+      state: options.state,
+      usage: options.response.usage,
+    })
+    : evaluateBoundQuality({
+      runtime: options.runtime,
+      producer: options.producer,
+      mode,
+      content: qualityDeliveryParts(options.state).join("\n\n"),
+      attempt: options.state.attempts,
+      state: options.state,
+      usage: options.response.usage,
+    });
+  if (!deterministic) return undefined;
+  const result = await observeBoundQualityWithJudge({
+    result: deterministic,
+    runtime: options.runtime,
+    experimentalProfile: options.experimentalQuality,
+    state: options.state,
+    signal: options.signal,
+  });
+  if (result.event.experimentalJudge) options.state.experimentalJudge = result.event.experimentalJudge;
+  options.state.lastResult = { outcome: result.outcome, findingCount: qualityFindingCount(result) };
+  return result;
+}

--- a/src/core/agent-loop/quality-round-recording.ts
+++ b/src/core/agent-loop/quality-round-recording.ts
@@ -1,0 +1,400 @@
+import type { ExperimentalQualityProfile } from "../../config/quality";
+import type { VesicleMessage, VesicleResponse } from "../../providers/shared/types";
+import type { EngineProfile } from "../engine/profile";
+import {
+  isQualityArtifactMutationCall,
+  qualityModeForEngine,
+  qualityRewriteFeedback,
+  recordQualityEvent,
+  shouldBufferQualityOutput,
+  type BoundQualityEvaluation,
+  type QualityDecisionPoint,
+  type QualityRuntimeContext,
+  type QualityTargetWarningReason,
+  type QualityWarning,
+} from "../quality";
+import { loadSessionSnapshot, type SessionStore } from "../session/store";
+import type { ToolCall } from "../tools";
+import {
+  durableQualityState,
+  qualityDecisionCandidate,
+  qualityFindingCount,
+  type QualityRoundState,
+} from "./quality-round-state";
+import { failedToolResult, recordToolResult } from "./tool-result-recorder";
+import type { AgentLoopEvent, RunPromptResult } from "./types";
+
+export type QualityRoundRecordingContext = {
+  rootDir: string;
+  runtime?: QualityRuntimeContext;
+  experimentalQuality?: ExperimentalQualityProfile;
+  state: QualityRoundState;
+  responseMessages: VesicleMessage[];
+  session: SessionStore;
+  profile: EngineProfile;
+  model: string;
+  onEvent?: (event: AgentLoopEvent) => void;
+};
+
+export async function recordQualityEvaluation(
+  context: QualityRoundRecordingContext,
+  result: BoundQualityEvaluation,
+): Promise<void> {
+  if (result.action !== "ask-user" && result.event.targets.some((target) => target.warningReason)) {
+    await recordInconclusiveWarnings(context, result);
+  }
+  if (result.outcome !== "inconclusive") await resolveQualityWarnings(context, result);
+  if (result.decision !== "rewrite") {
+    await recordQualityEvent(context.session, result);
+    emitQualityStatus(result, context.state, context.onEvent);
+  }
+}
+
+export async function recordQualityRewriteResult(
+  context: QualityRoundRecordingContext,
+  result: BoundQualityEvaluation,
+): Promise<void> {
+  await recordQualityEvent(context.session, result);
+  emitQualityStatus(result, context.state, context.onEvent);
+}
+
+export async function recordPendingQualityCheck(
+  context: QualityRoundRecordingContext,
+  response: VesicleResponse,
+  executableCalls: ToolCall[],
+): Promise<void> {
+  if (!context.runtime
+    || !executableCalls.some((call) => isQualityArtifactMutationCall(call, context.profile.id))
+    || !isBuffered(context)) return;
+  context.state.candidate = qualityDecisionCandidate(response);
+  const pending = persistedQualityState(context);
+  if (!pending) return;
+  await context.session.append({
+    role: "system",
+    content: "",
+    metadata: {
+      kind: "quality-check-pending",
+      qualityRewrite: pending,
+    },
+  });
+}
+
+export async function recordPostMutationQualityRewrite(
+  context: QualityRoundRecordingContext,
+  response: VesicleResponse,
+  interactionCalls: ToolCall[],
+  result: BoundQualityEvaluation,
+): Promise<void> {
+  context.state.candidate = qualityDecisionCandidate(response);
+  const persistedState = persistedQualityState(context);
+  if (!persistedState) throw new Error("Quality rewrite state is unavailable under the active Guard.");
+  const feedback = qualityRewriteFeedback(result);
+  for (const call of interactionCalls) {
+    await recordToolResult({
+      result: failedToolResult(call.id, call.name, feedback),
+      messages: context.responseMessages,
+      session: context.session,
+      metadata: {
+        kind: "quality-rewrite-feedback",
+        candidateHash: result.evaluation.candidateHash,
+        qualityRewrite: { ...persistedState, candidateParts: [] },
+      },
+      emitEvent: false,
+    });
+  }
+}
+
+export async function pauseForQualityDecision(
+  context: QualityRoundRecordingContext,
+  response: VesicleResponse,
+  result: BoundQualityEvaluation,
+  phase: QualityDecisionPoint["phase"],
+  candidateRecorded: boolean,
+): Promise<Extract<RunPromptResult, { kind: "needs_quality_decision" }>> {
+  const warningTargets = result.event.targets.filter((target) =>
+    target.status === "warning" && !target.warningReason
+  );
+  const warningId = context.state.warningId ?? `quality-warning_${crypto.randomUUID()}`;
+  context.state.warningId = warningId;
+  context.state.warningTargetIds = warningTargets.map((target) => target.id);
+  context.state.candidate = qualityDecisionCandidate(response);
+  const state = persistedQualityState(context);
+  if (!state) throw new Error("Quality decision state is unavailable under the active Guard.");
+  state.candidateParts = [];
+  const warning: QualityWarning = {
+    id: warningId,
+    guard: "anti-ai-flavor",
+    reason: "exhausted",
+    producer: context.profile.id,
+    attempt: context.state.attempts,
+    targets: warningTargets,
+  };
+  const request = {
+    id: warningId,
+    reason: "exhausted" as const,
+    producer: context.profile.id,
+    findingCount: warningTargets.reduce((count, target) => count + target.findingIds.length, 0),
+    targets: warningTargets.map((target) => ({
+      id: target.id,
+      ...(target.path ? { path: target.path } : {}),
+      findingIds: [...target.findingIds],
+    })),
+    canRetry: true,
+  };
+  const point: QualityDecisionPoint = {
+    request,
+    warning,
+    qualityState: state,
+    candidate: context.state.candidate,
+    phase,
+    candidateRecorded,
+  };
+  await context.session.append({
+    role: "system",
+    content: qualityWarningText(warning),
+    metadata: {
+      kind: "quality-warning",
+      qualityWarning: warning,
+      qualityDecision: point,
+    },
+  });
+  return {
+    kind: "needs_quality_decision",
+    sessionId: context.session.sessionId,
+    sessionPath: context.session.sessionPath,
+    profile: context.profile,
+    decision: request,
+    assistantContent: response.content,
+    messages: context.responseMessages,
+  };
+}
+
+export async function recordRejectedQualityRound(
+  context: QualityRoundRecordingContext,
+  response: VesicleResponse,
+  result: BoundQualityEvaluation,
+): Promise<void> {
+  const calls = response.toolCalls ?? [];
+  const persistedState = persistedQualityState(context);
+  if (!persistedState) throw new Error("Quality rewrite state is unavailable under the active Guard.");
+  const rewriteState = {
+    ...persistedState,
+    candidateParts: [],
+    candidate: qualityDecisionCandidate(response),
+  };
+  if (calls.length > 0) {
+    const feedback = qualityRewriteFeedback(result);
+    const assistantMessage: VesicleMessage = { role: "assistant", content: "", toolCalls: calls };
+    const toolMessages: VesicleMessage[] = calls.map((call) => ({
+      role: "tool",
+      toolCallId: call.id,
+      content: JSON.stringify({ ok: false, result: feedback }),
+    }));
+    await context.session.appendMany([
+      {
+        role: "assistant",
+        content: "",
+        metadata: {
+          kind: "quality-rejected-candidate",
+          engine: context.profile.id,
+          model: context.model,
+          providerResponseId: response.id,
+          candidateHash: result.evaluation.candidateHash,
+          toolCalls: calls,
+        },
+      },
+      ...calls.map((call) => ({
+        role: "tool" as const,
+        content: JSON.stringify({ ok: false, result: feedback }),
+        metadata: {
+          name: call.name,
+          ok: false,
+          toolCallId: call.id,
+          kind: "quality-rewrite-feedback",
+          candidateHash: result.evaluation.candidateHash,
+          qualityRewrite: rewriteState,
+        },
+      })),
+    ]);
+    context.responseMessages.push(assistantMessage, ...toolMessages);
+    return;
+  }
+  const feedback = qualityRewriteFeedback(result, true);
+  context.responseMessages.push({ role: "user", content: feedback });
+  await context.session.appendMany([{
+    role: "user",
+    content: feedback,
+    metadata: { kind: "quality-rewrite-feedback", candidateHash: result.evaluation.candidateHash, qualityRewrite: rewriteState },
+  }]);
+}
+
+function persistedQualityState(context: QualityRoundRecordingContext) {
+  return durableQualityState({
+    runtime: context.runtime,
+    producer: context.profile.id,
+    experimentalQuality: context.experimentalQuality,
+    state: context.state,
+    buffered: isBuffered(context),
+  });
+}
+
+function isBuffered(context: QualityRoundRecordingContext): boolean {
+  return shouldBufferQualityOutput(qualityModeForEngine(context.runtime, context.profile.id));
+}
+
+function emitQualityStatus(
+  result: BoundQualityEvaluation,
+  state: QualityRoundState,
+  onEvent?: (event: AgentLoopEvent) => void,
+): void {
+  onEvent?.({
+    type: "quality_status",
+    phase: result.action === "rewrite" ? "rewriting"
+      : result.action === "ask-user" ? "exhausted"
+        : result.outcome === "inconclusive" ? "inconclusive"
+          : result.action === "observe" ? "observed"
+            : result.outcome === "findings" ? "findings"
+              : "clean",
+    attempt: state.attempts,
+    findingCount: qualityFindingCount(result),
+    findings: result.event.targets.flatMap((target) => target.findings.map((finding) => ({
+      ...finding,
+      ...(target.path ? { targetPath: target.path } : {}),
+    }))).slice(0, 8),
+    warningReasons: [...new Set(result.event.targets.flatMap((target) =>
+      target.warningReason ? [target.warningReason] : []
+    ))],
+  });
+}
+
+async function resolveQualityWarnings(
+  context: QualityRoundRecordingContext,
+  result: BoundQualityEvaluation,
+): Promise<void> {
+  const snapshot = await loadSessionSnapshot(context.rootDir, context.session.sessionId, {
+    synthesizeDanglingToolResults: false,
+  });
+  const cleanTargetIds = new Set(result.event.targets
+    .filter((target) => target.status === "clean" || target.status === "findings")
+    .map((target) => target.id));
+  for (const warning of snapshot.qualityWarnings) {
+    const targetIds = warning.targets
+      .filter((target) => cleanTargetIds.has(target.id)
+        || (warning.id === context.state.warningId
+          && target.kind === "assistant-response"
+          && (result.outcome === "clean" || result.outcome === "findings")))
+      .map((target) => target.id);
+    if (targetIds.length === 0) continue;
+    await context.session.append({
+      role: "system",
+      content: "",
+      metadata: {
+        kind: "quality-resolution",
+        qualityResolution: {
+          warningId: warning.id,
+          resolution: "revised-clean",
+          targetIds,
+        },
+      },
+    });
+  }
+}
+
+async function recordInconclusiveWarnings(
+  context: QualityRoundRecordingContext,
+  result: BoundQualityEvaluation,
+): Promise<void> {
+  const snapshot = await loadSessionSnapshot(context.rootDir, context.session.sessionId, {
+    synthesizeDanglingToolResults: false,
+  });
+  let reusedPendingWarning = false;
+  for (const reason of [
+    "target-unreadable", "target-oversize", "detector-budget-exhausted",
+    "judge-invalid", "judge-timeout", "judge-unavailable",
+  ] as const) {
+    const existing = new Set(snapshot.qualityWarnings
+      .filter((warning) => warning.id !== context.state.warningId && warning.reason === reason)
+      .flatMap((warning) => warning.targets.map((target) => target.id)));
+    const targets = result.event.targets.filter((target) =>
+      target.warningReason === reason
+      && !existing.has(target.id)
+    );
+    if (targets.length === 0) continue;
+    const warning: QualityWarning = {
+      id: context.state.warningId && !reusedPendingWarning
+        ? context.state.warningId
+        : `quality-warning_${crypto.randomUUID()}`,
+      guard: "anti-ai-flavor",
+      reason,
+      producer: context.profile.id,
+      attempt: result.event.attempt,
+      targets,
+    };
+    await context.session.append({
+      role: "system",
+      content: inconclusiveWarningText(reason, targets.length),
+      metadata: { kind: "quality-warning", qualityWarning: warning },
+    });
+    if (warning.id === context.state.warningId) reusedPendingWarning = true;
+  }
+  if (reusedPendingWarning && context.state.warningId) {
+    await context.session.append({
+      role: "system",
+      content: "",
+      metadata: { kind: "quality-check-cleared", warningId: context.state.warningId },
+    });
+  } else if (context.state.warningId) {
+    const pendingWarning = snapshot.qualityWarnings.find((warning) => warning.id === context.state.warningId);
+    const unresolvedTargetIds = new Set(result.event.targets
+      .filter((target) => target.status === "warning")
+      .map((target) => target.id));
+    const resolvedTargetIds = pendingWarning?.targets
+      .filter((target) => !unresolvedTargetIds.has(target.id))
+      .map((target) => target.id) ?? [];
+    await context.session.appendMany([
+      ...(resolvedTargetIds.length > 0 ? [{
+        role: "system" as const,
+        content: "",
+        metadata: {
+          kind: "quality-resolution",
+          qualityResolution: {
+            warningId: context.state.warningId,
+            resolution: "revised-clean",
+            targetIds: resolvedTargetIds,
+          },
+        },
+      }] : []),
+      {
+        role: "system",
+        content: "",
+        metadata: { kind: "quality-check-cleared", warningId: context.state.warningId },
+      },
+    ]);
+  }
+}
+
+function qualityWarningText(warning: QualityWarning): string {
+  const paths = warning.targets.flatMap((target) => target.path ? [target.path] : []);
+  const findings = [...new Set(warning.targets.flatMap((target) => target.findingIds))];
+  return [
+    `Automatic quality revision is exhausted with ${findings.length} blocking finding${findings.length === 1 ? "" : "s"}.`,
+    ...(paths.length > 0 ? [`Targets: ${paths.join(", ")}.`] : []),
+    `Rules: ${findings.join(", ") || "unknown"}.`,
+    "The current version has not been confirmed clean. Choose another revision, use it with the warning, or stop.",
+  ].join(" ");
+}
+
+function inconclusiveWarningText(reason: QualityTargetWarningReason, targetCount: number): string {
+  const detail = reason === "target-oversize"
+    ? "over the quality check size limit"
+    : reason === "detector-budget-exhausted"
+      ? "over the deterministic check work limit"
+      : reason === "judge-invalid"
+        ? "returned an invalid Semantic Judge result"
+        : reason === "judge-timeout"
+          ? "not checked before the Semantic Judge timeout"
+          : reason === "judge-unavailable"
+            ? "not checked because the Semantic Judge provider was unavailable"
+            : "not readable as a guarded UTF-8 file";
+  return `${targetCount} quality target${targetCount === 1 ? " was" : "s were"} ${detail}. The content was delivered without a clean quality result.`;
+}

--- a/src/core/agent-loop/quality-round-state.ts
+++ b/src/core/agent-loop/quality-round-state.ts
@@ -1,0 +1,114 @@
+import type { ExperimentalQualityProfile } from "../../config/quality";
+import type { VesicleResponse } from "../../providers/shared/types";
+import type { EngineId } from "../engine/profile";
+import {
+  durableQualityTargets,
+  qualityArtifactTargetFromResult,
+  upsertQualityArtifactTarget,
+  type BoundQualityEvaluation,
+  type DurableQualityState,
+  type QualityDecisionCandidate,
+  type QualityRewriteState,
+  type QualityRuntimeContext,
+} from "../quality";
+import type { ToolResult } from "../tools";
+
+export type QualityRoundState = QualityRewriteState & {
+  proseParts: string[];
+  mutationParts: string[];
+  targets: NonNullable<QualityRewriteState["targets"]>;
+  lastResult?: { outcome: BoundQualityEvaluation["outcome"]; findingCount: number };
+};
+
+export function createQualityRoundState(initial?: QualityRewriteState): QualityRoundState {
+  return {
+    attempts: initial?.attempts ?? 0,
+    rejectedHashes: new Set(initial?.rejectedHashes ?? []),
+    proseParts: [],
+    mutationParts: [...(initial?.candidateParts ?? [])],
+    targets: (initial?.targets ?? []).map((target) => ({
+      ...target,
+      mutationCallIds: [...target.mutationCallIds],
+      rejectedHashes: new Set(target.rejectedHashes),
+    })),
+    warningId: initial?.warningId,
+    warningTargetIds: initial?.warningTargetIds ? [...initial.warningTargetIds] : undefined,
+    candidate: initial?.candidate,
+    experimentalJudge: initial?.experimentalJudge,
+  };
+}
+
+export function qualityDeliveryParts(state: QualityRoundState): string[] {
+  return state.mutationParts.length > 0 ? state.mutationParts : state.proseParts;
+}
+
+export function qualityFindingCount(result: BoundQualityEvaluation): number {
+  return result.event.targets.reduce((total, target) => total + target.findings.length, 0);
+}
+
+export function clearQualityCandidate(state: QualityRoundState): void {
+  state.proseParts = [];
+  state.mutationParts = [];
+  state.targets = [];
+}
+
+export function qualityDecisionCandidate(response: VesicleResponse): QualityDecisionCandidate {
+  return {
+    responseId: response.id,
+    content: response.content,
+    toolCalls: (response.toolCalls ?? []).map((call) => ({ ...call })),
+    ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
+    ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks.map((block) => ({ ...block })) } : {}),
+    ...(response.finishReason ? { finishReason: response.finishReason } : {}),
+    ...(response.usage ? { usage: response.usage } : {}),
+  };
+}
+
+export function durableQualityState(options: {
+  runtime?: QualityRuntimeContext;
+  producer: EngineId;
+  experimentalQuality?: ExperimentalQualityProfile;
+  state: QualityRoundState;
+  buffered: boolean;
+}): DurableQualityState | undefined {
+  const experimentalRewrite = options.experimentalQuality?.mode === "rewrite"
+    && (options.producer === "runtime" || options.producer === "stage");
+  if (!options.runtime || (!options.buffered && !experimentalRewrite)) return undefined;
+  const state = options.state;
+  return {
+    producer: options.producer,
+    packId: options.runtime.packId,
+    packVersion: options.runtime.packVersion,
+    manifestSha256: options.runtime.manifestSha256,
+    ruleVersion: options.runtime.ruleManifest.version,
+    ruleSourceHash: options.runtime.ruleManifest.sourceHash,
+    attempts: state.attempts,
+    rejectedHashes: [...state.rejectedHashes],
+    candidateParts: [...qualityDeliveryParts(state)],
+    targets: durableQualityTargets(state.targets),
+    ...(state.warningId ? { warningId: state.warningId } : {}),
+    ...(state.warningTargetIds ? { warningTargetIds: [...state.warningTargetIds] } : {}),
+    ...(state.candidate ? { candidate: state.candidate } : {}),
+    ...(state.experimentalJudge ? { experimentalJudge: state.experimentalJudge } : {}),
+  };
+}
+
+export function captureQualityArtifactResult(
+  state: QualityRoundState,
+  producer: EngineId,
+  result: Pick<ToolResult, "callId" | "ok" | "fileEvent">,
+): void {
+  const target = qualityArtifactTargetFromResult(producer, result);
+  if (target) upsertQualityArtifactTarget(state.targets, target);
+}
+
+export function retainBlockingArtifactTargets(
+  state: QualityRoundState,
+  result: BoundQualityEvaluation,
+): void {
+  if (!result.targetEvaluations) return;
+  const unresolvedIds = new Set(result.targetEvaluations
+    .filter((target) => target.evaluation.blockingFindings.length > 0 || target.warningReason)
+    .map((target) => target.target.id));
+  state.targets = state.targets.filter((target) => unresolvedIds.has(target.id));
+}

--- a/src/core/agent-loop/turn-loop.ts
+++ b/src/core/agent-loop/turn-loop.ts
@@ -8,14 +8,13 @@ import type { EngineProfile } from "../engine/profile";
 import { defaultPermissionRuntime } from "../permissions";
 import type { PermissionRuntimeOptions, ToolPermissionBroker } from "../permissions";
 import { getProcessManager, type ProcessManager } from "../process/manager";
-import { loadSessionSnapshot, type SessionStore } from "../session/store";
-import type { ToolCall, ToolDefinition } from "../tools";
+import type { SessionStore } from "../session/store";
+import type { ToolDefinition } from "../tools";
 import { createTurnAgentManager } from "./agent-manager";
 import { recordAssistantToolCalls } from "./assistant-recorder";
 import { resolveInteractionPause } from "./interaction-pause";
 import { completeProviderRound, emitAssistantResponse } from "./provider-round";
 import { executeToolRound } from "./tool-round-executor";
-import { failedToolResult, recordToolResult } from "./tool-result-recorder";
 import { planToolRound } from "./tool-round-planner";
 import { finalizeTurn } from "./turn-finalizer";
 import { clearFrozenInstructionBlocks, readFrozenInstructionBlocks } from "../instructions/instruction-context";
@@ -26,26 +25,31 @@ import type { ExperimentalQualityProfile } from "../../config/quality";
 import { persistedImageAttachments } from "../attachments/store";
 import { generationMetadata } from "./generation";
 import {
-  evaluateBoundQuality,
-  evaluateBoundQualityTargets,
-  durableQualityTargets,
   isQualityBoundary,
-  isQualityArtifactMutationCall,
   qualityCandidateParts,
   qualityModeForEngine,
-  qualityArtifactTargetFromResult,
-  readQualityArtifactTargets,
-  qualityRewriteFeedback,
-  observeBoundQualityWithJudge,
-  recordQualityEvent,
   shouldBufferQualityOutput,
   type BoundQualityEvaluation,
-  type QualityDecisionCandidate,
-  type QualityDecisionPoint,
   type QualityRewriteState,
-  type QualityWarning,
-  upsertQualityArtifactTarget,
 } from "../quality";
+import { evaluateQualityRoundBoundary } from "./quality-round-evaluation";
+import {
+  captureQualityArtifactResult,
+  clearQualityCandidate,
+  createQualityRoundState,
+  durableQualityState,
+  retainBlockingArtifactTargets,
+  type QualityRoundState,
+} from "./quality-round-state";
+import {
+  pauseForQualityDecision,
+  recordPendingQualityCheck,
+  recordPostMutationQualityRewrite,
+  recordQualityEvaluation,
+  recordQualityRewriteResult,
+  recordRejectedQualityRound,
+  type QualityRoundRecordingContext,
+} from "./quality-round-recording";
 
 const maxToolIterations = 40;
 const maxConsecutiveFailedTools = 4;
@@ -85,8 +89,7 @@ type LoopRuntime = {
   permission: PermissionRuntimeOptions;
   checkpoint?: FileCheckpointManager;
   checkpointMutationTail: Promise<void>;
-  quality: QualityRewriteState & { proseParts: string[]; mutationParts: string[]; targets: NonNullable<QualityRewriteState["targets"]> };
-  lastQuality?: { outcome: BoundQualityEvaluation["outcome"]; findingCount: number };
+  quality: QualityRoundState;
 };
 
 export async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
@@ -156,7 +159,7 @@ async function runLoopInternal(args: RunLoopArgs): Promise<RunPromptResult> {
     profile: args.profile,
     model: args.config.model,
     onEvent: args.onEvent,
-    quality: runtime.lastQuality,
+    quality: runtime.quality.lastResult,
   });
 }
 
@@ -187,28 +190,27 @@ async function advanceRound(
   });
   const toolCalls = response.toolCalls ?? [];
   if (toolCalls.length === 0) runtime.quality.proseParts.push(...qualityCandidateParts(response));
-  const quality = await evaluateQualityBoundary(args, runtime, response, "before-mutations");
+  const quality = await evaluateRoundQuality(args, runtime, response, "before-mutations");
   if (quality?.decision === "rewrite") {
-    retainBlockingArtifactTargets(runtime, quality);
-    await recordRejectedQualityRound(args, runtime, response, quality);
-    await recordQualityEvent(args.session, quality);
-    emitQualityStatus(args, runtime, quality);
+    retainBlockingArtifactTargets(runtime.quality, quality);
+    await recordRejectedQualityRound(qualityRecordingContext(args, runtime), response, quality);
+    await recordQualityRewriteResult(qualityRecordingContext(args, runtime), quality);
     runtime.quality.proseParts = [];
     runtime.quality.mutationParts = [];
     return { response, hadToolCalls: true, anyFailed: false };
   }
   if (quality?.action === "ask-user") {
-    retainBlockingArtifactTargets(runtime, quality);
+    retainBlockingArtifactTargets(runtime.quality, quality);
     return {
       response,
       hadToolCalls: toolCalls.length > 0,
       anyFailed: false,
-      pause: await pauseForQualityDecision(args, runtime, response, quality, "before-mutations", false),
+      pause: await pauseForQualityDecision(qualityRecordingContext(args, runtime), response, quality, "before-mutations", false),
     };
   }
   const buffered = shouldBufferQualityOutput(qualityModeForEngine(args.harness?.quality, args.profile.id));
   emitAssistantResponse(buffered && !isQualityBoundary(response) ? { ...response, content: "" } : response, args.onEvent);
-  if (quality) clearQualityCandidate(runtime);
+  if (quality) clearQualityCandidate(runtime.quality);
   if (toolCalls.length === 0) return { response, hadToolCalls: false, anyFailed: false };
 
   const parentMessagesBeforeToolCall = await recordAssistantToolCalls({
@@ -221,8 +223,7 @@ async function advanceRound(
   });
   const plan = planToolRound(toolCalls, args.tools, runtime.permission);
   await recordPendingQualityCheck(
-    args,
-    runtime,
+    qualityRecordingContext(args, runtime),
     response,
     plan.executableHostToolCalls,
   );
@@ -250,31 +251,29 @@ async function advanceRound(
     markCheckpointTainted: async () => { await runtime.checkpoint?.markTaintedByHostProcess(); },
   });
   for (const fileResult of execution.fileResults) {
-    const target = qualityArtifactTargetFromResult(args.profile.id, fileResult);
-    if (target) upsertQualityArtifactTarget(runtime.quality.targets, target);
+    captureQualityArtifactResult(runtime.quality, args.profile.id, fileResult);
   }
   const postMutationQuality = plan.permissionRequiredCalls.length === 0
-    ? await evaluateQualityBoundary(args, runtime, response, "after-mutations")
+    ? await evaluateRoundQuality(args, runtime, response, "after-mutations")
     : undefined;
   if (postMutationQuality?.decision === "rewrite") {
-    retainBlockingArtifactTargets(runtime, postMutationQuality);
-    await recordPostMutationQualityRewrite(args, runtime, response, plan.interactiveCalls, postMutationQuality);
-    await recordQualityEvent(args.session, postMutationQuality);
-    emitQualityStatus(args, runtime, postMutationQuality);
+    retainBlockingArtifactTargets(runtime.quality, postMutationQuality);
+    await recordPostMutationQualityRewrite(qualityRecordingContext(args, runtime), response, plan.interactiveCalls, postMutationQuality);
+    await recordQualityRewriteResult(qualityRecordingContext(args, runtime), postMutationQuality);
     runtime.quality.proseParts = [];
     runtime.quality.mutationParts = [];
     return { response, hadToolCalls: true, anyFailed: execution.anyFailed };
   }
   if (postMutationQuality?.action === "ask-user") {
-    retainBlockingArtifactTargets(runtime, postMutationQuality);
+    retainBlockingArtifactTargets(runtime.quality, postMutationQuality);
     return {
       response,
       hadToolCalls: true,
       anyFailed: execution.anyFailed,
-      pause: await pauseForQualityDecision(args, runtime, response, postMutationQuality, "after-mutations", true),
+      pause: await pauseForQualityDecision(qualityRecordingContext(args, runtime), response, postMutationQuality, "after-mutations", true),
     };
   }
-  if (postMutationQuality) clearQualityCandidate(runtime);
+  if (postMutationQuality) clearQualityCandidate(runtime.quality);
   if (execution.delegationPause) {
     return {
       response,
@@ -300,7 +299,7 @@ async function advanceRound(
     profile: args.profile,
     assistantContent: response.content,
     permission: runtime.permission,
-    qualityState: durableQualityState(args, runtime),
+    qualityState: persistedQualityState(args, runtime),
     onEvent: args.onEvent,
   });
   return {
@@ -311,436 +310,49 @@ async function advanceRound(
   };
 }
 
-function qualityDeliveryParts(runtime: LoopRuntime): string[] {
-  return runtime.quality.mutationParts.length > 0 ? runtime.quality.mutationParts : runtime.quality.proseParts;
-}
-
-function clearQualityCandidate(runtime: LoopRuntime): void {
-  runtime.quality.proseParts = [];
-  runtime.quality.mutationParts = [];
-  runtime.quality.targets = [];
-}
-
-async function recordPendingQualityCheck(
-  args: RunLoopArgs,
-  runtime: LoopRuntime,
-  response: VesicleResponse,
-  executableCalls: ToolCall[],
-): Promise<boolean> {
-  const quality = args.harness?.quality;
-  if (!quality
-    || !executableCalls.some((call) => isQualityArtifactMutationCall(call, args.profile.id))) return false;
-  if (!shouldBufferQualityOutput(qualityModeForEngine(quality, args.profile.id))) return false;
-  runtime.quality.candidate = qualityDecisionCandidate(response);
-  const pending = durableQualityState(args, runtime);
-  if (!pending) return false;
-  await args.session.append({
-    role: "system",
-    content: "",
-    metadata: {
-      kind: "quality-check-pending",
-      qualityRewrite: pending,
-    },
-  });
-  return true;
-}
-
-function durableQualityState(args: RunLoopArgs, runtime: LoopRuntime) {
-  const quality = args.harness?.quality;
-  const experimentalRewrite = args.experimentalQuality?.mode === "rewrite"
-    && (args.profile.id === "runtime" || args.profile.id === "stage");
-  if (!quality || (!shouldBufferQualityOutput(qualityModeForEngine(quality, args.profile.id)) && !experimentalRewrite)) return undefined;
-  return {
-    producer: args.profile.id,
-    packId: quality.packId,
-    packVersion: quality.packVersion,
-    manifestSha256: quality.manifestSha256,
-    ruleVersion: quality.ruleManifest.version,
-    ruleSourceHash: quality.ruleManifest.sourceHash,
-    attempts: runtime.quality.attempts,
-    rejectedHashes: [...runtime.quality.rejectedHashes],
-    candidateParts: [...qualityDeliveryParts(runtime)],
-    targets: durableQualityTargets(runtime.quality.targets),
-    ...(runtime.quality.warningId ? { warningId: runtime.quality.warningId } : {}),
-    ...(runtime.quality.warningTargetIds ? { warningTargetIds: [...runtime.quality.warningTargetIds] } : {}),
-    ...(runtime.quality.candidate ? { candidate: runtime.quality.candidate } : {}),
-    ...(runtime.quality.experimentalJudge ? { experimentalJudge: runtime.quality.experimentalJudge } : {}),
-  };
-}
-
-async function evaluateQualityBoundary(
+async function evaluateRoundQuality(
   args: RunLoopArgs,
   runtime: LoopRuntime,
   response: VesicleResponse,
   phase: "before-mutations" | "after-mutations",
 ): Promise<BoundQualityEvaluation | undefined> {
-  const qualityRuntime = args.harness?.quality;
-  if (!qualityRuntime || !isQualityBoundary(response)) return undefined;
-  const hasArtifactMutation = (response.toolCalls ?? [])
-    .some((call) => isQualityArtifactMutationCall(call, args.profile.id));
-  if ((phase === "before-mutations" && hasArtifactMutation)
-    || (phase === "after-mutations" && !hasArtifactMutation)) return undefined;
-  const mode = qualityModeForEngine(qualityRuntime, args.profile.id);
-  if (mode === "off" || mode === "analyze") return undefined;
-  args.onEvent?.({ type: "quality_status", phase: "checking", attempt: runtime.quality.attempts, findingCount: 0 });
-  const deterministic = runtime.quality.targets.length > 0
-    ? evaluateBoundQualityTargets({
-      runtime: qualityRuntime,
-      producer: args.profile.id,
-      mode,
-      targets: await readQualityArtifactTargets(args.rootDir, runtime.quality.targets),
-      attempt: runtime.quality.attempts,
-      state: runtime.quality,
-      usage: response.usage,
-    })
-    : evaluateBoundQuality({
-      runtime: qualityRuntime,
-      producer: args.profile.id,
-      mode,
-      content: qualityDeliveryParts(runtime).join("\n\n"),
-      attempt: runtime.quality.attempts,
-      state: runtime.quality,
-      usage: response.usage,
-    });
-  if (!deterministic) return undefined;
-  const result = await observeBoundQualityWithJudge({
-    result: deterministic,
-    runtime: qualityRuntime,
-    experimentalProfile: args.experimentalQuality,
+  const result = await evaluateQualityRoundBoundary({
+    rootDir: args.rootDir,
+    runtime: args.harness?.quality,
+    producer: args.profile.id,
+    experimentalQuality: args.experimentalQuality,
+    response,
+    phase,
     state: runtime.quality,
     signal: args.signal,
+    onEvent: args.onEvent,
   });
-  if (result.event.experimentalJudge) runtime.quality.experimentalJudge = result.event.experimentalJudge;
-  runtime.lastQuality = { outcome: result.outcome, findingCount: qualityFindingCount(result) };
-  if (result.action !== "ask-user" && result.event.targets.some((target) => target.warningReason)) {
-    await recordInconclusiveWarnings(args, runtime, result);
-  }
-  if (result.outcome !== "inconclusive") {
-    await resolveQualityWarnings(args, runtime, result);
-  }
-  if (result.decision !== "rewrite") {
-    await recordQualityEvent(args.session, result);
-    emitQualityStatus(args, runtime, result);
-  }
+  if (result) await recordQualityEvaluation(qualityRecordingContext(args, runtime), result);
   return result;
 }
 
-async function recordPostMutationQualityRewrite(
-  args: RunLoopArgs,
-  runtime: LoopRuntime,
-  response: VesicleResponse,
-  interactionCalls: ToolCall[],
-  result: BoundQualityEvaluation,
-): Promise<void> {
-  runtime.quality.candidate = qualityDecisionCandidate(response);
-  const persistedState = durableQualityState(args, runtime);
-  if (!persistedState) throw new Error("Quality rewrite state is unavailable under the active Guard.");
-  const feedback = qualityRewriteFeedback(result);
-  for (const call of interactionCalls) {
-    await recordToolResult({
-      result: failedToolResult(call.id, call.name, feedback),
-      messages: args.messages,
-      session: args.session,
-      metadata: {
-        kind: "quality-rewrite-feedback",
-        candidateHash: result.evaluation.candidateHash,
-        qualityRewrite: { ...persistedState, candidateParts: [] },
-      },
-      emitEvent: false,
-    });
-  }
-}
-
-async function pauseForQualityDecision(
-  args: RunLoopArgs,
-  runtime: LoopRuntime,
-  response: VesicleResponse,
-  result: BoundQualityEvaluation,
-  phase: QualityDecisionPoint["phase"],
-  candidateRecorded: boolean,
-): Promise<Extract<RunPromptResult, { kind: "needs_quality_decision" }>> {
-  const warningTargets = result.event.targets.filter((target) =>
-    target.status === "warning" && !target.warningReason
-  );
-  const warningId = runtime.quality.warningId ?? `quality-warning_${crypto.randomUUID()}`;
-  runtime.quality.warningId = warningId;
-  runtime.quality.warningTargetIds = warningTargets.map((target) => target.id);
-  runtime.quality.candidate = qualityDecisionCandidate(response);
-  const state = durableQualityState(args, runtime);
-  if (!state) throw new Error("Quality decision state is unavailable under the active Guard.");
-  state.candidateParts = [];
-  const warning: QualityWarning = {
-    id: warningId,
-    guard: "anti-ai-flavor",
-    reason: "exhausted",
-    producer: args.profile.id,
-    attempt: runtime.quality.attempts,
-    targets: warningTargets,
-  };
-  const request = {
-    id: warningId,
-    reason: "exhausted" as const,
-    producer: args.profile.id,
-    findingCount: warningTargets.reduce((count, target) => count + target.findingIds.length, 0),
-    targets: warningTargets.map((target) => ({
-      id: target.id,
-      ...(target.path ? { path: target.path } : {}),
-      findingIds: [...target.findingIds],
-    })),
-    canRetry: true,
-  };
-  const point: QualityDecisionPoint = {
-    request,
-    warning,
-    qualityState: state,
-    candidate: runtime.quality.candidate,
-    phase,
-    candidateRecorded,
-  };
-  await args.session.append({
-    role: "system",
-    content: qualityWarningText(warning),
-    metadata: {
-      kind: "quality-warning",
-      qualityWarning: warning,
-      qualityDecision: point,
-    },
-  });
+function qualityRecordingContext(args: RunLoopArgs, runtime: LoopRuntime): QualityRoundRecordingContext {
   return {
-    kind: "needs_quality_decision",
-    sessionId: args.session.sessionId,
-    sessionPath: args.session.sessionPath,
+    rootDir: args.rootDir,
+    runtime: args.harness?.quality,
+    experimentalQuality: args.experimentalQuality,
+    state: runtime.quality,
+    responseMessages: args.messages,
+    session: args.session,
     profile: args.profile,
-    decision: request,
-    assistantContent: response.content,
-    messages: args.messages,
+    model: args.config.model,
+    onEvent: args.onEvent,
   };
 }
 
-function qualityWarningText(warning: QualityWarning): string {
-  const paths = warning.targets.flatMap((target) => target.path ? [target.path] : []);
-  const findings = [...new Set(warning.targets.flatMap((target) => target.findingIds))];
-  return [
-    `Automatic quality revision is exhausted with ${findings.length} blocking finding${findings.length === 1 ? "" : "s"}.`,
-    ...(paths.length > 0 ? [`Targets: ${paths.join(", ")}.`] : []),
-    `Rules: ${findings.join(", ") || "unknown"}.`,
-    "The current version has not been confirmed clean. Choose another revision, use it with the warning, or stop.",
-  ].join(" ");
-}
-
-function qualityDecisionCandidate(response: VesicleResponse): QualityDecisionCandidate {
-  return {
-    responseId: response.id,
-    content: response.content,
-    toolCalls: (response.toolCalls ?? []).map((call) => ({ ...call })),
-    ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
-    ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks.map((block) => ({ ...block })) } : {}),
-    ...(response.finishReason ? { finishReason: response.finishReason } : {}),
-    ...(response.usage ? { usage: response.usage } : {}),
-  };
-}
-
-async function resolveQualityWarnings(
-  args: RunLoopArgs,
-  runtime: LoopRuntime,
-  result: BoundQualityEvaluation,
-): Promise<void> {
-  const snapshot = await loadSessionSnapshot(args.rootDir, args.session.sessionId, {
-    synthesizeDanglingToolResults: false,
+function persistedQualityState(args: RunLoopArgs, runtime: LoopRuntime) {
+  return durableQualityState({
+    runtime: args.harness?.quality,
+    producer: args.profile.id,
+    experimentalQuality: args.experimentalQuality,
+    state: runtime.quality,
+    buffered: shouldBufferQualityOutput(qualityModeForEngine(args.harness?.quality, args.profile.id)),
   });
-  const cleanTargetIds = new Set(result.event.targets
-    .filter((target) => target.status === "clean" || target.status === "findings")
-    .map((target) => target.id));
-  for (const warning of snapshot.qualityWarnings) {
-    const targetIds = warning.targets
-      .filter((target) => cleanTargetIds.has(target.id)
-        || (warning.id === runtime.quality.warningId
-          && target.kind === "assistant-response"
-          && (result.outcome === "clean" || result.outcome === "findings")))
-      .map((target) => target.id);
-    if (targetIds.length === 0) continue;
-    await args.session.append({
-      role: "system",
-      content: "",
-      metadata: {
-        kind: "quality-resolution",
-        qualityResolution: {
-          warningId: warning.id,
-          resolution: "revised-clean",
-          targetIds,
-        },
-      },
-    });
-  }
-}
-
-async function recordInconclusiveWarnings(
-  args: RunLoopArgs,
-  runtime: LoopRuntime,
-  result: BoundQualityEvaluation,
-): Promise<void> {
-  const snapshot = await loadSessionSnapshot(args.rootDir, args.session.sessionId, {
-    synthesizeDanglingToolResults: false,
-  });
-  let reusedPendingWarning = false;
-  for (const reason of [
-    "target-unreadable", "target-oversize", "detector-budget-exhausted",
-    "judge-invalid", "judge-timeout", "judge-unavailable",
-  ] as const) {
-    const existing = new Set(snapshot.qualityWarnings
-      .filter((warning) => warning.id !== runtime.quality.warningId && warning.reason === reason)
-      .flatMap((warning) => warning.targets.map((target) => target.id)));
-    const targets = result.event.targets.filter((target) =>
-      target.warningReason === reason
-      && !existing.has(target.id)
-    );
-    if (targets.length === 0) continue;
-    const warning: QualityWarning = {
-      id: runtime.quality.warningId && !reusedPendingWarning
-        ? runtime.quality.warningId
-        : `quality-warning_${crypto.randomUUID()}`,
-      guard: "anti-ai-flavor",
-      reason,
-      producer: args.profile.id,
-      attempt: result.event.attempt,
-      targets,
-    };
-    await args.session.append({
-      role: "system",
-      content: `${targets.length} quality target${targets.length === 1 ? " was" : "s were"} ${reason === "target-oversize"
-        ? "over the quality check size limit"
-        : reason === "detector-budget-exhausted"
-          ? "over the deterministic check work limit"
-          : reason === "judge-invalid"
-            ? "returned an invalid Semantic Judge result"
-            : reason === "judge-timeout"
-              ? "not checked before the Semantic Judge timeout"
-              : reason === "judge-unavailable"
-                ? "not checked because the Semantic Judge provider was unavailable"
-          : "not readable as a guarded UTF-8 file"}. The content was delivered without a clean quality result.`,
-      metadata: { kind: "quality-warning", qualityWarning: warning },
-    });
-    if (warning.id === runtime.quality.warningId) reusedPendingWarning = true;
-  }
-  if (reusedPendingWarning && runtime.quality.warningId) {
-    await args.session.append({
-      role: "system",
-      content: "",
-      metadata: { kind: "quality-check-cleared", warningId: runtime.quality.warningId },
-    });
-  } else if (runtime.quality.warningId) {
-    const pendingWarning = snapshot.qualityWarnings.find((warning) => warning.id === runtime.quality.warningId);
-    const unresolvedTargetIds = new Set(result.event.targets
-      .filter((target) => target.status === "warning")
-      .map((target) => target.id));
-    const resolvedTargetIds = pendingWarning?.targets
-      .filter((target) => !unresolvedTargetIds.has(target.id))
-      .map((target) => target.id) ?? [];
-    await args.session.appendMany([
-      ...(resolvedTargetIds.length > 0 ? [{
-        role: "system" as const,
-        content: "",
-        metadata: {
-          kind: "quality-resolution",
-          qualityResolution: {
-            warningId: runtime.quality.warningId,
-            resolution: "revised-clean",
-            targetIds: resolvedTargetIds,
-          },
-        },
-      }] : []),
-      {
-        role: "system",
-        content: "",
-        metadata: { kind: "quality-check-cleared", warningId: runtime.quality.warningId },
-      },
-    ]);
-  }
-}
-
-function emitQualityStatus(args: RunLoopArgs, runtime: LoopRuntime, result: BoundQualityEvaluation): void {
-  args.onEvent?.({
-    type: "quality_status",
-    phase: result.action === "rewrite" ? "rewriting"
-      : result.action === "ask-user" ? "exhausted"
-        : result.outcome === "inconclusive" ? "inconclusive"
-          : result.action === "observe" ? "observed"
-          : result.outcome === "findings" ? "findings"
-            : "clean",
-    attempt: runtime.quality.attempts,
-    findingCount: qualityFindingCount(result),
-    findings: result.event.targets.flatMap((target) => target.findings.map((finding) => ({
-      ...finding,
-      ...(target.path ? { targetPath: target.path } : {}),
-    }))).slice(0, 8),
-    warningReasons: [...new Set(result.event.targets.flatMap((target) =>
-      target.warningReason ? [target.warningReason] : []
-    ))],
-  });
-}
-
-function qualityFindingCount(result: BoundQualityEvaluation): number {
-  return result.event.targets.reduce((total, target) => total + target.findings.length, 0);
-}
-
-async function recordRejectedQualityRound(
-  args: RunLoopArgs,
-  runtime: LoopRuntime,
-  response: VesicleResponse,
-  result: BoundQualityEvaluation,
-): Promise<void> {
-  const calls = response.toolCalls ?? [];
-  const persistedState = durableQualityState(args, runtime);
-  if (!persistedState) throw new Error("Quality rewrite state is unavailable under the active Guard.");
-  const rewriteState = {
-    ...persistedState,
-    candidateParts: [],
-    candidate: qualityDecisionCandidate(response),
-  };
-  if (calls.length > 0) {
-    const feedback = qualityRewriteFeedback(result);
-    const assistantMessage: VesicleMessage = { role: "assistant", content: "", toolCalls: calls };
-    const toolMessages: VesicleMessage[] = calls.map((call) => ({
-      role: "tool",
-      toolCallId: call.id,
-      content: JSON.stringify({ ok: false, result: feedback }),
-    }));
-    await args.session.appendMany([
-      {
-        role: "assistant",
-        content: "",
-        metadata: {
-          kind: "quality-rejected-candidate",
-          engine: args.profile.id,
-          model: args.config.model,
-          providerResponseId: response.id,
-          candidateHash: result.evaluation.candidateHash,
-          toolCalls: calls,
-        },
-      },
-      ...calls.map((call) => ({
-        role: "tool" as const,
-        content: JSON.stringify({ ok: false, result: feedback }),
-        metadata: {
-          name: call.name,
-          ok: false,
-          toolCallId: call.id,
-          kind: "quality-rewrite-feedback",
-          candidateHash: result.evaluation.candidateHash,
-          qualityRewrite: rewriteState,
-        },
-      })),
-    ]);
-    args.messages.push(assistantMessage, ...toolMessages);
-    return;
-  }
-  const feedback = qualityRewriteFeedback(result, true);
-  args.messages.push({ role: "user", content: feedback });
-  await args.session.appendMany([{
-    role: "user",
-    content: feedback,
-    metadata: { kind: "quality-rewrite-feedback", candidateHash: result.evaluation.candidateHash, qualityRewrite: rewriteState },
-  }]);
 }
 
 function createLoopRuntime(args: RunLoopArgs): LoopRuntime {
@@ -750,30 +362,8 @@ function createLoopRuntime(args: RunLoopArgs): LoopRuntime {
     permission: args.permission ?? defaultPermissionRuntime,
     checkpoint: args.checkpoint,
     checkpointMutationTail: Promise.resolve(),
-    quality: {
-      attempts: args.qualityState?.attempts ?? 0,
-      rejectedHashes: new Set(args.qualityState?.rejectedHashes ?? []),
-      proseParts: [],
-      mutationParts: [...(args.qualityState?.candidateParts ?? [])],
-      targets: (args.qualityState?.targets ?? []).map((target) => ({
-        ...target,
-        mutationCallIds: [...target.mutationCallIds],
-        rejectedHashes: new Set(target.rejectedHashes),
-      })),
-      warningId: args.qualityState?.warningId,
-      warningTargetIds: args.qualityState?.warningTargetIds ? [...args.qualityState.warningTargetIds] : undefined,
-      candidate: args.qualityState?.candidate,
-      experimentalJudge: args.qualityState?.experimentalJudge,
-    },
+    quality: createQualityRoundState(args.qualityState),
   };
-}
-
-function retainBlockingArtifactTargets(runtime: LoopRuntime, result: BoundQualityEvaluation): void {
-  if (!result.targetEvaluations) return;
-  const unresolvedIds = new Set(result.targetEvaluations
-    .filter((target) => target.evaluation.blockingFindings.length > 0 || target.warningReason)
-    .map((target) => target.target.id));
-  runtime.quality.targets = runtime.quality.targets.filter((target) => unresolvedIds.has(target.id));
 }
 
 function trackCheckpointMutation(runtime: LoopRuntime, paths: string[]): Promise<void> {


### PR DESCRIPTION
## Summary

- extract Quality round candidate, artifact target, and durable-state projection from the provider/tool loop
- isolate before/after mutation evaluation and deterministic/Semantic Judge composition
- isolate pending, rewrite, warning, resolution, and status recording while preserving session order
- keep `turn-loop.ts` focused on provider round, optional Quality action, tool round, interaction pause, and finalization

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test tests/integration/quality tests/integration/agent-loop tests/integration/session/quality-recovery.test.ts` (142 pass)
- `bun test` (877 pass, 5 Windows-only skips)
- `bun run doctor`
- `git diff --check`

## Risk and contracts

No Quality policy, session schema, Harness identity, provider protocol, or user-visible behavior changes. Existing integration coverage protects before/after mutation ordering, artifact post-images, permission continuations, rewrite bounds, warning/resolution durability, and interrupted recovery.