### PR TITLE
refactor(tui): separate startup and stage activation

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -53,13 +53,14 @@ import { createSessionPreferencesController } from "./session-preferences-contro
 import { createAgentCommand } from "./agent-command";
 import { useInputRouting } from "./input-routing";
 import { createQualityPickerController } from "./quality-picker-controller";
-import { startStageSession } from "../core/stage/bootstrap";
 import { artifactFocusAction, artifactFocusPath, initialArtifactFocusPath } from "./artifact-focus";
 import { ArtifactFocusPreview } from "./widgets/ArtifactFocusPreview";
 import { createInputQueue } from "./input-queue";
 import { routeCommandSubmission } from "./command-scheduler";
 import { createSideQuestionController } from "./side-question-controller";
 import { createQueuedWorkController } from "./queued-work-controller";
+import { createStageSessionController } from "./stage-session-controller";
+import { createStartupController } from "./startup-controller";
 import { SideQuestionOverlay } from "./views/SideQuestionOverlay";
 import { copyTextToClipboard } from "./clipboard";
 
@@ -533,7 +534,6 @@ export function App(props: AppProps = {}) {
       await resumeSession(target);
     },
     compactSession: (instructions) => sessionActions.compactSession(instructions),
-    initProject: (notes) => sessionActions.initProject(notes),
     executeLocalCommand: (prompt) => executeCommand(prompt, commandContext, builtinCommands),
     recordPromptHistory,
     applyComposerState,
@@ -675,6 +675,47 @@ export function App(props: AppProps = {}) {
     handleSessionPickerKey,
     resetRewindState,
   } = sessionActions;
+  const startupController = createStartupController({
+    dangerouslySkipPermissions: props.dangerouslySkipPermissions === true,
+    initialResume: props.initialResume === true,
+    refreshArtifacts,
+    recoverInterruptedAgents: () => agentStore.recoverInterrupted(),
+    notifyContinuation: (id) => continuationScheduler.notify(id),
+    refreshMcpStatus,
+    loadPermissionSettings: loadPermissionSettingsOnce,
+    loadProviderConfig: loadProviderConfigOnce,
+    setProviderConfigReady,
+    listSessions,
+    setResumableSessions,
+    setSessionPicker,
+    setMessages,
+    setStatus,
+    reportError,
+  });
+  const stageSessionController = createStageSessionController({
+    rootDir: process.cwd(),
+    activeProvider,
+    activeModel,
+    permissionMode,
+    reasoningTier: thinkingTier,
+    clearQueuedInputs,
+    setSessionId,
+    setSessionPath,
+    setActiveEngine,
+    setConversation,
+    setOutput,
+    setLastTurnUsage,
+    setSessionUsage,
+    setNextSessionParent,
+    setPendingGate,
+    setPendingEngineSwitch,
+    setPendingUserQuestion,
+    setPendingPermission,
+    setPendingQualityDecision,
+    setMessages,
+    setStatus,
+    recordActivity,
+  });
   createEffect(() => {
     const id = sessionId();
     const ready = !restoringSession() && !busy() && !pendingGate() && !pendingEngineSwitch() && !pendingUserQuestion() && !pendingPermission() && !pendingQualityDecision() && !pendingChildPermission();
@@ -709,49 +750,8 @@ export function App(props: AppProps = {}) {
   });
   const composerPopupMaxRows = createMemo(() => Math.min(8, Math.max(1, layout().bottomHeight - 4)));
 
-  // On mount, detect existing sessions so the welcome line can offer resume.
   onMount(() => {
-    void refreshArtifacts();
-    void agentStore.recoverInterrupted().then((recovered) => {
-      if (recovered.length === 0) return;
-      setMessages((current) => [...current, {
-        role: "system",
-        content: `Recovered ${recovered.length} interrupted SubAgent${recovered.length === 1 ? "" : "s"}; foreground tool calls were closed and background failures will be delivered when their parent sessions resume.`,
-      }]);
-      for (const agent of recovered.filter((entry) => entry.mode === "background")) {
-        void continuationScheduler.notify(agent.parentSessionId).catch(reportError);
-      }
-    }).catch(reportError);
-    void refreshMcpStatus().catch(reportError);
-    if (!props.dangerouslySkipPermissions) void loadPermissionSettingsOnce().catch(reportError);
-    void loadProviderConfigOnce().catch((error) => {
-      setProviderConfigReady(true);
-      reportError(error);
-    });
-    void listSessions().then((sessions) => {
-      setResumableSessions(sessions);
-      // `--resume`/`-r` routes to the same host-owned picker as `/resume` with
-      // no argument: show the list, or report no sessions. Opening the picker
-      // is state-only and never starts a provider turn on its own.
-      if (props.initialResume) {
-        if (sessions.length > 0) {
-          setSessionPicker({ sessions, selected: 0 });
-          setStatus("choose a session to resume");
-        } else {
-          setMessages((prev) => [...prev, { role: "system", content: "No existing sessions found." }]);
-        }
-        return;
-      }
-      if (sessions.length > 0) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            role: "system",
-            content: `Found ${sessions.length} existing session${sessions.length > 1 ? "s" : ""}. Type /resume to list and continue one, or just type a new prompt to start fresh.`,
-          },
-        ]);
-      }
-    });
+    void startupController.start();
   });
 
   useInputRouting({
@@ -855,39 +855,7 @@ export function App(props: AppProps = {}) {
     openRewindPicker: rewindController.open,
     resetRewindState,
     agentCommand,
-    startStage: async (characterPath, scenarioPath, commandEcho) => {
-      const started = await startStageSession({
-        rootDir: process.cwd(),
-        characterPath,
-        scenarioPath,
-        provider: activeProvider(),
-        providerId: activeProvider(),
-        model: activeModel(),
-        permissionMode: permissionMode(),
-        reasoningTier: thinkingTier(),
-      });
-      clearQueuedInputs();
-      setSessionId(started.sessionId);
-      setSessionPath(started.sessionPath);
-      setActiveEngine("stage");
-      setConversation(started.messages);
-      setOutput(started.opening);
-      setLastTurnUsage(undefined);
-      setSessionUsage({ inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, contextInputTokens: 0 });
-      setNextSessionParent(null);
-      setPendingGate(null);
-      setPendingEngineSwitch(null);
-      setPendingUserQuestion(null);
-      setPendingPermission(null);
-      setPendingQualityDecision(null);
-      setMessages([
-        { role: "user", content: commandEcho },
-        ...started.warnings.map((warning) => ({ role: "system" as const, content: `Stage card warning: ${warning}` })),
-        { id: started.openingRecordUuid, role: "assistant", content: started.opening, kind: "stage-bootstrap-opening", engine: "stage" },
-      ]);
-      setStatus("Stage session ready");
-      recordActivity({ kind: "system", text: `started Stage session ${started.sessionId}` });
-    },
+    startStage: stageSessionController.start,
     openModelPicker,
     openQualityPicker,
     openSideQuestion: (args) => sideQuestionController.openSideQuestion(args),

--- a/src/tui/stage-session-controller.ts
+++ b/src/tui/stage-session-controller.ts
@@ -1,0 +1,83 @@
+import { startStageSession, type StartStageSessionOptions, type StartedStageSession } from "../core/stage/bootstrap";
+import type { EngineId } from "../core/engine/profile";
+import type { PermissionMode } from "../core/permissions";
+import type { ReasoningTier, VesicleMessage } from "../providers/shared/types";
+import type { PendingEngineSwitchState, PendingGateState, PendingPermissionState, PendingQualityDecisionState, PendingUserQuestionState } from "./decision-interaction";
+import type { ActivityEntry, Message } from "./types";
+import type { TokenUsageSummary } from "./telemetry";
+
+type StageSessionControllerOptions = {
+  rootDir: string;
+  activeProvider: () => string;
+  activeModel: () => string;
+  permissionMode: () => PermissionMode;
+  reasoningTier: () => ReasoningTier | undefined;
+  clearQueuedInputs: () => void;
+  setSessionId: (sessionId: string) => void;
+  setSessionPath: (sessionPath: string) => void;
+  setActiveEngine: (engine: EngineId) => void;
+  setConversation: (messages: VesicleMessage[]) => void;
+  setOutput: (output: string) => void;
+  setLastTurnUsage: (usage: TokenUsageSummary | undefined) => void;
+  setSessionUsage: (usage: TokenUsageSummary) => void;
+  setNextSessionParent: (parent: null) => void;
+  setPendingGate: (pending: PendingGateState | null) => void;
+  setPendingEngineSwitch: (pending: PendingEngineSwitchState | null) => void;
+  setPendingUserQuestion: (pending: PendingUserQuestionState | null) => void;
+  setPendingPermission: (pending: PendingPermissionState | null) => void;
+  setPendingQualityDecision: (pending: PendingQualityDecisionState | null) => void;
+  setMessages: (messages: Message[]) => void;
+  setStatus: (status: string) => void;
+  recordActivity: (entry: ActivityEntry) => void;
+  startSession?: (options: StartStageSessionOptions) => Promise<StartedStageSession>;
+};
+
+const emptyUsage: TokenUsageSummary = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cachedInputTokens: 0,
+  contextInputTokens: 0,
+};
+
+export function createStageSessionController(options: StageSessionControllerOptions) {
+  async function start(characterPath: string, scenarioPath: string, commandEcho: string): Promise<void> {
+    const provider = options.activeProvider();
+    const started = await (options.startSession ?? startStageSession)({
+      rootDir: options.rootDir,
+      characterPath,
+      scenarioPath,
+      provider,
+      providerId: provider,
+      model: options.activeModel(),
+      permissionMode: options.permissionMode(),
+      reasoningTier: options.reasoningTier(),
+    });
+    applyStartedSession(started, commandEcho);
+  }
+
+  function applyStartedSession(started: StartedStageSession, commandEcho: string): void {
+    options.clearQueuedInputs();
+    options.setSessionId(started.sessionId);
+    options.setSessionPath(started.sessionPath);
+    options.setActiveEngine("stage");
+    options.setConversation(started.messages);
+    options.setOutput(started.opening);
+    options.setLastTurnUsage(undefined);
+    options.setSessionUsage(emptyUsage);
+    options.setNextSessionParent(null);
+    options.setPendingGate(null);
+    options.setPendingEngineSwitch(null);
+    options.setPendingUserQuestion(null);
+    options.setPendingPermission(null);
+    options.setPendingQualityDecision(null);
+    options.setMessages([
+      { role: "user", content: commandEcho },
+      ...started.warnings.map((warning) => ({ role: "system" as const, content: `Stage card warning: ${warning}` })),
+      { id: started.openingRecordUuid, role: "assistant", content: started.opening, kind: "stage-bootstrap-opening", engine: "stage" },
+    ]);
+    options.setStatus("Stage session ready");
+    options.recordActivity({ kind: "system", text: `started Stage session ${started.sessionId}` });
+  }
+
+  return { start };
+}

--- a/src/tui/stage-session-controller.ts
+++ b/src/tui/stage-session-controller.ts
@@ -32,13 +32,6 @@ type StageSessionControllerOptions = {
   startSession?: (options: StartStageSessionOptions) => Promise<StartedStageSession>;
 };
 
-const emptyUsage: TokenUsageSummary = {
-  inputTokens: 0,
-  outputTokens: 0,
-  cachedInputTokens: 0,
-  contextInputTokens: 0,
-};
-
 export function createStageSessionController(options: StageSessionControllerOptions) {
   async function start(characterPath: string, scenarioPath: string, commandEcho: string): Promise<void> {
     const provider = options.activeProvider();
@@ -63,7 +56,7 @@ export function createStageSessionController(options: StageSessionControllerOpti
     options.setConversation(started.messages);
     options.setOutput(started.opening);
     options.setLastTurnUsage(undefined);
-    options.setSessionUsage(emptyUsage);
+    options.setSessionUsage({ inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, contextInputTokens: 0 });
     options.setNextSessionParent(null);
     options.setPendingGate(null);
     options.setPendingEngineSwitch(null);

--- a/src/tui/startup-controller.ts
+++ b/src/tui/startup-controller.ts
@@ -41,9 +41,9 @@ export function createStartupController(options: StartupControllerOptions) {
         role: "system",
         content: `Recovered ${recovered.length} interrupted SubAgent${recovered.length === 1 ? "" : "s"}; foreground tool calls were closed and background failures will be delivered when their parent sessions resume.`,
       }]);
-      for (const agent of recovered.filter((entry) => entry.mode === "background")) {
-        void options.notifyContinuation(agent.parentSessionId).catch(options.reportError);
-      }
+      await Promise.all(recovered
+        .filter((entry) => entry.mode === "background")
+        .map((agent) => options.notifyContinuation(agent.parentSessionId).catch(options.reportError)));
     } catch (error) {
       options.reportError(error);
     }

--- a/src/tui/startup-controller.ts
+++ b/src/tui/startup-controller.ts
@@ -1,0 +1,94 @@
+import type { AgentMetadata } from "../core/agents/types";
+import type { SessionSummary } from "../core/session/store";
+import type { Message, SessionPickerState } from "./types";
+
+type StartupControllerOptions = {
+  dangerouslySkipPermissions: boolean;
+  initialResume: boolean;
+  refreshArtifacts: () => Promise<unknown>;
+  recoverInterruptedAgents: () => Promise<AgentMetadata[]>;
+  notifyContinuation: (sessionId: string) => Promise<void>;
+  refreshMcpStatus: () => Promise<void>;
+  loadPermissionSettings: () => Promise<void>;
+  loadProviderConfig: () => Promise<void>;
+  setProviderConfigReady: (ready: boolean) => void;
+  listSessions: () => Promise<SessionSummary[]>;
+  setResumableSessions: (sessions: SessionSummary[]) => void;
+  setSessionPicker: (state: SessionPickerState | null) => void;
+  setMessages: (value: Message[] | ((current: Message[]) => Message[])) => void;
+  setStatus: (status: string) => void;
+  reportError: (error: unknown) => void;
+};
+
+export function createStartupController(options: StartupControllerOptions) {
+  async function start(): Promise<void> {
+    const tasks: Promise<unknown>[] = [
+      reportFailure(options.refreshArtifacts()),
+      recoverInterruptedAgents(),
+      reportFailure(options.refreshMcpStatus()),
+      loadProviderConfig(),
+      discoverSessions(),
+    ];
+    if (!options.dangerouslySkipPermissions) tasks.push(reportFailure(options.loadPermissionSettings()));
+    await Promise.all(tasks);
+  }
+
+  async function recoverInterruptedAgents(): Promise<void> {
+    try {
+      const recovered = await options.recoverInterruptedAgents();
+      if (recovered.length === 0) return;
+      options.setMessages((current) => [...current, {
+        role: "system",
+        content: `Recovered ${recovered.length} interrupted SubAgent${recovered.length === 1 ? "" : "s"}; foreground tool calls were closed and background failures will be delivered when their parent sessions resume.`,
+      }]);
+      for (const agent of recovered.filter((entry) => entry.mode === "background")) {
+        void options.notifyContinuation(agent.parentSessionId).catch(options.reportError);
+      }
+    } catch (error) {
+      options.reportError(error);
+    }
+  }
+
+  async function loadProviderConfig(): Promise<void> {
+    try {
+      await options.loadProviderConfig();
+    } catch (error) {
+      options.setProviderConfigReady(true);
+      options.reportError(error);
+    }
+  }
+
+  async function discoverSessions(): Promise<void> {
+    try {
+      const sessions = await options.listSessions();
+      options.setResumableSessions(sessions);
+      if (options.initialResume) {
+        if (sessions.length > 0) {
+          options.setSessionPicker({ sessions, selected: 0 });
+          options.setStatus("choose a session to resume");
+        } else {
+          options.setMessages((current) => [...current, { role: "system", content: "No existing sessions found." }]);
+        }
+        return;
+      }
+      if (sessions.length > 0) {
+        options.setMessages((current) => [...current, {
+          role: "system",
+          content: `Found ${sessions.length} existing session${sessions.length > 1 ? "s" : ""}. Type /resume to list and continue one, or just type a new prompt to start fresh.`,
+        }]);
+      }
+    } catch (error) {
+      options.reportError(error);
+    }
+  }
+
+  async function reportFailure(operation: Promise<unknown>): Promise<void> {
+    try {
+      await operation;
+    } catch (error) {
+      options.reportError(error);
+    }
+  }
+
+  return { start };
+}

--- a/src/tui/turn-controller-options.ts
+++ b/src/tui/turn-controller-options.ts
@@ -90,7 +90,6 @@ export type TurnControllerOptions = {
   refreshQualityWarnings: (sessionId?: string) => Promise<unknown>;
   resumeQualitySession: (sessionId: string) => Promise<void>;
   compactSession: (instructions?: string) => Promise<{ summary: string; messagesSummarized: number }>;
-  initProject: (notes?: string) => Promise<{ path: string; overwritten: boolean }>;
   executeLocalCommand: (prompt: string) => Promise<void>;
   recordPromptHistory: (value: string, elements: ComposerElement[], images: VesicleImageAttachment[]) => void;
   applyComposerState: (state: ComposerState) => void;

--- a/tests/unit/tui/tui-stage-session-controller.test.ts
+++ b/tests/unit/tui/tui-stage-session-controller.test.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test";
+import type { StartedStageSession } from "../../../src/core/stage/bootstrap";
+import type { VesicleMessage } from "../../../src/providers/shared/types";
+import { createStageSessionController } from "../../../src/tui/stage-session-controller";
+import type { ActivityEntry, Message } from "../../../src/tui/types";
+
+test("Stage startup applies the durable bootstrap result to host session state", async () => {
+  const started: StartedStageSession = {
+    sessionId: "stage-session",
+    sessionPath: "/tmp/stage-session.jsonl",
+    systemPrompt: "system",
+    opening: "Stage opening",
+    openingRecordUuid: "opening-record",
+    messages: [{ role: "assistant", content: "Stage opening", kind: "stage-bootstrap-opening" }],
+    bootstrap: {} as StartedStageSession["bootstrap"],
+    warnings: ["scenario warning"],
+  };
+  const state = {
+    queueCleared: false,
+    sessionId: "",
+    sessionPath: "",
+    engine: "etl",
+    conversation: [] as VesicleMessage[],
+    output: "old",
+    lastTurnUsage: { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, contextInputTokens: 1 } as any,
+    sessionUsage: undefined as any,
+    nextParent: { uuid: "parent" } as { uuid: string } | null,
+    pendingClears: 0,
+    messages: [] as Message[],
+    status: "",
+    activity: [] as ActivityEntry[],
+  };
+  let bootstrapOptions: unknown;
+  const controller = createStageSessionController({
+    rootDir: "/project",
+    activeProvider: () => "provider-a",
+    activeModel: () => "model-a",
+    permissionMode: () => "MOMENTUM",
+    reasoningTier: () => "high",
+    clearQueuedInputs: () => { state.queueCleared = true; },
+    setSessionId: (value) => { state.sessionId = value; },
+    setSessionPath: (value) => { state.sessionPath = value; },
+    setActiveEngine: (value) => { state.engine = value; },
+    setConversation: (value) => { state.conversation = value; },
+    setOutput: (value) => { state.output = value; },
+    setLastTurnUsage: (value) => { state.lastTurnUsage = value; },
+    setSessionUsage: (value) => { state.sessionUsage = value; },
+    setNextSessionParent: (value) => { state.nextParent = value; },
+    setPendingGate: () => { state.pendingClears += 1; },
+    setPendingEngineSwitch: () => { state.pendingClears += 1; },
+    setPendingUserQuestion: () => { state.pendingClears += 1; },
+    setPendingPermission: () => { state.pendingClears += 1; },
+    setPendingQualityDecision: () => { state.pendingClears += 1; },
+    setMessages: (value) => { state.messages = value; },
+    setStatus: (value) => { state.status = value; },
+    recordActivity: (value) => { state.activity.push(value); },
+    startSession: async (options) => { bootstrapOptions = options; return started; },
+  });
+
+  await controller.start("workspace/character.md", "workspace/scenario.md", "/stage workspace/character.md workspace/scenario.md");
+
+  expect(bootstrapOptions).toEqual({
+    rootDir: "/project",
+    characterPath: "workspace/character.md",
+    scenarioPath: "workspace/scenario.md",
+    provider: "provider-a",
+    providerId: "provider-a",
+    model: "model-a",
+    permissionMode: "MOMENTUM",
+    reasoningTier: "high",
+  });
+  expect(state.queueCleared).toBe(true);
+  expect(state.sessionId).toBe("stage-session");
+  expect(state.sessionPath).toBe("/tmp/stage-session.jsonl");
+  expect(state.engine).toBe("stage");
+  expect(state.conversation).toEqual(started.messages);
+  expect(state.output).toBe("Stage opening");
+  expect(state.lastTurnUsage).toBeUndefined();
+  expect(state.sessionUsage).toEqual({ inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, contextInputTokens: 0 });
+  expect(state.nextParent).toBeNull();
+  expect(state.pendingClears).toBe(5);
+  expect(state.messages.map((message) => [message.role, message.content])).toEqual([
+    ["user", "/stage workspace/character.md workspace/scenario.md"],
+    ["system", "Stage card warning: scenario warning"],
+    ["assistant", "Stage opening"],
+  ]);
+  expect(state.status).toBe("Stage session ready");
+  expect(state.activity).toEqual([{ kind: "system", text: "started Stage session stage-session" }]);
+});

--- a/tests/unit/tui/tui-startup-controller.test.ts
+++ b/tests/unit/tui/tui-startup-controller.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import type { AgentMetadata } from "../../../src/core/agents/types";
+import type { SessionSummary } from "../../../src/core/session/store";
+import { createStartupController } from "../../../src/tui/startup-controller";
+import type { Message, SessionPickerState } from "../../../src/tui/types";
+
+test("startup coordinates recovery and opens the requested resume picker", async () => {
+  const session: SessionSummary = {
+    sessionId: "session-1",
+    startedAt: "2026-07-24T00:00:00.000Z",
+    updatedAt: "2026-07-24T00:01:00.000Z",
+    recordCount: 2,
+    preview: "existing work",
+  };
+  const recovered = [
+    recoveredAgent("background", "parent-background"),
+    recoveredAgent("foreground", "parent-foreground"),
+  ];
+  const calls: string[] = [];
+  const notified: string[] = [];
+  const errors: unknown[] = [];
+  let messages: Message[] = [];
+  let resumableSessions: SessionSummary[] = [];
+  let picker: SessionPickerState | null = null;
+  let status = "loading";
+  let providerReady = false;
+  const controller = createStartupController({
+    dangerouslySkipPermissions: true,
+    initialResume: true,
+    refreshArtifacts: async () => { calls.push("artifacts"); },
+    recoverInterruptedAgents: async () => recovered,
+    notifyContinuation: async (sessionId) => { notified.push(sessionId); },
+    refreshMcpStatus: async () => { calls.push("mcp"); },
+    loadPermissionSettings: async () => { calls.push("permissions"); },
+    loadProviderConfig: async () => { calls.push("provider"); throw new Error("provider failed"); },
+    setProviderConfigReady: (ready) => { providerReady = ready; },
+    listSessions: async () => [session],
+    setResumableSessions: (sessions) => { resumableSessions = sessions; },
+    setSessionPicker: (state) => { picker = state; },
+    setMessages: (value) => { messages = typeof value === "function" ? value(messages) : value; },
+    setStatus: (value) => { status = value; },
+    reportError: (error) => { errors.push(error); },
+  });
+
+  await controller.start();
+  await Promise.resolve();
+
+  expect(calls.sort()).toEqual(["artifacts", "mcp", "provider"]);
+  expect(notified).toEqual(["parent-background"]);
+  expect(messages.map((message) => message.content)).toEqual([
+    "Recovered 2 interrupted SubAgents; foreground tool calls were closed and background failures will be delivered when their parent sessions resume.",
+  ]);
+  expect(resumableSessions).toEqual([session]);
+  expect(picker as unknown).toEqual({ sessions: [session], selected: 0 });
+  expect(status).toBe("choose a session to resume");
+  expect(providerReady).toBe(true);
+  expect(errors).toHaveLength(1);
+});
+
+function recoveredAgent(mode: "background" | "foreground", parentSessionId: string): AgentMetadata {
+  return {
+    runId: `run-${mode}`,
+    handle: `explore-${mode}`,
+    profileId: "explore",
+    description: "Recovered agent",
+    prompt: "inspect",
+    mode,
+    parentSessionId,
+    parentToolCallId: `call-${mode}`,
+    status: "failed",
+    createdAt: "2026-07-24T00:00:00.000Z",
+    updatedAt: "2026-07-24T00:01:00.000Z",
+  };
+}

--- a/tests/unit/tui/tui-startup-controller.test.ts
+++ b/tests/unit/tui/tui-startup-controller.test.ts
@@ -43,7 +43,6 @@ test("startup coordinates recovery and opens the requested resume picker", async
   });
 
   await controller.start();
-  await Promise.resolve();
 
   expect(calls.sort()).toEqual(["artifacts", "mcp", "provider"]);
   expect(notified).toEqual(["parent-background"]);
@@ -55,6 +54,69 @@ test("startup coordinates recovery and opens the requested resume picker", async
   expect(status).toBe("choose a session to resume");
   expect(providerReady).toBe(true);
   expect(errors).toHaveLength(1);
+});
+
+test("startup loads normal permissions and reports resumable sessions", async () => {
+  const session: SessionSummary = {
+    sessionId: "session-2",
+    startedAt: "2026-07-24T00:00:00.000Z",
+    updatedAt: "2026-07-24T00:01:00.000Z",
+    recordCount: 1,
+    preview: "resume me",
+  };
+  const calls: string[] = [];
+  let messages: Message[] = [];
+  let picker: SessionPickerState | null = null;
+  const controller = createStartupController({
+    dangerouslySkipPermissions: false,
+    initialResume: false,
+    refreshArtifacts: async () => undefined,
+    recoverInterruptedAgents: async () => [],
+    notifyContinuation: async () => undefined,
+    refreshMcpStatus: async () => undefined,
+    loadPermissionSettings: async () => { calls.push("permissions"); },
+    loadProviderConfig: async () => undefined,
+    setProviderConfigReady: () => undefined,
+    listSessions: async () => [session],
+    setResumableSessions: () => undefined,
+    setSessionPicker: (state) => { picker = state; },
+    setMessages: (value) => { messages = typeof value === "function" ? value(messages) : value; },
+    setStatus: () => undefined,
+    reportError: (error) => { throw error; },
+  });
+
+  await controller.start();
+
+  expect(calls).toEqual(["permissions"]);
+  expect(picker).toBeNull();
+  expect(messages.map((message) => message.content)).toEqual([
+    "Found 1 existing session. Type /resume to list and continue one, or just type a new prompt to start fresh.",
+  ]);
+});
+
+test("startup reports an empty explicit resume request", async () => {
+  let messages: Message[] = [];
+  const controller = createStartupController({
+    dangerouslySkipPermissions: true,
+    initialResume: true,
+    refreshArtifacts: async () => undefined,
+    recoverInterruptedAgents: async () => [],
+    notifyContinuation: async () => undefined,
+    refreshMcpStatus: async () => undefined,
+    loadPermissionSettings: async () => undefined,
+    loadProviderConfig: async () => undefined,
+    setProviderConfigReady: () => undefined,
+    listSessions: async () => [],
+    setResumableSessions: () => undefined,
+    setSessionPicker: () => undefined,
+    setMessages: (value) => { messages = typeof value === "function" ? value(messages) : value; },
+    setStatus: () => undefined,
+    reportError: (error) => { throw error; },
+  });
+
+  await controller.start();
+
+  expect(messages.map((message) => message.content)).toEqual(["No existing sessions found."]);
 });
 
 function recoveredAgent(mode: "background" | "foreground", parentSessionId: string): AgentMetadata {


### PR DESCRIPTION
## Summary

- extract mount-time artifact, SubAgent recovery, MCP/config, and session discovery orchestration into a startup owner
- extract Stage bootstrap invocation and complete host-session state application into a Stage session owner
- remove the unused `/init` pass-through from the turn controller option bag while preserving the command-owned action

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test` (883 pass, 5 Windows-only skips, 0 fail)
- `bun run doctor`
- `git diff --check`
- native 80-column PTY smoke with isolated config: `--resume` opens the existing-session picker; `/stage` from two guarded workspace cards switches the header to Stage, renders warnings and frozen opening, and persists `prism-stage-bootstrap/v1` plus `stage-bootstrap-opening` records

## Scope

This is Phase 2B of the local code-smell remediation plan. It preserves Stage core bootstrap/path guards, provider protocols, session schema, startup task concurrency, and `/init` behavior. Decision continuation domain splitting remains Phase 2C.