### PR TITLE
refactor(setup): separate state effects and views

### DIFF
--- a/src/setup/app.tsx
+++ b/src/setup/app.tsx
@@ -1,138 +1,41 @@
-import { homedir } from "node:os";
-import { join, resolve } from "node:path";
-import { TextAttributes } from "@opentui/core";
 import { useKeyboard, usePaste, useRenderer, useTerminalDimensions } from "@opentui/solid";
-import { For, Show, createMemo, createSignal } from "solid-js";
-import type { PermissionMode } from "../core/permissions";
-import { engineIds, type EngineId } from "../core/engine/profile";
-import { applyComposerKey, insertComposerText, normalizeKeyName, type ComposerState } from "../tui/composer";
-import { truncateLine } from "../tui/format";
-import { PromptComposer } from "../tui/PromptComposer";
-import { palette } from "../tui/theme";
-import { discoverOpenAIModels, normalizeOpenAIBaseUrl } from "./model-discovery";
-import { testMcpServer, type McpTestResult } from "./mcp-test";
-import { writeSetupConfiguration, type SetupMcpServer, type SetupWriteResult } from "./config-writer";
+import { createSignal } from "solid-js";
+import { applyComposerKey, insertComposerText, normalizeKeyName } from "../tui/composer";
+import { runSetupEffect, type SetupEffectDependencies } from "./setup-effects";
+import {
+  createInitialSetupState,
+  isSetupInputStep,
+  setupIsBusy,
+  transitionSetup,
+  type SetupAction,
+  type SetupCompletion,
+  type SetupEffect,
+  type SetupStep,
+} from "./setup-state";
+import { SetupView } from "./setup-views";
 
-export type SetupStep =
-  | "welcome"
-  | "base-url"
-  | "api-key"
-  | "discovering"
-  | "discovery-error"
-  | "models"
-  | "add-model"
-  | "default-model"
-  | "tavily-choice"
-  | "tavily-key"
-  | "mcp-choice"
-  | "mcp-name"
-  | "mcp-url"
-  | "mcp-auth"
-  | "mcp-header"
-  | "mcp-secret"
-  | "mcp-engines"
-  | "mcp-testing"
-  | "mcp-result"
-  | "mcp-more"
-  | "permissions"
-  | "project-choice"
-  | "project"
-  | "review"
-  | "saving"
-  | "complete"
-  | "save-error";
+export type { SetupCompletion, SetupStep } from "./setup-state";
+export {
+  defaultProjectDirectory,
+  resolveProjectPath,
+  setupChoiceSupportsBack,
+  setupMultiSelectBackAt,
+  setupMultiSelectChoices,
+  setupMultiSelectValueAt,
+  setupReviewBackIndex,
+} from "./setup-state";
+export { maskValue, setupMultiSelectVisibleRowLimit, setupUsesCompactHeight } from "./setup-views";
 
-export type SetupCompletion = {
-  launch: boolean;
-  projectDirectory?: string;
-  writeResult?: SetupWriteResult;
-};
-
-export type SetupAppProps = {
-  env?: NodeJS.ProcessEnv;
+export type SetupAppProps = SetupEffectDependencies & {
   initialStep?: SetupStep;
-  discoverModels?: typeof discoverOpenAIModels;
-  testMcp?: typeof testMcpServer;
-  writeConfiguration?: typeof writeSetupConfiguration;
   onComplete: (result: SetupCompletion) => void;
 };
-
-type InputPage = Extract<SetupStep,
-  "base-url" | "api-key" | "add-model" | "tavily-key" | "mcp-name" | "mcp-url" | "mcp-header" | "mcp-secret" | "project"
->;
-
-const permissionOptions: Array<{ mode: Exclude<PermissionMode, "YOLO">; label: string; detail: string }> = [
-  { mode: "MOMENTUM", label: "Recommended", detail: "Reads and ordinary workspace changes proceed; shell stays off" },
-  { mode: "INERTIA", label: "More cautious", detail: "Reads proceed; changes ask first" },
-  { mode: "MANUAL", label: "Ask every time", detail: "Every model-visible tool asks first" },
-];
-
-const explicitBackSteps: SetupStep[] = [
-  "discovery-error",
-  "default-model",
-  "tavily-choice",
-  "mcp-choice",
-  "mcp-auth",
-  "mcp-result",
-  "mcp-more",
-  "permissions",
-  "project-choice",
-  "review",
-];
-
-export type SetupMultiSelectChoice<T> =
-  | { kind: "value"; value: T }
-  | { kind: "back" };
-
-export function setupMultiSelectChoices<T>(values: readonly T[]): Array<SetupMultiSelectChoice<T>> {
-  return [...values.map((value) => ({ kind: "value" as const, value })), { kind: "back" }];
-}
-
-export function setupMultiSelectValueAt<T>(choices: Array<SetupMultiSelectChoice<T>>, index: number): T | undefined {
-  const choice = choices[index];
-  return choice?.kind === "value" ? choice.value : undefined;
-}
-
-export function setupMultiSelectBackAt<T>(choices: Array<SetupMultiSelectChoice<T>>, index: number): boolean {
-  return choices[index]?.kind === "back";
-}
-
-export function setupChoiceSupportsBack(step: SetupStep): boolean {
-  return explicitBackSteps.includes(step);
-}
-
-export function setupReviewBackIndex(projectDirectory: string): number {
-  return projectDirectory ? 1 : 0;
-}
 
 export function SetupApp(props: SetupAppProps) {
   const renderer = useRenderer();
   const dimensions = useTerminalDimensions();
   const env = props.env ?? process.env;
-  const [step, setStep] = createSignal<SetupStep>(props.initialStep ?? "welcome");
-  const [selectedIndex, setSelectedIndex] = createSignal(0);
-  const [draft, setDraft] = createSignal("");
-  const [draftCursor, setDraftCursor] = createSignal(0);
-  const [status, setStatus] = createSignal("Use arrow keys and Enter. Ctrl+Q exits Setup.");
-  const [baseUrl, setBaseUrl] = createSignal("");
-  const [apiKey, setApiKey] = createSignal("");
-  const [models, setModels] = createSignal<string[]>([]);
-  const [selectedModels, setSelectedModels] = createSignal<string[]>([]);
-  const [defaultModel, setDefaultModel] = createSignal("");
-  const [tavilyApiKey, setTavilyApiKey] = createSignal("");
-  const [mcpServers, setMcpServers] = createSignal<SetupMcpServer[]>([]);
-  const [mcpDraft, setMcpDraft] = createSignal<SetupMcpServer>(emptyMcpDraft());
-  const [mcpTestResult, setMcpTestResult] = createSignal<McpTestResult | null>(null);
-  const [mcpTestError, setMcpTestError] = createSignal("");
-  const [permissionMode, setPermissionMode] = createSignal<Exclude<PermissionMode, "YOLO">>("MOMENTUM");
-  const [projectDirectory, setProjectDirectory] = createSignal(defaultProjectDirectory(env));
-  const [projectInputReturnStep, setProjectInputReturnStep] = createSignal<"project-choice" | "review">("project-choice");
-  const [writeResult, setWriteResult] = createSignal<SetupWriteResult>();
-  const busy = createMemo(() => step() === "discovering" || step() === "mcp-testing" || step() === "saving");
-  const compactHeight = createMemo(() => setupUsesCompactHeight(dimensions().height, step()));
-  const rootPaddingX = createMemo(() => dimensions().width < 64 ? 1 : 2);
-  const panelPaddingX = createMemo(() => dimensions().width < 64 ? 1 : 2);
-  const panelTextWidth = createMemo(() => Math.max(8, dimensions().width - (rootPaddingX() * 2) - (panelPaddingX() * 2) - 2));
+  const [state, setState] = createSignal(createInitialSetupState(env, props.initialStep));
 
   useKeyboard((rawKey) => {
     const key = {
@@ -151,452 +54,76 @@ export function SetupApp(props: SetupAppProps) {
       consumeKey(key);
       return;
     }
-    if (busy()) {
+    if (setupIsBusy(state().step)) {
       consumeKey(key);
       return;
     }
-    if (isInputPage(step())) {
-      handleInputKey(key);
-      consumeKey(key);
-      return;
-    }
-    handleChoiceKey(key);
+    if (isSetupInputStep(state().step)) handleInputKey(key);
+    else handleChoiceKey(key);
     consumeKey(key);
   });
 
   usePaste((event) => {
-    if (!isInputPage(step()) || busy()) {
+    if (!isSetupInputStep(state().step) || setupIsBusy(state().step)) {
       event.preventDefault();
       return;
     }
     const text = new TextDecoder().decode(event.bytes).replace(/[\r\n]+/g, " ");
-    const next = insertComposerText(inputState(), text);
-    applyInputState(next);
+    dispatch({ type: "set-input", input: insertComposerText(state().input, text) });
     event.preventDefault();
   });
 
   function handleInputKey(key: Parameters<typeof applyComposerKey>[1]): void {
     if (key.name === "escape") {
-      goBackFromInput();
+      dispatch({ type: "back" });
       return;
     }
-    const result = applyComposerKey(inputState(), key);
-    applyInputState(result.state);
-    if (result.action?.type === "submit") submitInput(result.action.value.trim());
+    const result = applyComposerKey(state().input, key);
+    dispatch({ type: "set-input", input: result.state });
+    if (result.action?.type === "submit") dispatch({ type: "submit-input", value: result.action.value.trim() });
   }
 
   function handleChoiceKey(key: { name?: string; ctrl?: boolean }): void {
     if (key.name === "escape") {
-      goBackFromChoice();
+      dispatch({ type: "back" });
       return;
     }
-    if (step() === "models" || step() === "mcp-engines") {
-      handleMultiSelectKey(key);
-      return;
-    }
-    const items = choiceItems();
     if (key.name === "up" || (key.ctrl && key.name === "p")) {
-      setSelectedIndex((value) => wrapIndex(value - 1, items.length));
+      dispatch({ type: "move-selection", delta: -1 });
       return;
     }
     if (key.name === "down" || (key.ctrl && key.name === "n")) {
-      setSelectedIndex((value) => wrapIndex(value + 1, items.length));
+      dispatch({ type: "move-selection", delta: 1 });
       return;
     }
-    if (key.name === "enter" || key.name === "return") chooseCurrent();
-  }
-
-  function handleMultiSelectKey(key: { name?: string; ctrl?: boolean }): void {
-    const items = setupMultiSelectChoices(step() === "models" ? models() : [...engineIds]);
-    if (key.name === "up" || (key.ctrl && key.name === "p")) {
-      setSelectedIndex((value) => wrapIndex(value - 1, items.length));
+    const multi = state().step === "models" || state().step === "mcp-engines";
+    if (state().step === "models" && key.name?.toLowerCase() === "a") {
+      dispatch({ type: "add-model-input" });
       return;
     }
-    if (key.name === "down" || (key.ctrl && key.name === "n")) {
-      setSelectedIndex((value) => wrapIndex(value + 1, items.length));
-      return;
-    }
-    if (step() === "models" && key.name?.toLowerCase() === "a") {
-      enterInput("add-model", "");
-      return;
-    }
-    if (key.name === "space") {
-      const value = setupMultiSelectValueAt(items, selectedIndex());
-      if (!value) return;
-      if (step() === "models") toggleSelectedModel(value);
-      else toggleEngine(value as EngineId);
+    if (multi && key.name === "space") {
+      dispatch({ type: "toggle-multi" });
       return;
     }
     if (key.name !== "enter" && key.name !== "return") return;
-    if (setupMultiSelectBackAt(items, selectedIndex())) {
-      goBackFromChoice();
-      return;
-    }
-    if (step() === "models") {
-      if (selectedModels().length === 0) {
-        setStatus("Select at least one model with Space, or press A to add one.");
-        return;
-      }
-      setSelectedIndex(0);
-      setStep("default-model");
-      setStatus("Choose the model Vesicle should use by default.");
-    } else {
-      if (mcpDraft().enabledEngines.length === 0) {
-        setStatus("Select at least one Engine with Space.");
-        return;
-      }
-      void runMcpTest();
-    }
+    dispatch({ type: multi ? "continue-multi" : "choose" });
   }
 
-  function submitInput(value: string): void {
-    switch (step()) {
-      case "base-url": {
-        try {
-          const normalized = normalizeOpenAIBaseUrl(value);
-          setBaseUrl(normalized);
-          enterInput("api-key", "");
-          setStatus(`Models will be requested from ${normalized}/models.`);
-        } catch (error) {
-          setStatus(errorMessage(error));
-        }
-        return;
-      }
-      case "api-key":
-        if (!value) {
-          setStatus("API key is required.");
-          return;
-        }
-        setApiKey(value);
-        void runDiscovery();
-        return;
-      case "add-model":
-        if (!value) {
-          setStatus("Enter an exact model id.");
-          return;
-        }
-        setModels((current) => [...new Set([...current, value])].sort((a, b) => a.localeCompare(b)));
-        setSelectedModels((current) => [...new Set([...current, value])]);
-        setStep("models");
-        setSelectedIndex(Math.max(0, models().indexOf(value)));
-        setStatus(`Added and selected ${value}.`);
-        return;
-      case "tavily-key":
-        if (!value) {
-          setStatus("Enter a Tavily API key, or press Esc to skip.");
-          return;
-        }
-        setTavilyApiKey(value);
-        setStep("mcp-choice");
-        setSelectedIndex(0);
-        setStatus("Tavily will be available to the ETL and Evaluate engines.");
-        return;
-      case "mcp-name":
-        if (!value) {
-          setStatus("Enter a short name for this MCP server.");
-          return;
-        }
-        setMcpDraft((current) => ({ ...current, name: value }));
-        enterInput("mcp-url", "");
-        return;
-      case "mcp-url":
-        try {
-          const url = new URL(value);
-          if (url.protocol !== "https:" && url.protocol !== "http:") throw new Error("MCP URL must use http:// or https://.");
-          setMcpDraft((current) => ({ ...current, url: url.toString() }));
-          setStep("mcp-auth");
-          setSelectedIndex(0);
-          setStatus("Choose how this MCP server authenticates.");
-        } catch (error) {
-          setStatus(errorMessage(error));
-        }
-        return;
-      case "mcp-header":
-        if (!/^[A-Za-z0-9-]+$/.test(value)) {
-          setStatus("Header name may contain letters, numbers, and hyphens.");
-          return;
-        }
-        setMcpDraft((current) => ({ ...current, headerName: value }));
-        enterInput("mcp-secret", "");
-        return;
-      case "mcp-secret":
-        if (!value) {
-          setStatus("Authentication secret is required.");
-          return;
-        }
-        setMcpDraft((current) => ({ ...current, secret: value }));
-        setStep("mcp-engines");
-        setSelectedIndex(0);
-        setStatus("Space toggles Engines; Enter tests the server.");
-        return;
-      case "project": {
-        if (!value) {
-          setStatus("Enter a folder for the one-time launch, or press Esc to skip it.");
-          return;
-        }
-        const resolved = resolveProjectPath(value, env);
-        setProjectDirectory(resolved);
-        setStep("review");
-        setSelectedIndex(0);
-        setStatus("Review the choices, then save them together.");
-        return;
-      }
-    }
+  function dispatch(action: SetupAction): void {
+    const transition = transitionSetup(state(), action, env);
+    setState(transition.state);
+    if (transition.completion) complete(transition.completion);
+    if (transition.effect) void executeEffect(transition.effect);
   }
 
-  function chooseCurrent(): void {
-    const index = selectedIndex();
-    if (setupChoiceSupportsBack(step()) && index === choiceItems().length - 1) {
-      goBackFromChoice();
-      return;
-    }
-    switch (step()) {
-      case "welcome":
-        if (index === 0) enterInput("base-url", "");
-        else complete({ launch: false });
-        return;
-      case "discovery-error":
-        if (index === 0) void runDiscovery();
-        else if (index === 1) enterInput("base-url", baseUrl());
-        else {
-          setModels([]);
-          setSelectedModels([]);
-          enterInput("add-model", "");
-        }
-        return;
-      case "default-model": {
-        const model = selectedModels()[index];
-        if (!model) return;
-        setDefaultModel(model);
-        setStep("tavily-choice");
-        setSelectedIndex(0);
-        setStatus("Tavily web research is optional and can be configured later.");
-        return;
-      }
-      case "tavily-choice":
-        if (index === 0) {
-          setTavilyApiKey("");
-          setStep("mcp-choice");
-          setSelectedIndex(0);
-        } else enterInput("tavily-key", "");
-        return;
-      case "mcp-choice":
-        if (index === 0) {
-          setStep("permissions");
-          setSelectedIndex(0);
-          setStatus("Choose how often Vesicle should ask before using tools.");
-        } else beginMcpServer();
-        return;
-      case "mcp-auth": {
-        const auth = (["none", "bearer", "custom-header"] as const)[index] ?? "none";
-        setMcpDraft((current) => ({ ...current, auth }));
-        if (auth === "none") {
-          setStep("mcp-engines");
-          setSelectedIndex(0);
-          setStatus("Space toggles Engines; Enter tests the server.");
-        } else if (auth === "custom-header") enterInput("mcp-header", "X-API-Key");
-        else enterInput("mcp-secret", "");
-        return;
-      }
-      case "mcp-result":
-        if (index === 0) {
-          setMcpServers((current) => [...current, mcpDraft()]);
-          setStep("mcp-more");
-          setSelectedIndex(0);
-          setStatus("The server will be written when Setup saves all configuration.");
-        } else if (index === 1) void runMcpTest();
-        else enterInput("mcp-url", mcpDraft().url);
-        return;
-      case "mcp-more":
-        if (index === 0) {
-          setStep("permissions");
-          setSelectedIndex(0);
-          setStatus("Choose how often Vesicle should ask before using tools.");
-        } else beginMcpServer();
-        return;
-      case "permissions": {
-        const option = permissionOptions[index] ?? permissionOptions[0];
-        setPermissionMode(option.mode);
-        setStep("project-choice");
-        setSelectedIndex(0);
-        setStatus("Project selection is optional and is never saved as a global default.");
-        return;
-      }
-      case "project-choice":
-        if (index === 0) {
-          setProjectDirectory("");
-          setStep("review");
-          setSelectedIndex(0);
-          setStatus("No project will be pinned. Launch Vesicle from any folder with vesicle .");
-        } else {
-          setProjectInputReturnStep("project-choice");
-          enterInput("project", projectDirectory() || defaultProjectDirectory(env));
-          setStatus("This folder is used for the first launch only and is not saved globally.");
-        }
-        return;
-      case "review":
-        if (index === 0) void saveConfiguration();
-        else if (index === 1) {
-          setProjectInputReturnStep("review");
-          enterInput("project", projectDirectory() || defaultProjectDirectory(env));
-        }
-        else {
-          setProjectDirectory("");
-          setSelectedIndex(0);
-          setStatus("The one-time first launch was removed; no project will be pinned.");
-        }
-        return;
-      case "complete": {
-        const launch = Boolean(projectDirectory()) && index === 0;
-        complete({
-          launch,
-          ...(launch ? { projectDirectory: projectDirectory() } : {}),
-          writeResult: writeResult(),
-        });
-        return;
-      }
-      case "save-error":
-        if (index === 0) void saveConfiguration();
-        else if (index === 1) {
-          setStep("review");
-          setSelectedIndex(0);
-        } else complete({ launch: false });
-        return;
-    }
-  }
-
-  async function runDiscovery(): Promise<void> {
-    setStep("discovering");
-    setStatus("Contacting the provider without saving the API key yet...");
-    try {
-      const result = await (props.discoverModels ?? discoverOpenAIModels)(baseUrl(), apiKey());
-      setBaseUrl(result.baseUrl);
-      setModels(result.models);
-      setSelectedModels(result.models[0] ? [result.models[0]] : []);
-      setSelectedIndex(0);
-      setStep("models");
-      setStatus(`Found ${result.models.length} models. Space toggles; A adds an exact model id.`);
-    } catch (error) {
-      setStep("discovery-error");
-      setSelectedIndex(0);
-      setStatus(errorMessage(error));
-    }
-  }
-
-  async function runMcpTest(): Promise<void> {
-    setStep("mcp-testing");
-    setMcpTestResult(null);
-    setMcpTestError("");
-    setStatus("Initializing the MCP server and requesting its tool list...");
-    try {
-      const result = await (props.testMcp ?? testMcpServer)(mcpDraft());
-      setMcpTestResult(result);
-      setStatus(`Connected successfully; discovered ${result.toolCount} tools.`);
-    } catch (error) {
-      setMcpTestError(errorMessage(error));
-      setStatus("The MCP test failed. You may edit, retry, or explicitly save it anyway.");
-    } finally {
-      setStep("mcp-result");
-      setSelectedIndex(0);
-    }
-  }
-
-  async function saveConfiguration(): Promise<void> {
-    setStep("saving");
-    setStatus("Validating and saving user configuration with backups...");
-    try {
-      const result = await (props.writeConfiguration ?? writeSetupConfiguration)({
-        baseUrl: baseUrl(),
-        apiKey: apiKey(),
-        modelIds: selectedModels(),
-        defaultModel: defaultModel(),
-        ...(tavilyApiKey() ? { tavilyApiKey: tavilyApiKey() } : {}),
-        ...(mcpServers().length ? { mcpServers: mcpServers() } : {}),
-        permissionMode: permissionMode(),
-        ...(projectDirectory() ? { projectDirectory: projectDirectory() } : {}),
-      }, env);
-      setWriteResult(result);
-      setStep("complete");
-      setSelectedIndex(0);
-      setStatus(result.backups.length > 0
-        ? `Saved successfully and created ${result.backups.length} backups.`
-        : "Saved successfully. Prism Vesicle is ready to launch.");
-    } catch (error) {
-      setStep("save-error");
-      setSelectedIndex(0);
-      setStatus(errorMessage(error));
-    }
-  }
-
-  function goBackFromInput(): void {
-    switch (step()) {
-      case "base-url": setStep("welcome"); return;
-      case "api-key": enterInput("base-url", baseUrl()); return;
-      case "add-model": setStep("models"); return;
-      case "tavily-key": setStep("tavily-choice"); return;
-      case "mcp-name": setStep("mcp-choice"); return;
-      case "mcp-url": enterInput("mcp-name", mcpDraft().name); return;
-      case "mcp-header": setStep("mcp-auth"); return;
-      case "mcp-secret": setStep("mcp-auth"); return;
-      case "project": setStep(projectInputReturnStep()); return;
-    }
-  }
-
-  function goBackFromChoice(): void {
-    switch (step()) {
-      case "discovery-error": enterInput("api-key", ""); return;
-      case "models": enterInput("api-key", ""); return;
-      case "default-model": returnToChoice("models", Math.max(0, selectedModels().indexOf(defaultModel()))); return;
-      case "tavily-choice": returnToChoice("default-model", Math.max(0, selectedModels().indexOf(defaultModel()))); return;
-      case "mcp-choice": returnToChoice("tavily-choice", tavilyApiKey() ? 1 : 0); return;
-      case "mcp-auth": enterInput("mcp-url", mcpDraft().url); return;
-      case "mcp-engines": returnToChoice("mcp-auth", Math.max(0, ["none", "bearer", "custom-header"].indexOf(mcpDraft().auth))); return;
-      case "mcp-result": enterInput("mcp-url", mcpDraft().url); return;
-      case "mcp-more": returnToChoice("mcp-choice"); return;
-      case "permissions": returnToChoice("mcp-choice"); return;
-      case "project-choice": returnToChoice("permissions", Math.max(0, permissionOptions.findIndex((option) => option.mode === permissionMode()))); return;
-      case "review": returnToChoice("project-choice", setupReviewBackIndex(projectDirectory())); return;
-      case "save-error": returnToChoice("review"); return;
-    }
-  }
-
-  function returnToChoice(next: SetupStep, index = 0): void {
-    setStep(next);
-    setSelectedIndex(index);
-  }
-
-  function enterInput(next: InputPage, value: string): void {
-    setDraft(value);
-    setDraftCursor(value.length);
-    setStep(next);
-    setStatus(inputHint(next));
-  }
-
-  function beginMcpServer(): void {
-    setMcpDraft(emptyMcpDraft());
-    enterInput("mcp-name", "");
-  }
-
-  function inputState(): ComposerState {
-    return { value: draft(), cursor: draftCursor() };
-  }
-
-  function applyInputState(state: ComposerState): void {
-    setDraft(state.value);
-    setDraftCursor(state.cursor);
-  }
-
-  function toggleSelectedModel(model: string): void {
-    setSelectedModels((current) => current.includes(model) ? current.filter((entry) => entry !== model) : [...current, model]);
-  }
-
-  function toggleEngine(engine: EngineId): void {
-    setMcpDraft((current) => ({
-      ...current,
-      enabledEngines: current.enabledEngines.includes(engine)
-        ? current.enabledEngines.filter((entry) => entry !== engine)
-        : [...current.enabledEngines, engine],
-    }));
+  async function executeEffect(effect: SetupEffect): Promise<void> {
+    const result = await runSetupEffect(effect, {
+      env,
+      discoverModels: props.discoverModels,
+      testMcp: props.testMcp,
+      writeConfiguration: props.writeConfiguration,
+    });
+    dispatch({ type: "effect-result", result });
   }
 
   function complete(result: SetupCompletion): void {
@@ -604,335 +131,10 @@ export function SetupApp(props: SetupAppProps) {
     process.nextTick(() => renderer.destroy());
   }
 
-  function choiceItems(): Array<{ label: string; detail?: string }> {
-    const items = baseChoiceItems();
-    return setupChoiceSupportsBack(step())
-      ? [...items, { label: "Back", detail: "Return to the previous step" }]
-      : items;
-  }
-
-  function baseChoiceItems(): Array<{ label: string; detail?: string }> {
-    switch (step()) {
-      case "welcome": return [
-        { label: "Begin guided setup", detail: "No configuration files to edit" },
-        { label: "Exit", detail: "You can reopen Setup from the Start Menu" },
-      ];
-      case "discovery-error": return [
-        { label: "Retry model discovery" },
-        { label: "Edit Base URL" },
-        { label: "Add a model manually", detail: "Continue even when /models is unavailable" },
-      ];
-      case "default-model": return selectedModels().map((model) => ({ label: model }));
-      case "tavily-choice": return [
-        { label: "Skip for now", detail: "Web research can be added later" },
-        { label: "Configure Tavily", detail: "Add optional web research tools" },
-      ];
-      case "mcp-choice": return [
-        { label: "Skip for now", detail: "MCP servers can be added later" },
-        { label: "Add an MCP server", detail: "Streamable HTTP" },
-      ];
-      case "mcp-auth": return [
-        { label: "No authentication" },
-        { label: "Bearer token", detail: "Authorization: Bearer ..." },
-        { label: "Custom header", detail: "For X-API-Key and similar services" },
-      ];
-      case "mcp-result": return [
-        { label: mcpTestError() ? "Save server anyway" : "Save server and continue", detail: mcpTestError() ? "The failed connection is recorded only after this choice" : undefined },
-        { label: "Retry test" },
-        { label: "Edit server URL" },
-      ];
-      case "mcp-more": return [
-        { label: "Continue", detail: `${mcpServers().length} MCP server(s) ready` },
-        { label: "Add another MCP server" },
-      ];
-      case "permissions": return permissionOptions.map((option) => ({ label: option.label, detail: option.detail }));
-      case "project-choice": return [
-        { label: "Skip project selection", detail: "Launch projects later with vesicle ." },
-        { label: "Choose a folder for the first launch", detail: "Used once; never pinned" },
-      ];
-      case "review": return [
-        { label: "Save configuration", detail: "Existing files receive timestamped backups" },
-        { label: projectDirectory() ? "Change one-time launch folder" : "Choose a one-time launch folder" },
-        ...(projectDirectory() ? [{ label: "Skip the one-time launch", detail: "No project is saved globally" }] : []),
-      ];
-      case "complete": return projectDirectory()
-        ? [
-            { label: "Launch this folder once", detail: projectDirectory() },
-            { label: "Exit Setup", detail: "Later, run vesicle . in a project" },
-          ]
-        : [{ label: "Exit Setup", detail: "Run vesicle . from any project folder" }];
-      case "save-error": return [
-        { label: "Retry save" },
-        { label: "Back to review" },
-        { label: "Exit without changes" },
-      ];
-      default: return [];
-    }
-  }
-
-  const visibleMultiItems = createMemo(() => {
-    const values = step() === "models" ? models() : [...engineIds];
-    return visibleWindow(setupMultiSelectChoices(values), selectedIndex(), setupMultiSelectVisibleRowLimit(dimensions().height));
-  });
-
-  return (
-    <box flexDirection="column" width="100%" height="100%" paddingX={rootPaddingX()} paddingY={compactHeight() ? 0 : 1} overflow="hidden" backgroundColor={palette.bg}>
-      <box height={compactHeight() ? 1 : 2} flexDirection="column" overflow="hidden">
-        <text content={truncateLine("Prism Vesicle Setup", panelTextWidth())} wrapMode="none" fg={palette.brand} attributes={TextAttributes.BOLD} />
-        <text content={compactHeight() ? "" : progressLabel(step())} height={compactHeight() ? 0 : 1} wrapMode="none" fg={palette.textDim} />
-      </box>
-      <box marginTop={compactHeight() ? 0 : 1} flexGrow={1} flexDirection="column" border borderColor={palette.panelBorder} paddingX={panelPaddingX()} paddingY={compactHeight() ? 0 : 1} overflow="hidden">
-        <text content={truncateLine(pageTitle(step()), panelTextWidth())} wrapMode="none" fg={palette.textPrimary} attributes={TextAttributes.BOLD} />
-        <text content={compactHeight() ? "" : truncateLine(pageDescription(step()), panelTextWidth())} height={compactHeight() ? 0 : 1} wrapMode="none" fg={palette.textSecondary} />
-        <box marginTop={compactHeight() ? 0 : 1} flexDirection="column" flexGrow={1} overflow="hidden">
-          <Show when={isInputPage(step())} fallback={renderChoiceContent()}>
-            <text content={truncateLine(inputLabel(step() as InputPage), panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-            <box marginTop={1} border borderColor={palette.brandDim} paddingX={1} height={3}>
-              <PromptComposer
-                value={isSecretPage(step()) ? maskValue(draft()) : draft()}
-                cursor={draftCursor()}
-                placeholder={inputPlaceholder(step() as InputPage)}
-                width={Math.max(4, panelTextWidth() - 4)}
-                maxLines={1}
-              />
-            </box>
-            <text content={truncateLine("Enter continues · Esc goes back", panelTextWidth())} wrapMode="none" fg={palette.textDim} />
-          </Show>
-        </box>
-      </box>
-      <box height={compactHeight() ? 1 : 3} marginTop={compactHeight() ? 0 : 1} flexDirection="column" overflow="hidden">
-        <text content={truncateLine(status(), Math.max(8, dimensions().width - (rootPaddingX() * 2)))} wrapMode="none" fg={status().toLowerCase().includes("failed") || status().toLowerCase().includes("required") ? palette.error : palette.textSecondary} />
-        <text content={compactHeight() ? "" : truncateLine("Secrets stay in .env; Setup never writes them to YAML or logs.", Math.max(8, dimensions().width - (rootPaddingX() * 2)))} height={compactHeight() ? 0 : 1} wrapMode="none" fg={palette.textDim} />
-      </box>
-    </box>
-  );
-
-  function renderChoiceContent() {
-    if (step() === "discovering" || step() === "mcp-testing" || step() === "saving") {
-      return <text content="Working..." fg={palette.warn} />;
-    }
-    if (step() === "models" || step() === "mcp-engines") {
-      return (
-        <box flexDirection="column">
-          <For each={visibleMultiItems().visible}>{(item, index) => {
-            const absolute = () => visibleMultiItems().start + index();
-            const selected = () => absolute() === selectedIndex();
-            const checked = () => item.kind === "value" && (step() === "models"
-              ? selectedModels().includes(item.value)
-              : mcpDraft().enabledEngines.includes(item.value as EngineId));
-            const content = () => item.kind === "back"
-              ? `${selected() ? ">" : " "} Back  — Return to the previous step`
-              : `${selected() ? ">" : " "} [${checked() ? "x" : " "}] ${item.value}`;
-            return <text
-              content={truncateLine(content(), panelTextWidth())}
-              wrapMode="none"
-              fg={selected() ? palette.textPrimary : palette.textSecondary}
-              attributes={selected() ? TextAttributes.BOLD : TextAttributes.NONE}
-            />;
-          }}</For>
-          <text content={truncateLine(step() === "models" ? "Space toggles · A adds a model · Enter continues · Esc goes back" : "Space toggles · Enter tests connection · Esc goes back", panelTextWidth())} wrapMode="none" fg={palette.textDim} />
-        </box>
-      );
-    }
-    if (step() === "review") {
-      return (
-        <box flexDirection="column">
-          <text content={truncateLine(`Provider  ${baseUrl()}`, panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-          <text content={truncateLine(`Models    ${selectedModels().length} selected · default ${defaultModel()}`, panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-          <Show when={!compactHeight()} fallback={
-            <text content={truncateLine(`Permission ${permissionMode()} · Tavily ${tavilyApiKey() ? "on" : "off"} · MCP ${mcpServers().length}`, panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-          }>
-            <text content={truncateLine(`Tavily    ${tavilyApiKey() ? "configured" : "skipped"}`, panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-            <text content={truncateLine(`MCP       ${mcpServers().length} server(s)`, panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-            <text content={truncateLine(`Permission ${permissionMode()} · shell default off / existing setting preserved`, panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-          </Show>
-          <text content={truncateLine(`First run ${projectDirectory() || "skipped; no project is pinned"}`, panelTextWidth())} wrapMode="none" fg={palette.textSecondary} />
-          <box marginTop={1} flexDirection="column">{renderOptions(choiceItems())}</box>
-        </box>
-      );
-    }
-    if (step() === "mcp-result") {
-      return (
-        <box flexDirection="column">
-          <text content={truncateLine(mcpTestError() || `Connected${mcpTestResult()?.serverName ? ` to ${mcpTestResult()!.serverName}` : ""}; ${mcpTestResult()?.toolCount ?? 0} tools found.`, panelTextWidth())} wrapMode="none" fg={mcpTestError() ? palette.error : palette.success} />
-          <box marginTop={1} flexDirection="column">{renderOptions(choiceItems())}</box>
-        </box>
-      );
-    }
-    return <box flexDirection="column">{renderOptions(choiceItems())}</box>;
-  }
-
-  function renderOptions(items: Array<{ label: string; detail?: string }>) {
-    return <For each={items}>{(item, index) => {
-      const selected = () => index() === selectedIndex();
-      return <text
-        content={truncateLine(`${selected() ? ">" : " "} ${item.label}${item.detail ? `  — ${item.detail}` : ""}`, panelTextWidth())}
-        wrapMode="none"
-        fg={selected() ? palette.textPrimary : palette.textSecondary}
-        attributes={selected() ? TextAttributes.BOLD : TextAttributes.NONE}
-      />;
-    }}</For>;
-  }
-}
-
-export function defaultProjectDirectory(env: NodeJS.ProcessEnv = process.env): string {
-  const home = env.USERPROFILE || env.HOME || homedir();
-  return join(home, "Documents", "PrismVesicle", "MyFirstProject");
-}
-
-export function resolveProjectPath(input: string, env: NodeJS.ProcessEnv = process.env): string {
-  const home = env.USERPROFILE || env.HOME || homedir();
-  const expanded = input.trim().replace(/^~(?=$|[\\/])/, home);
-  return resolve(expanded);
-}
-
-export function setupUsesCompactHeight(height: number, currentStep?: SetupStep): boolean {
-  return height < (currentStep === "review" ? 27 : 24);
-}
-
-export function setupMultiSelectVisibleRowLimit(height: number): number {
-  const structuralRows = setupUsesCompactHeight(height, "models") ? 6 : 17;
-  return Math.max(5, Math.min(14, height - structuralRows));
-}
-
-function emptyMcpDraft(): SetupMcpServer {
-  return { name: "", url: "", auth: "none", enabledEngines: ["etl", "evaluate"] };
-}
-
-function isInputPage(step: SetupStep): step is InputPage {
-  return ["base-url", "api-key", "add-model", "tavily-key", "mcp-name", "mcp-url", "mcp-header", "mcp-secret", "project"].includes(step);
-}
-
-function isSecretPage(step: SetupStep): boolean {
-  return step === "api-key" || step === "tavily-key" || step === "mcp-secret";
-}
-
-export function maskValue(value: string): string {
-  return value.replace(/[\s\S]/g, "•");
-}
-
-function inputLabel(step: SetupStep): string {
-  const labels: Record<InputPage, string> = {
-    "base-url": "OpenAI-compatible Base URL",
-    "api-key": "Provider API key",
-    "add-model": "Exact model id",
-    "tavily-key": "Tavily API key",
-    "mcp-name": "MCP server name",
-    "mcp-url": "MCP Streamable HTTP URL",
-    "mcp-header": "Authentication header name",
-    "mcp-secret": "MCP authentication secret",
-    "project": "One-time first-launch folder",
-  };
-  return isInputPage(step) ? labels[step] : "";
-}
-
-function inputPlaceholder(step: SetupStep): string {
-  const placeholders: Record<InputPage, string> = {
-    "base-url": "https://api.example.com/v1",
-    "api-key": "Paste the key; it is masked",
-    "add-model": "provider-model-id",
-    "tavily-key": "tvly-...",
-    "mcp-name": "Research server",
-    "mcp-url": "https://mcp.example.com/mcp",
-    "mcp-header": "X-API-Key",
-    "mcp-secret": "Paste the token; it is masked",
-    "project": "C:\\Users\\you\\Documents\\PrismVesicle\\MyFirstProject",
-  };
-  return isInputPage(step) ? placeholders[step] : "";
-}
-
-function inputHint(step: InputPage): string {
-  if (isSecretPage(step)) return "Input is masked. Enter continues; Esc goes back without saving.";
-  if (step === "base-url") return "Enter the API base. A missing /v1 suffix is added automatically.";
-  if (step === "project") return "The folder is created when Setup saves; it is never saved as a global project.";
-  return "Enter continues; Esc goes back.";
-}
-
-function pageTitle(step: SetupStep): string {
-  const titles: Record<SetupStep, string> = {
-    welcome: "Welcome",
-    "base-url": "Connect a model provider",
-    "api-key": "Authenticate securely",
-    discovering: "Discovering models",
-    "discovery-error": "Model discovery needs attention",
-    models: "Choose available models",
-    "add-model": "Add a model manually",
-    "default-model": "Choose the default model",
-    "tavily-choice": "Optional web research",
-    "tavily-key": "Configure Tavily",
-    "mcp-choice": "Optional MCP tools",
-    "mcp-name": "Name the MCP server",
-    "mcp-url": "Connect the MCP server",
-    "mcp-auth": "MCP authentication",
-    "mcp-header": "Custom MCP header",
-    "mcp-secret": "MCP secret",
-    "mcp-engines": "Choose MCP Engines",
-    "mcp-testing": "Testing MCP connection",
-    "mcp-result": "MCP connection result",
-    "mcp-more": "MCP configuration",
-    permissions: "Tool approval preference",
-    "project-choice": "Optional first launch",
-    project: "Choose a one-time launch folder",
-    review: "Review and save",
-    saving: "Saving configuration",
-    complete: "Setup complete",
-    "save-error": "Configuration was not saved",
-  };
-  return titles[step];
-}
-
-function pageDescription(step: SetupStep): string {
-  if (step === "welcome") return "No YAML editing is required. Existing configuration is merged and backed up.";
-  if (step === "models") return "The provider returned model ids. Select only the models you want Vesicle to offer.";
-  if (step === "tavily-choice") return "Tavily enables web_search and related research tools. It is not required for the first conversation.";
-  if (step === "mcp-choice") return "MCP servers add external tools. Each server can be limited to selected Prism Engines.";
-  if (step === "permissions") return "Permission presets change approval friction; they never weaken path, process, or tool guards.";
-  if (step === "project-choice") return "Vesicle never stores one global project. Optionally choose a folder for this first launch only.";
-  if (step === "complete") return "Configuration validated successfully. Project selection remains local to each launch.";
-  return "Follow the prompt below. Nothing is written until the final review step.";
-}
-
-function progressLabel(step: SetupStep): string {
-  const order: SetupStep[] = ["welcome", "base-url", "api-key", "models", "default-model", "tavily-choice", "mcp-choice", "permissions", "project-choice", "review", "complete"];
-  const aliases: Partial<Record<SetupStep, SetupStep>> = {
-    discovering: "api-key",
-    "discovery-error": "api-key",
-    "add-model": "models",
-    "tavily-key": "tavily-choice",
-    "mcp-name": "mcp-choice",
-    "mcp-url": "mcp-choice",
-    "mcp-auth": "mcp-choice",
-    "mcp-header": "mcp-choice",
-    "mcp-secret": "mcp-choice",
-    "mcp-engines": "mcp-choice",
-    "mcp-testing": "mcp-choice",
-    "mcp-result": "mcp-choice",
-    "mcp-more": "mcp-choice",
-    project: "project-choice",
-    saving: "review",
-    "save-error": "review",
-  };
-  const current = aliases[step] ?? step;
-  const index = Math.max(0, order.indexOf(current));
-  return `Step ${index + 1} of ${order.length}`;
-}
-
-function visibleWindow<T>(items: T[], selected: number, maximum: number): { start: number; visible: T[] } {
-  if (items.length <= maximum) return { start: 0, visible: items };
-  const start = Math.max(0, Math.min(selected - Math.floor(maximum / 2), items.length - maximum));
-  return { start, visible: items.slice(start, start + maximum) };
-}
-
-function wrapIndex(value: number, length: number): number {
-  if (length <= 0) return 0;
-  return ((value % length) + length) % length;
+  return <SetupView state={state()} width={dimensions().width} height={dimensions().height} />;
 }
 
 function consumeKey(key: { preventDefault?: () => void; stopPropagation?: () => void }): void {
   key.preventDefault?.();
   key.stopPropagation?.();
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message.trim() ? error.message : String(error);
 }

--- a/src/setup/setup-effects.ts
+++ b/src/setup/setup-effects.ts
@@ -1,7 +1,7 @@
 import { writeSetupConfiguration } from "./config-writer";
 import { testMcpServer } from "./mcp-test";
 import { discoverOpenAIModels } from "./model-discovery";
-import type { SetupEffect, SetupEffectResult } from "./setup-state";
+import { setupErrorMessage, type SetupEffect, type SetupEffectResult } from "./setup-state";
 
 export type SetupEffectDependencies = {
   env?: NodeJS.ProcessEnv;
@@ -33,13 +33,9 @@ export async function runSetupEffect(
         };
     }
   } catch (error) {
-    const message = errorMessage(error);
+    const message = setupErrorMessage(error);
     if (effect.kind === "discover-models") return { kind: "discovery-failed", error: message };
     if (effect.kind === "test-mcp") return { kind: "mcp-test-failed", error: message };
     return { kind: "save-failed", error: message };
   }
-}
-
-function errorMessage(error: unknown): string {
-  return error instanceof Error && error.message.trim() ? error.message : String(error);
 }

--- a/src/setup/setup-effects.ts
+++ b/src/setup/setup-effects.ts
@@ -1,0 +1,45 @@
+import { writeSetupConfiguration } from "./config-writer";
+import { testMcpServer } from "./mcp-test";
+import { discoverOpenAIModels } from "./model-discovery";
+import type { SetupEffect, SetupEffectResult } from "./setup-state";
+
+export type SetupEffectDependencies = {
+  env?: NodeJS.ProcessEnv;
+  discoverModels?: typeof discoverOpenAIModels;
+  testMcp?: typeof testMcpServer;
+  writeConfiguration?: typeof writeSetupConfiguration;
+};
+
+export async function runSetupEffect(
+  effect: SetupEffect,
+  dependencies: SetupEffectDependencies = {},
+): Promise<SetupEffectResult> {
+  try {
+    switch (effect.kind) {
+      case "discover-models":
+        return {
+          kind: "discovery-succeeded",
+          result: await (dependencies.discoverModels ?? discoverOpenAIModels)(effect.baseUrl, effect.apiKey),
+        };
+      case "test-mcp":
+        return {
+          kind: "mcp-test-succeeded",
+          result: await (dependencies.testMcp ?? testMcpServer)(effect.server),
+        };
+      case "save-configuration":
+        return {
+          kind: "save-succeeded",
+          result: await (dependencies.writeConfiguration ?? writeSetupConfiguration)(effect.configuration, dependencies.env),
+        };
+    }
+  } catch (error) {
+    const message = errorMessage(error);
+    if (effect.kind === "discover-models") return { kind: "discovery-failed", error: message };
+    if (effect.kind === "test-mcp") return { kind: "mcp-test-failed", error: message };
+    return { kind: "save-failed", error: message };
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim() ? error.message : String(error);
+}

--- a/src/setup/setup-state.ts
+++ b/src/setup/setup-state.ts
@@ -36,9 +36,11 @@ export type SetupStep =
   | "complete"
   | "save-error";
 
-export type SetupInputStep = Extract<SetupStep,
-  "base-url" | "api-key" | "add-model" | "tavily-key" | "mcp-name" | "mcp-url" | "mcp-header" | "mcp-secret" | "project"
->;
+export const setupInputSteps = [
+  "base-url", "api-key", "add-model", "tavily-key", "mcp-name", "mcp-url", "mcp-header", "mcp-secret", "project",
+] as const satisfies readonly SetupStep[];
+
+export type SetupInputStep = typeof setupInputSteps[number];
 
 export type SetupCompletion = {
   launch: boolean;
@@ -167,8 +169,8 @@ export function transitionSetup(
 }
 
 function setupSelectionCount(state: SetupState): number {
-  if (state.step === "models") return setupMultiSelectChoices(state.models).length;
-  if (state.step === "mcp-engines") return setupMultiSelectChoices(engineIds).length;
+  if (state.step === "models") return state.models.length + 1;
+  if (state.step === "mcp-engines") return engineIds.length + 1;
   return setupChoiceItems(state).length;
 }
 
@@ -245,7 +247,7 @@ function submitInput(state: SetupState, value: string, env: NodeJS.ProcessEnv): 
         const normalized = normalizeOpenAIBaseUrl(value);
         return unchanged(enterInput({ ...state, baseUrl: normalized }, "api-key", "", `Models will be requested from ${normalized}/models.`));
       } catch (error) {
-        return unchanged({ ...state, status: errorMessage(error) });
+        return unchanged({ ...state, status: setupErrorMessage(error) });
       }
     }
     case "api-key":
@@ -281,7 +283,7 @@ function submitInput(state: SetupState, value: string, env: NodeJS.ProcessEnv): 
           status: "Choose how this MCP server authenticates.",
         });
       } catch (error) {
-        return unchanged({ ...state, status: errorMessage(error) });
+        return unchanged({ ...state, status: setupErrorMessage(error) });
       }
     }
     case "mcp-header":
@@ -579,7 +581,7 @@ export function setupIsBusy(step: SetupStep): boolean {
 }
 
 export function isSetupInputStep(step: SetupStep): step is SetupInputStep {
-  return ["base-url", "api-key", "add-model", "tavily-key", "mcp-name", "mcp-url", "mcp-header", "mcp-secret", "project"].includes(step);
+  return setupInputSteps.some((inputStep) => inputStep === step);
 }
 
 export function isSetupSecretStep(step: SetupStep): boolean {
@@ -613,6 +615,6 @@ function wrapIndex(value: number, length: number): number {
   return ((value % length) + length) % length;
 }
 
-function errorMessage(error: unknown): string {
+export function setupErrorMessage(error: unknown): string {
   return error instanceof Error && error.message.trim() ? error.message : String(error);
 }

--- a/src/setup/setup-state.ts
+++ b/src/setup/setup-state.ts
@@ -1,0 +1,618 @@
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { engineIds, type EngineId } from "../core/engine/profile";
+import type { PermissionMode } from "../core/permissions";
+import type { ComposerState } from "../tui/composer";
+import type { SetupConfiguration, SetupMcpServer, SetupWriteResult } from "./config-writer";
+import type { McpTestResult } from "./mcp-test";
+import { normalizeOpenAIBaseUrl, type ModelDiscoveryResult } from "./model-discovery";
+
+export type SetupStep =
+  | "welcome"
+  | "base-url"
+  | "api-key"
+  | "discovering"
+  | "discovery-error"
+  | "models"
+  | "add-model"
+  | "default-model"
+  | "tavily-choice"
+  | "tavily-key"
+  | "mcp-choice"
+  | "mcp-name"
+  | "mcp-url"
+  | "mcp-auth"
+  | "mcp-header"
+  | "mcp-secret"
+  | "mcp-engines"
+  | "mcp-testing"
+  | "mcp-result"
+  | "mcp-more"
+  | "permissions"
+  | "project-choice"
+  | "project"
+  | "review"
+  | "saving"
+  | "complete"
+  | "save-error";
+
+export type SetupInputStep = Extract<SetupStep,
+  "base-url" | "api-key" | "add-model" | "tavily-key" | "mcp-name" | "mcp-url" | "mcp-header" | "mcp-secret" | "project"
+>;
+
+export type SetupCompletion = {
+  launch: boolean;
+  projectDirectory?: string;
+  writeResult?: SetupWriteResult;
+};
+
+export type SetupState = {
+  step: SetupStep;
+  selectedIndex: number;
+  input: ComposerState;
+  status: string;
+  baseUrl: string;
+  apiKey: string;
+  models: string[];
+  selectedModels: string[];
+  defaultModel: string;
+  tavilyApiKey: string;
+  mcpServers: SetupMcpServer[];
+  mcpDraft: SetupMcpServer;
+  mcpTestResult: McpTestResult | null;
+  mcpTestError: string;
+  permissionMode: Exclude<PermissionMode, "YOLO">;
+  projectDirectory: string;
+  projectInputReturnStep: "project-choice" | "review";
+  writeResult?: SetupWriteResult;
+};
+
+export type SetupEffect =
+  | { kind: "discover-models"; baseUrl: string; apiKey: string }
+  | { kind: "test-mcp"; server: SetupMcpServer }
+  | { kind: "save-configuration"; configuration: SetupConfiguration };
+
+export type SetupEffectResult =
+  | { kind: "discovery-succeeded"; result: ModelDiscoveryResult }
+  | { kind: "discovery-failed"; error: string }
+  | { kind: "mcp-test-succeeded"; result: McpTestResult }
+  | { kind: "mcp-test-failed"; error: string }
+  | { kind: "save-succeeded"; result: SetupWriteResult }
+  | { kind: "save-failed"; error: string };
+
+export type SetupAction =
+  | { type: "set-input"; input: ComposerState }
+  | { type: "move-selection"; delta: number }
+  | { type: "back" }
+  | { type: "submit-input"; value: string }
+  | { type: "choose" }
+  | { type: "toggle-multi" }
+  | { type: "add-model-input" }
+  | { type: "continue-multi" }
+  | { type: "effect-result"; result: SetupEffectResult };
+
+export type SetupTransition = {
+  state: SetupState;
+  effect?: SetupEffect;
+  completion?: SetupCompletion;
+};
+
+export type SetupChoiceItem = { label: string; detail?: string };
+
+export const permissionOptions: Array<{ mode: Exclude<PermissionMode, "YOLO">; label: string; detail: string }> = [
+  { mode: "MOMENTUM", label: "Recommended", detail: "Reads and ordinary workspace changes proceed; shell stays off" },
+  { mode: "INERTIA", label: "More cautious", detail: "Reads proceed; changes ask first" },
+  { mode: "MANUAL", label: "Ask every time", detail: "Every model-visible tool asks first" },
+];
+
+const explicitBackSteps: SetupStep[] = [
+  "discovery-error", "default-model", "tavily-choice", "mcp-choice", "mcp-auth", "mcp-result",
+  "mcp-more", "permissions", "project-choice", "review",
+];
+
+export type SetupMultiSelectChoice<T> =
+  | { kind: "value"; value: T }
+  | { kind: "back" };
+
+export function createInitialSetupState(
+  env: NodeJS.ProcessEnv = process.env,
+  initialStep: SetupStep = "welcome",
+): SetupState {
+  return {
+    step: initialStep,
+    selectedIndex: 0,
+    input: { value: "", cursor: 0 },
+    status: "Use arrow keys and Enter. Ctrl+Q exits Setup.",
+    baseUrl: "",
+    apiKey: "",
+    models: [],
+    selectedModels: [],
+    defaultModel: "",
+    tavilyApiKey: "",
+    mcpServers: [],
+    mcpDraft: emptyMcpDraft(),
+    mcpTestResult: null,
+    mcpTestError: "",
+    permissionMode: "MOMENTUM",
+    projectDirectory: defaultProjectDirectory(env),
+    projectInputReturnStep: "project-choice",
+  };
+}
+
+export function transitionSetup(
+  state: SetupState,
+  action: SetupAction,
+  env: NodeJS.ProcessEnv = process.env,
+): SetupTransition {
+  switch (action.type) {
+    case "set-input":
+      return unchanged({ ...state, input: action.input });
+    case "move-selection":
+      return unchanged({ ...state, selectedIndex: wrapIndex(state.selectedIndex + action.delta, setupSelectionCount(state)) });
+    case "back":
+      return unchanged(goBack(state));
+    case "submit-input":
+      return submitInput(state, action.value, env);
+    case "choose":
+      return chooseCurrent(state, env);
+    case "toggle-multi":
+      return unchanged(toggleMultiValue(state));
+    case "add-model-input":
+      return unchanged(state.step === "models" ? enterInput(state, "add-model", "") : state);
+    case "continue-multi":
+      return continueMultiSelect(state);
+    case "effect-result":
+      return unchanged(applyEffectResult(state, action.result));
+  }
+}
+
+function setupSelectionCount(state: SetupState): number {
+  if (state.step === "models") return setupMultiSelectChoices(state.models).length;
+  if (state.step === "mcp-engines") return setupMultiSelectChoices(engineIds).length;
+  return setupChoiceItems(state).length;
+}
+
+export function setupChoiceItems(state: SetupState): SetupChoiceItem[] {
+  const items = baseChoiceItems(state);
+  return setupChoiceSupportsBack(state.step)
+    ? [...items, { label: "Back", detail: "Return to the previous step" }]
+    : items;
+}
+
+function baseChoiceItems(state: SetupState): SetupChoiceItem[] {
+  switch (state.step) {
+    case "welcome": return [
+      { label: "Begin guided setup", detail: "No configuration files to edit" },
+      { label: "Exit", detail: "You can reopen Setup from the Start Menu" },
+    ];
+    case "discovery-error": return [
+      { label: "Retry model discovery" },
+      { label: "Edit Base URL" },
+      { label: "Add a model manually", detail: "Continue even when /models is unavailable" },
+    ];
+    case "default-model": return state.selectedModels.map((model) => ({ label: model }));
+    case "tavily-choice": return [
+      { label: "Skip for now", detail: "Web research can be added later" },
+      { label: "Configure Tavily", detail: "Add optional web research tools" },
+    ];
+    case "mcp-choice": return [
+      { label: "Skip for now", detail: "MCP servers can be added later" },
+      { label: "Add an MCP server", detail: "Streamable HTTP" },
+    ];
+    case "mcp-auth": return [
+      { label: "No authentication" },
+      { label: "Bearer token", detail: "Authorization: Bearer ..." },
+      { label: "Custom header", detail: "For X-API-Key and similar services" },
+    ];
+    case "mcp-result": return [
+      { label: state.mcpTestError ? "Save server anyway" : "Save server and continue", detail: state.mcpTestError ? "The failed connection is recorded only after this choice" : undefined },
+      { label: "Retry test" },
+      { label: "Edit server URL" },
+    ];
+    case "mcp-more": return [
+      { label: "Continue", detail: `${state.mcpServers.length} MCP server(s) ready` },
+      { label: "Add another MCP server" },
+    ];
+    case "permissions": return permissionOptions.map((option) => ({ label: option.label, detail: option.detail }));
+    case "project-choice": return [
+      { label: "Skip project selection", detail: "Launch projects later with vesicle ." },
+      { label: "Choose a folder for the first launch", detail: "Used once; never pinned" },
+    ];
+    case "review": return [
+      { label: "Save configuration", detail: "Existing files receive timestamped backups" },
+      { label: state.projectDirectory ? "Change one-time launch folder" : "Choose a one-time launch folder" },
+      ...(state.projectDirectory ? [{ label: "Skip the one-time launch", detail: "No project is saved globally" }] : []),
+    ];
+    case "complete": return state.projectDirectory
+      ? [
+          { label: "Launch this folder once", detail: state.projectDirectory },
+          { label: "Exit Setup", detail: "Later, run vesicle . in a project" },
+        ]
+      : [{ label: "Exit Setup", detail: "Run vesicle . from any project folder" }];
+    case "save-error": return [
+      { label: "Retry save" },
+      { label: "Back to review" },
+      { label: "Exit without changes" },
+    ];
+    default: return [];
+  }
+}
+
+function submitInput(state: SetupState, value: string, env: NodeJS.ProcessEnv): SetupTransition {
+  switch (state.step) {
+    case "base-url": {
+      try {
+        const normalized = normalizeOpenAIBaseUrl(value);
+        return unchanged(enterInput({ ...state, baseUrl: normalized }, "api-key", "", `Models will be requested from ${normalized}/models.`));
+      } catch (error) {
+        return unchanged({ ...state, status: errorMessage(error) });
+      }
+    }
+    case "api-key":
+      if (!value) return unchanged({ ...state, status: "API key is required." });
+      return beginDiscovery({ ...state, apiKey: value });
+    case "add-model": {
+      if (!value) return unchanged({ ...state, status: "Enter an exact model id." });
+      const models = [...new Set([...state.models, value])].sort((a, b) => a.localeCompare(b));
+      return unchanged({
+        ...state,
+        models,
+        selectedModels: [...new Set([...state.selectedModels, value])],
+        step: "models",
+        selectedIndex: Math.max(0, models.indexOf(value)),
+        status: `Added and selected ${value}.`,
+      });
+    }
+    case "tavily-key":
+      if (!value) return unchanged({ ...state, status: "Enter a Tavily API key, or press Esc to skip." });
+      return unchanged({ ...state, tavilyApiKey: value, step: "mcp-choice", selectedIndex: 0, status: "Tavily will be available to the ETL and Evaluate engines." });
+    case "mcp-name":
+      if (!value) return unchanged({ ...state, status: "Enter a short name for this MCP server." });
+      return unchanged(enterInput({ ...state, mcpDraft: { ...state.mcpDraft, name: value } }, "mcp-url", ""));
+    case "mcp-url": {
+      try {
+        const url = new URL(value);
+        if (url.protocol !== "https:" && url.protocol !== "http:") throw new Error("MCP URL must use http:// or https://.");
+        return unchanged({
+          ...state,
+          mcpDraft: { ...state.mcpDraft, url: url.toString() },
+          step: "mcp-auth",
+          selectedIndex: 0,
+          status: "Choose how this MCP server authenticates.",
+        });
+      } catch (error) {
+        return unchanged({ ...state, status: errorMessage(error) });
+      }
+    }
+    case "mcp-header":
+      if (!/^[A-Za-z0-9-]+$/.test(value)) return unchanged({ ...state, status: "Header name may contain letters, numbers, and hyphens." });
+      return unchanged(enterInput({ ...state, mcpDraft: { ...state.mcpDraft, headerName: value } }, "mcp-secret", ""));
+    case "mcp-secret":
+      if (!value) return unchanged({ ...state, status: "Authentication secret is required." });
+      return unchanged({
+        ...state,
+        mcpDraft: { ...state.mcpDraft, secret: value },
+        step: "mcp-engines",
+        selectedIndex: 0,
+        status: "Space toggles Engines; Enter tests the server.",
+      });
+    case "project": {
+      if (!value) return unchanged({ ...state, status: "Enter a folder for the one-time launch, or press Esc to skip it." });
+      return unchanged({
+        ...state,
+        projectDirectory: resolveProjectPath(value, env),
+        step: "review",
+        selectedIndex: 0,
+        status: "Review the choices, then save them together.",
+      });
+    }
+    default:
+      return unchanged(state);
+  }
+}
+
+function chooseCurrent(state: SetupState, env: NodeJS.ProcessEnv): SetupTransition {
+  const index = state.selectedIndex;
+  if (setupChoiceSupportsBack(state.step) && index === setupChoiceItems(state).length - 1) return unchanged(goBack(state));
+  switch (state.step) {
+    case "welcome":
+      return index === 0 ? unchanged(enterInput(state, "base-url", "")) : { state, completion: { launch: false } };
+    case "discovery-error":
+      if (index === 0) return beginDiscovery(state);
+      if (index === 1) return unchanged(enterInput(state, "base-url", state.baseUrl));
+      return unchanged(enterInput({ ...state, models: [], selectedModels: [] }, "add-model", ""));
+    case "default-model": {
+      const model = state.selectedModels[index];
+      if (!model) return unchanged(state);
+      return unchanged({ ...state, defaultModel: model, step: "tavily-choice", selectedIndex: 0, status: "Tavily web research is optional and can be configured later." });
+    }
+    case "tavily-choice":
+      return index === 0
+        ? unchanged({ ...state, tavilyApiKey: "", step: "mcp-choice", selectedIndex: 0 })
+        : unchanged(enterInput(state, "tavily-key", ""));
+    case "mcp-choice":
+      return index === 0
+        ? unchanged({ ...state, step: "permissions", selectedIndex: 0, status: "Choose how often Vesicle should ask before using tools." })
+        : unchanged(enterInput({ ...state, mcpDraft: emptyMcpDraft() }, "mcp-name", ""));
+    case "mcp-auth": {
+      const auth = (["none", "bearer", "custom-header"] as const)[index] ?? "none";
+      const next = { ...state, mcpDraft: { ...state.mcpDraft, auth } };
+      if (auth === "none") return unchanged({ ...next, step: "mcp-engines", selectedIndex: 0, status: "Space toggles Engines; Enter tests the server." });
+      return unchanged(enterInput(next, auth === "custom-header" ? "mcp-header" : "mcp-secret", auth === "custom-header" ? "X-API-Key" : ""));
+    }
+    case "mcp-result":
+      if (index === 0) return unchanged({
+        ...state,
+        mcpServers: [...state.mcpServers, state.mcpDraft],
+        step: "mcp-more",
+        selectedIndex: 0,
+        status: "The server will be written when Setup saves all configuration.",
+      });
+      if (index === 1) return beginMcpTest(state);
+      return unchanged(enterInput(state, "mcp-url", state.mcpDraft.url));
+    case "mcp-more":
+      return index === 0
+        ? unchanged({ ...state, step: "permissions", selectedIndex: 0, status: "Choose how often Vesicle should ask before using tools." })
+        : unchanged(enterInput({ ...state, mcpDraft: emptyMcpDraft() }, "mcp-name", ""));
+    case "permissions": {
+      const option = permissionOptions[index] ?? permissionOptions[0];
+      return unchanged({ ...state, permissionMode: option.mode, step: "project-choice", selectedIndex: 0, status: "Project selection is optional and is never saved as a global default." });
+    }
+    case "project-choice":
+      if (index === 0) return unchanged({ ...state, projectDirectory: "", step: "review", selectedIndex: 0, status: "No project will be pinned. Launch Vesicle from any folder with vesicle ." });
+      return unchanged(enterInput({ ...state, projectInputReturnStep: "project-choice" }, "project", state.projectDirectory || defaultProjectDirectory(env), "This folder is used for the first launch only and is not saved globally."));
+    case "review":
+      if (index === 0) return beginSave(state);
+      if (index === 1) return unchanged(enterInput({ ...state, projectInputReturnStep: "review" }, "project", state.projectDirectory || defaultProjectDirectory(env)));
+      return unchanged({ ...state, projectDirectory: "", selectedIndex: 0, status: "The one-time first launch was removed; no project will be pinned." });
+    case "complete": {
+      const launch = Boolean(state.projectDirectory) && index === 0;
+      return {
+        state,
+        completion: {
+          launch,
+          ...(launch ? { projectDirectory: state.projectDirectory } : {}),
+          writeResult: state.writeResult,
+        },
+      };
+    }
+    case "save-error":
+      if (index === 0) return beginSave(state);
+      if (index === 1) return unchanged({ ...state, step: "review", selectedIndex: 0 });
+      return { state, completion: { launch: false } };
+    default:
+      return unchanged(state);
+  }
+}
+
+function continueMultiSelect(state: SetupState): SetupTransition {
+  const choices = setupMultiSelectChoices(state.step === "models" ? state.models : [...engineIds]);
+  if (setupMultiSelectBackAt(choices, state.selectedIndex)) return unchanged(goBack(state));
+  if (state.step === "models") {
+    if (state.selectedModels.length === 0) return unchanged({ ...state, status: "Select at least one model with Space, or press A to add one." });
+    return unchanged({ ...state, selectedIndex: 0, step: "default-model", status: "Choose the model Vesicle should use by default." });
+  }
+  if (state.step === "mcp-engines") {
+    if (state.mcpDraft.enabledEngines.length === 0) return unchanged({ ...state, status: "Select at least one Engine with Space." });
+    return beginMcpTest(state);
+  }
+  return unchanged(state);
+}
+
+function toggleMultiValue(state: SetupState): SetupState {
+  const choices = setupMultiSelectChoices(state.step === "models" ? state.models : [...engineIds]);
+  const value = setupMultiSelectValueAt(choices, state.selectedIndex);
+  if (!value) return state;
+  if (state.step === "models") {
+    const model = value as string;
+    return {
+      ...state,
+      selectedModels: state.selectedModels.includes(model)
+        ? state.selectedModels.filter((entry) => entry !== model)
+        : [...state.selectedModels, model],
+    };
+  }
+  if (state.step === "mcp-engines") {
+    const engine = value as EngineId;
+    return {
+      ...state,
+      mcpDraft: {
+        ...state.mcpDraft,
+        enabledEngines: state.mcpDraft.enabledEngines.includes(engine)
+          ? state.mcpDraft.enabledEngines.filter((entry) => entry !== engine)
+          : [...state.mcpDraft.enabledEngines, engine],
+      },
+    };
+  }
+  return state;
+}
+
+function beginDiscovery(state: SetupState): SetupTransition {
+  return {
+    state: { ...state, step: "discovering", status: "Contacting the provider without saving the API key yet..." },
+    effect: { kind: "discover-models", baseUrl: state.baseUrl, apiKey: state.apiKey },
+  };
+}
+
+function beginMcpTest(state: SetupState): SetupTransition {
+  return {
+    state: {
+      ...state,
+      step: "mcp-testing",
+      mcpTestResult: null,
+      mcpTestError: "",
+      status: "Initializing the MCP server and requesting its tool list...",
+    },
+    effect: { kind: "test-mcp", server: state.mcpDraft },
+  };
+}
+
+function beginSave(state: SetupState): SetupTransition {
+  return {
+    state: { ...state, step: "saving", status: "Validating and saving user configuration with backups..." },
+    effect: {
+      kind: "save-configuration",
+      configuration: {
+        baseUrl: state.baseUrl,
+        apiKey: state.apiKey,
+        modelIds: state.selectedModels,
+        defaultModel: state.defaultModel,
+        ...(state.tavilyApiKey ? { tavilyApiKey: state.tavilyApiKey } : {}),
+        ...(state.mcpServers.length ? { mcpServers: state.mcpServers } : {}),
+        permissionMode: state.permissionMode,
+        ...(state.projectDirectory ? { projectDirectory: state.projectDirectory } : {}),
+      },
+    },
+  };
+}
+
+function applyEffectResult(state: SetupState, result: SetupEffectResult): SetupState {
+  switch (result.kind) {
+    case "discovery-succeeded":
+      return {
+        ...state,
+        baseUrl: result.result.baseUrl,
+        models: result.result.models,
+        selectedModels: result.result.models[0] ? [result.result.models[0]] : [],
+        selectedIndex: 0,
+        step: "models",
+        status: `Found ${result.result.models.length} models. Space toggles; A adds an exact model id.`,
+      };
+    case "discovery-failed":
+      return { ...state, step: "discovery-error", selectedIndex: 0, status: result.error };
+    case "mcp-test-succeeded":
+      return {
+        ...state,
+        mcpTestResult: result.result,
+        mcpTestError: "",
+        step: "mcp-result",
+        selectedIndex: 0,
+        status: `Connected successfully; discovered ${result.result.toolCount} tools.`,
+      };
+    case "mcp-test-failed":
+      return {
+        ...state,
+        mcpTestResult: null,
+        mcpTestError: result.error,
+        step: "mcp-result",
+        selectedIndex: 0,
+        status: "The MCP test failed. You may edit, retry, or explicitly save it anyway.",
+      };
+    case "save-succeeded":
+      return {
+        ...state,
+        writeResult: result.result,
+        step: "complete",
+        selectedIndex: 0,
+        status: result.result.backups.length > 0
+          ? `Saved successfully and created ${result.result.backups.length} backups.`
+          : "Saved successfully. Prism Vesicle is ready to launch.",
+      };
+    case "save-failed":
+      return { ...state, step: "save-error", selectedIndex: 0, status: result.error };
+  }
+}
+
+function goBack(state: SetupState): SetupState {
+  switch (state.step) {
+    case "base-url": return { ...state, step: "welcome" };
+    case "api-key": return enterInput(state, "base-url", state.baseUrl);
+    case "add-model": return { ...state, step: "models" };
+    case "tavily-key": return { ...state, step: "tavily-choice" };
+    case "mcp-name": return { ...state, step: "mcp-choice" };
+    case "mcp-url": return enterInput(state, "mcp-name", state.mcpDraft.name);
+    case "mcp-header":
+    case "mcp-secret": return { ...state, step: "mcp-auth" };
+    case "project": return { ...state, step: state.projectInputReturnStep };
+    case "discovery-error": return enterInput(state, "api-key", "");
+    case "models": return enterInput(state, "api-key", "");
+    case "default-model": return returnToChoice(state, "models", Math.max(0, state.selectedModels.indexOf(state.defaultModel)));
+    case "tavily-choice": return returnToChoice(state, "default-model", Math.max(0, state.selectedModels.indexOf(state.defaultModel)));
+    case "mcp-choice": return returnToChoice(state, "tavily-choice", state.tavilyApiKey ? 1 : 0);
+    case "mcp-auth": return enterInput(state, "mcp-url", state.mcpDraft.url);
+    case "mcp-engines": return returnToChoice(state, "mcp-auth", Math.max(0, ["none", "bearer", "custom-header"].indexOf(state.mcpDraft.auth)));
+    case "mcp-result": return enterInput(state, "mcp-url", state.mcpDraft.url);
+    case "mcp-more":
+    case "permissions": return returnToChoice(state, "mcp-choice");
+    case "project-choice": return returnToChoice(state, "permissions", Math.max(0, permissionOptions.findIndex((option) => option.mode === state.permissionMode)));
+    case "review": return returnToChoice(state, "project-choice", setupReviewBackIndex(state.projectDirectory));
+    case "save-error": return returnToChoice(state, "review");
+    default: return state;
+  }
+}
+
+function enterInput(state: SetupState, step: SetupInputStep, value: string, status = inputHint(step)): SetupState {
+  return { ...state, input: { value, cursor: value.length }, step, status };
+}
+
+function returnToChoice(state: SetupState, step: SetupStep, selectedIndex = 0): SetupState {
+  return { ...state, step, selectedIndex };
+}
+
+function unchanged(state: SetupState): SetupTransition {
+  return { state };
+}
+
+export function setupMultiSelectChoices<T>(values: readonly T[]): Array<SetupMultiSelectChoice<T>> {
+  return [...values.map((value) => ({ kind: "value" as const, value })), { kind: "back" }];
+}
+
+export function setupMultiSelectValueAt<T>(choices: Array<SetupMultiSelectChoice<T>>, index: number): T | undefined {
+  const choice = choices[index];
+  return choice?.kind === "value" ? choice.value : undefined;
+}
+
+export function setupMultiSelectBackAt<T>(choices: Array<SetupMultiSelectChoice<T>>, index: number): boolean {
+  return choices[index]?.kind === "back";
+}
+
+export function setupChoiceSupportsBack(step: SetupStep): boolean {
+  return explicitBackSteps.includes(step);
+}
+
+export function setupReviewBackIndex(projectDirectory: string): number {
+  return projectDirectory ? 1 : 0;
+}
+
+export function setupIsBusy(step: SetupStep): boolean {
+  return step === "discovering" || step === "mcp-testing" || step === "saving";
+}
+
+export function isSetupInputStep(step: SetupStep): step is SetupInputStep {
+  return ["base-url", "api-key", "add-model", "tavily-key", "mcp-name", "mcp-url", "mcp-header", "mcp-secret", "project"].includes(step);
+}
+
+export function isSetupSecretStep(step: SetupStep): boolean {
+  return step === "api-key" || step === "tavily-key" || step === "mcp-secret";
+}
+
+export function defaultProjectDirectory(env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.USERPROFILE || env.HOME || homedir();
+  return join(home, "Documents", "PrismVesicle", "MyFirstProject");
+}
+
+export function resolveProjectPath(input: string, env: NodeJS.ProcessEnv = process.env): string {
+  const home = env.USERPROFILE || env.HOME || homedir();
+  const expanded = input.trim().replace(/^~(?=$|[\\/])/, home);
+  return resolve(expanded);
+}
+
+function emptyMcpDraft(): SetupMcpServer {
+  return { name: "", url: "", auth: "none", enabledEngines: ["etl", "evaluate"] };
+}
+
+function inputHint(step: SetupInputStep): string {
+  if (isSetupSecretStep(step)) return "Input is masked. Enter continues; Esc goes back without saving.";
+  if (step === "base-url") return "Enter the API base. A missing /v1 suffix is added automatically.";
+  if (step === "project") return "The folder is created when Setup saves; it is never saved as a global project.";
+  return "Enter continues; Esc goes back.";
+}
+
+function wrapIndex(value: number, length: number): number {
+  if (length <= 0) return 0;
+  return ((value % length) + length) % length;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error && error.message.trim() ? error.message : String(error);
+}

--- a/src/setup/setup-views.tsx
+++ b/src/setup/setup-views.tsx
@@ -1,0 +1,289 @@
+import { TextAttributes } from "@opentui/core";
+import { For, Match, Show, Switch, createMemo } from "solid-js";
+import { engineIds, type EngineId } from "../core/engine/profile";
+import { PromptComposer } from "../tui/PromptComposer";
+import { truncateLine } from "../tui/format";
+import { palette } from "../tui/theme";
+import {
+  isSetupInputStep,
+  isSetupSecretStep,
+  setupChoiceItems,
+  setupMultiSelectChoices,
+  type SetupChoiceItem,
+  type SetupInputStep,
+  type SetupState,
+  type SetupStep,
+} from "./setup-state";
+
+export type SetupViewProps = {
+  state: SetupState;
+  width: number;
+  height: number;
+};
+
+export function SetupView(props: SetupViewProps) {
+  const compact = () => setupUsesCompactHeight(props.height, props.state.step);
+  const rootPaddingX = () => props.width < 64 ? 1 : 2;
+  const panelPaddingX = () => props.width < 64 ? 1 : 2;
+  const panelTextWidth = () => Math.max(8, props.width - (rootPaddingX() * 2) - (panelPaddingX() * 2) - 2);
+  const statusWidth = () => Math.max(8, props.width - (rootPaddingX() * 2));
+
+  return (
+    <box flexDirection="column" width="100%" height="100%" paddingX={rootPaddingX()} paddingY={compact() ? 0 : 1} overflow="hidden" backgroundColor={palette.bg}>
+      <box height={compact() ? 1 : 2} flexDirection="column" overflow="hidden">
+        <text content={truncateLine("Prism Vesicle Setup", panelTextWidth())} wrapMode="none" fg={palette.brand} attributes={TextAttributes.BOLD} />
+        <text content={compact() ? "" : progressLabel(props.state.step)} height={compact() ? 0 : 1} wrapMode="none" fg={palette.textDim} />
+      </box>
+      <box marginTop={compact() ? 0 : 1} flexGrow={1} flexDirection="column" border borderColor={palette.panelBorder} paddingX={panelPaddingX()} paddingY={compact() ? 0 : 1} overflow="hidden">
+        <text content={truncateLine(pageTitle(props.state.step), panelTextWidth())} wrapMode="none" fg={palette.textPrimary} attributes={TextAttributes.BOLD} />
+        <text content={compact() ? "" : truncateLine(pageDescription(props.state.step), panelTextWidth())} height={compact() ? 0 : 1} wrapMode="none" fg={palette.textSecondary} />
+        <box marginTop={compact() ? 0 : 1} flexDirection="column" flexGrow={1} overflow="hidden">
+          <Show when={isSetupInputStep(props.state.step)} fallback={
+            <ChoicePageView state={props.state} width={panelTextWidth()} height={props.height} compact={compact()} />
+          }>
+            <InputPageView state={props.state} width={panelTextWidth()} />
+          </Show>
+        </box>
+      </box>
+      <box height={compact() ? 1 : 3} marginTop={compact() ? 0 : 1} flexDirection="column" overflow="hidden">
+        <text content={truncateLine(props.state.status, statusWidth())} wrapMode="none" fg={statusIsError(props.state.status) ? palette.error : palette.textSecondary} />
+        <text content={compact() ? "" : truncateLine("Secrets stay in .env; Setup never writes them to YAML or logs.", statusWidth())} height={compact() ? 0 : 1} wrapMode="none" fg={palette.textDim} />
+      </box>
+    </box>
+  );
+}
+
+function InputPageView(props: { state: SetupState; width: number }) {
+  const step = () => props.state.step as SetupInputStep;
+  return (
+    <>
+      <text content={truncateLine(inputLabel(step()), props.width)} wrapMode="none" fg={palette.textSecondary} />
+      <box marginTop={1} border borderColor={palette.brandDim} paddingX={1} height={3}>
+        <PromptComposer
+          value={isSetupSecretStep(step()) ? maskValue(props.state.input.value) : props.state.input.value}
+          cursor={props.state.input.cursor}
+          placeholder={inputPlaceholder(step())}
+          width={Math.max(4, props.width - 4)}
+          maxLines={1}
+        />
+      </box>
+      <text content={truncateLine("Enter continues · Esc goes back", props.width)} wrapMode="none" fg={palette.textDim} />
+    </>
+  );
+}
+
+function ChoicePageView(props: { state: SetupState; width: number; height: number; compact: boolean }) {
+  return (
+    <Switch fallback={
+      <box flexDirection="column"><OptionList items={setupChoiceItems(props.state)} selectedIndex={props.state.selectedIndex} width={props.width} /></box>
+    }>
+      <Match when={props.state.step === "discovering" || props.state.step === "mcp-testing" || props.state.step === "saving"}>
+        <text content="Working..." fg={palette.warn} />
+      </Match>
+      <Match when={props.state.step === "models" || props.state.step === "mcp-engines"}>
+        <MultiSelectPageView state={props.state} width={props.width} height={props.height} />
+      </Match>
+      <Match when={props.state.step === "review"}>
+        <ReviewPageView state={props.state} width={props.width} compact={props.compact} />
+      </Match>
+      <Match when={props.state.step === "mcp-result"}>
+        <McpResultPageView state={props.state} width={props.width} />
+      </Match>
+    </Switch>
+  );
+}
+
+function MultiSelectPageView(props: { state: SetupState; width: number; height: number }) {
+  const window = createMemo(() => {
+    const values = props.state.step === "models" ? props.state.models : [...engineIds];
+    return visibleWindow(setupMultiSelectChoices(values), props.state.selectedIndex, setupMultiSelectVisibleRowLimit(props.height));
+  });
+  return (
+    <box flexDirection="column">
+      <For each={window().visible}>{(item, index) => {
+        const absolute = () => window().start + index();
+        const selected = () => absolute() === props.state.selectedIndex;
+        const checked = () => item.kind === "value" && (props.state.step === "models"
+          ? props.state.selectedModels.includes(item.value as string)
+          : props.state.mcpDraft.enabledEngines.includes(item.value as EngineId));
+        const content = () => item.kind === "back"
+          ? `${selected() ? ">" : " "} Back  — Return to the previous step`
+          : `${selected() ? ">" : " "} [${checked() ? "x" : " "}] ${item.value}`;
+        return <text
+          content={truncateLine(content(), props.width)}
+          wrapMode="none"
+          fg={selected() ? palette.textPrimary : palette.textSecondary}
+          attributes={selected() ? TextAttributes.BOLD : TextAttributes.NONE}
+        />;
+      }}</For>
+      <text content={truncateLine(props.state.step === "models" ? "Space toggles · A adds a model · Enter continues · Esc goes back" : "Space toggles · Enter tests connection · Esc goes back", props.width)} wrapMode="none" fg={palette.textDim} />
+    </box>
+  );
+}
+
+function ReviewPageView(props: { state: SetupState; width: number; compact: boolean }) {
+  return (
+    <box flexDirection="column">
+      <text content={truncateLine(`Provider  ${props.state.baseUrl}`, props.width)} wrapMode="none" fg={palette.textSecondary} />
+      <text content={truncateLine(`Models    ${props.state.selectedModels.length} selected · default ${props.state.defaultModel}`, props.width)} wrapMode="none" fg={palette.textSecondary} />
+      <Show when={!props.compact} fallback={
+        <text content={truncateLine(`Permission ${props.state.permissionMode} · Tavily ${props.state.tavilyApiKey ? "on" : "off"} · MCP ${props.state.mcpServers.length}`, props.width)} wrapMode="none" fg={palette.textSecondary} />
+      }>
+        <text content={truncateLine(`Tavily    ${props.state.tavilyApiKey ? "configured" : "skipped"}`, props.width)} wrapMode="none" fg={palette.textSecondary} />
+        <text content={truncateLine(`MCP       ${props.state.mcpServers.length} server(s)`, props.width)} wrapMode="none" fg={palette.textSecondary} />
+        <text content={truncateLine(`Permission ${props.state.permissionMode} · shell default off / existing setting preserved`, props.width)} wrapMode="none" fg={palette.textSecondary} />
+      </Show>
+      <text content={truncateLine(`First run ${props.state.projectDirectory || "skipped; no project is pinned"}`, props.width)} wrapMode="none" fg={palette.textSecondary} />
+      <box marginTop={1} flexDirection="column">
+        <OptionList items={setupChoiceItems(props.state)} selectedIndex={props.state.selectedIndex} width={props.width} />
+      </box>
+    </box>
+  );
+}
+
+function McpResultPageView(props: { state: SetupState; width: number }) {
+  const result = () => props.state.mcpTestResult;
+  return (
+    <box flexDirection="column">
+      <text content={truncateLine(props.state.mcpTestError || `Connected${result()?.serverName ? ` to ${result()!.serverName}` : ""}; ${result()?.toolCount ?? 0} tools found.`, props.width)} wrapMode="none" fg={props.state.mcpTestError ? palette.error : palette.success} />
+      <box marginTop={1} flexDirection="column">
+        <OptionList items={setupChoiceItems(props.state)} selectedIndex={props.state.selectedIndex} width={props.width} />
+      </box>
+    </box>
+  );
+}
+
+function OptionList(props: { items: SetupChoiceItem[]; selectedIndex: number; width: number }) {
+  return <For each={props.items}>{(item, index) => {
+    const selected = () => index() === props.selectedIndex;
+    return <text
+      content={truncateLine(`${selected() ? ">" : " "} ${item.label}${item.detail ? `  — ${item.detail}` : ""}`, props.width)}
+      wrapMode="none"
+      fg={selected() ? palette.textPrimary : palette.textSecondary}
+      attributes={selected() ? TextAttributes.BOLD : TextAttributes.NONE}
+    />;
+  }}</For>;
+}
+
+export function setupUsesCompactHeight(height: number, currentStep?: SetupStep): boolean {
+  return height < (currentStep === "review" ? 27 : 24);
+}
+
+export function setupMultiSelectVisibleRowLimit(height: number): number {
+  const structuralRows = setupUsesCompactHeight(height, "models") ? 6 : 17;
+  return Math.max(5, Math.min(14, height - structuralRows));
+}
+
+export function maskValue(value: string): string {
+  return value.replace(/[\s\S]/g, "•");
+}
+
+function inputLabel(step: SetupInputStep): string {
+  const labels: Record<SetupInputStep, string> = {
+    "base-url": "OpenAI-compatible Base URL",
+    "api-key": "Provider API key",
+    "add-model": "Exact model id",
+    "tavily-key": "Tavily API key",
+    "mcp-name": "MCP server name",
+    "mcp-url": "MCP Streamable HTTP URL",
+    "mcp-header": "Authentication header name",
+    "mcp-secret": "MCP authentication secret",
+    "project": "One-time first-launch folder",
+  };
+  return labels[step];
+}
+
+function inputPlaceholder(step: SetupInputStep): string {
+  const placeholders: Record<SetupInputStep, string> = {
+    "base-url": "https://api.example.com/v1",
+    "api-key": "Paste the key; it is masked",
+    "add-model": "provider-model-id",
+    "tavily-key": "tvly-...",
+    "mcp-name": "Research server",
+    "mcp-url": "https://mcp.example.com/mcp",
+    "mcp-header": "X-API-Key",
+    "mcp-secret": "Paste the token; it is masked",
+    "project": "C:\\Users\\you\\Documents\\PrismVesicle\\MyFirstProject",
+  };
+  return placeholders[step];
+}
+
+function pageTitle(step: SetupStep): string {
+  const titles: Record<SetupStep, string> = {
+    welcome: "Welcome",
+    "base-url": "Connect a model provider",
+    "api-key": "Authenticate securely",
+    discovering: "Discovering models",
+    "discovery-error": "Model discovery needs attention",
+    models: "Choose available models",
+    "add-model": "Add a model manually",
+    "default-model": "Choose the default model",
+    "tavily-choice": "Optional web research",
+    "tavily-key": "Configure Tavily",
+    "mcp-choice": "Optional MCP tools",
+    "mcp-name": "Name the MCP server",
+    "mcp-url": "Connect the MCP server",
+    "mcp-auth": "MCP authentication",
+    "mcp-header": "Custom MCP header",
+    "mcp-secret": "MCP secret",
+    "mcp-engines": "Choose MCP Engines",
+    "mcp-testing": "Testing MCP connection",
+    "mcp-result": "MCP connection result",
+    "mcp-more": "MCP configuration",
+    permissions: "Tool approval preference",
+    "project-choice": "Optional first launch",
+    project: "Choose a one-time launch folder",
+    review: "Review and save",
+    saving: "Saving configuration",
+    complete: "Setup complete",
+    "save-error": "Configuration was not saved",
+  };
+  return titles[step];
+}
+
+function pageDescription(step: SetupStep): string {
+  if (step === "welcome") return "No YAML editing is required. Existing configuration is merged and backed up.";
+  if (step === "models") return "The provider returned model ids. Select only the models you want Vesicle to offer.";
+  if (step === "tavily-choice") return "Tavily enables web_search and related research tools. It is not required for the first conversation.";
+  if (step === "mcp-choice") return "MCP servers add external tools. Each server can be limited to selected Prism Engines.";
+  if (step === "permissions") return "Permission presets change approval friction; they never weaken path, process, or tool guards.";
+  if (step === "project-choice") return "Vesicle never stores one global project. Optionally choose a folder for this first launch only.";
+  if (step === "complete") return "Configuration validated successfully. Project selection remains local to each launch.";
+  return "Follow the prompt below. Nothing is written until the final review step.";
+}
+
+function progressLabel(step: SetupStep): string {
+  const order: SetupStep[] = ["welcome", "base-url", "api-key", "models", "default-model", "tavily-choice", "mcp-choice", "permissions", "project-choice", "review", "complete"];
+  const aliases: Partial<Record<SetupStep, SetupStep>> = {
+    discovering: "api-key",
+    "discovery-error": "api-key",
+    "add-model": "models",
+    "tavily-key": "tavily-choice",
+    "mcp-name": "mcp-choice",
+    "mcp-url": "mcp-choice",
+    "mcp-auth": "mcp-choice",
+    "mcp-header": "mcp-choice",
+    "mcp-secret": "mcp-choice",
+    "mcp-engines": "mcp-choice",
+    "mcp-testing": "mcp-choice",
+    "mcp-result": "mcp-choice",
+    "mcp-more": "mcp-choice",
+    project: "project-choice",
+    saving: "review",
+    "save-error": "review",
+  };
+  const current = aliases[step] ?? step;
+  const index = Math.max(0, order.indexOf(current));
+  return `Step ${index + 1} of ${order.length}`;
+}
+
+function visibleWindow<T>(items: T[], selected: number, maximum: number): { start: number; visible: T[] } {
+  if (items.length <= maximum) return { start: 0, visible: items };
+  const start = Math.max(0, Math.min(selected - Math.floor(maximum / 2), items.length - maximum));
+  return { start, visible: items.slice(start, start + maximum) };
+}
+
+function statusIsError(status: string): boolean {
+  const normalized = status.toLowerCase();
+  return normalized.includes("failed") || normalized.includes("required");
+}

--- a/tests/component/setup/setup-ui.test.tsx
+++ b/tests/component/setup/setup-ui.test.tsx
@@ -14,6 +14,8 @@ import {
   setupReviewBackIndex,
   setupUsesCompactHeight,
 } from "../../../src/setup/app";
+import { createInitialSetupState, type SetupState } from "../../../src/setup/setup-state";
+import { SetupView } from "../../../src/setup/setup-views";
 
 describe("guided Setup UI", () => {
   test("renders a friendly no-YAML welcome screen", async () => {
@@ -100,6 +102,29 @@ describe("guided Setup UI", () => {
     expect(frame).toContain("Skip the one-time launch");
     expect(frame).toContain("Back");
     expect(frame.split("\n")).toHaveLength(25);
+  });
+
+  test("renders input and bounded multi-select page families", async () => {
+    const models = Array.from({ length: 12 }, (_, index) => `model-${String(index).padStart(2, "0")}`);
+    const inputState: SetupState = { ...createInitialSetupState(), step: "base-url" };
+    const input = await testRender(() => <SetupView state={inputState} width={80} height={24} />, { width: 80, height: 24 });
+    await input.flush();
+    expect(input.captureCharFrame()).toContain("OpenAI-compatible Base URL");
+    input.renderer.destroy();
+
+    const modelState: SetupState = {
+      ...createInitialSetupState(),
+      step: "models",
+      models,
+      selectedModels: [models[9]!],
+      selectedIndex: 9,
+    };
+    const multi = await testRender(() => <SetupView state={modelState} width={80} height={24} />, { width: 80, height: 24 });
+    await multi.flush();
+    const frame = multi.captureCharFrame();
+    multi.renderer.destroy();
+    expect(frame).toContain("model-09");
+    expect(frame).not.toContain("model-00");
   });
 
   test("offers explicit Back actions and resets review navigation to a valid project choice", () => {

--- a/tests/unit/setup/setup-transition.test.ts
+++ b/tests/unit/setup/setup-transition.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { createInitialSetupState, setupChoiceItems, transitionSetup, type SetupState } from "../../../src/setup/setup-state";
+
+describe("Setup transitions", () => {
+  test("discovery failure remains retryable without renderer or network", () => {
+    let state = createInitialSetupState({}, "base-url");
+    state = transitionSetup(state, { type: "submit-input", value: "https://api.example.com" }, {}).state;
+    const discovery = transitionSetup(state, { type: "submit-input", value: "secret" }, {});
+    expect(discovery.effect).toEqual({
+      kind: "discover-models",
+      baseUrl: "https://api.example.com/v1",
+      apiKey: "secret",
+    });
+
+    state = transitionSetup(discovery.state, { type: "effect-result", result: { kind: "discovery-failed", error: "HTTP 503" } }, {}).state;
+    expect(state.step).toBe("discovery-error");
+    const retry = transitionSetup(state, { type: "choose" }, {});
+    expect(retry.state.step).toBe("discovering");
+    expect(retry.effect?.kind).toBe("discover-models");
+  });
+
+  test("MCP auth paths return to the URL without losing the server draft", () => {
+    let state: SetupState = {
+      ...createInitialSetupState({}, "mcp-auth"),
+      mcpDraft: { name: "Research", url: "https://mcp.example.com/mcp", auth: "none", enabledEngines: ["etl"] },
+      selectedIndex: 1,
+    };
+    state = transitionSetup(state, { type: "choose" }, {}).state;
+    expect(state.step).toBe("mcp-secret");
+    expect(state.mcpDraft.auth).toBe("bearer");
+
+    state = transitionSetup(state, { type: "back" }, {}).state;
+    expect(state.step).toBe("mcp-auth");
+    state = transitionSetup(state, { type: "back" }, {}).state;
+    expect(state.step).toBe("mcp-url");
+    expect(state.input.value).toBe("https://mcp.example.com/mcp");
+    expect(state.mcpDraft.name).toBe("Research");
+  });
+
+  test("review Back restores the matching project choice", () => {
+    let state = { ...createInitialSetupState({}, "review"), projectDirectory: "C:\\Story" };
+    state = { ...state, selectedIndex: setupChoiceItems(state).length - 1 };
+    state = transitionSetup(state, { type: "choose" }, {}).state;
+    expect(state.step).toBe("project-choice");
+    expect(state.selectedIndex).toBe(1);
+  });
+
+  test("save errors return an explicit retry effect", () => {
+    let state: SetupState = {
+      ...createInitialSetupState({}, "review"),
+      baseUrl: "https://api.example.com/v1",
+      apiKey: "secret",
+      selectedModels: ["model-a"],
+      defaultModel: "model-a",
+      projectDirectory: "",
+    };
+    const saving = transitionSetup(state, { type: "choose" }, {});
+    expect(saving.effect?.kind).toBe("save-configuration");
+    state = transitionSetup(saving.state, { type: "effect-result", result: { kind: "save-failed", error: "disk full" } }, {}).state;
+    expect(state.step).toBe("save-error");
+
+    const retry = transitionSetup(state, { type: "choose" }, {});
+    expect(retry.state.step).toBe("saving");
+    expect(retry.effect?.kind).toBe("save-configuration");
+  });
+});


### PR DESCRIPTION
## Summary

- centralize Setup draft/navigation state in a pure transition owner with explicit effect and completion intents
- isolate model discovery, MCP testing, and configuration saving behind one effect runner
- split rendering into input, choice, multi-select, review, and MCP-result page families while reducing `SetupApp` to host composition
- add focused transition coverage for discovery retry, MCP auth/back, review back, and save retry

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test` (890 pass, 5 Windows-only skips, 0 fail)
- `bun run doctor`
- Setup unit/component/integration/CLI journey (30 pass, 0 fail)
- `git diff --check`

## Native Setup Smoke

In an isolated HOME/XDG config with an 80x24 PTY and local mock provider, Setup traversed input, working, model multi-select, review, save-error, retry, and completion. The 12-model window scrolled correctly, Review Back restored project choice, a forced EACCES produced the retry surface, and retry after restoring permissions wrote provider/.env/permissions files. Isolated `doctor` reported `Missing: none`.

## Follow-up Observed

Using `127.0.0.1` as the provider host exposes a pre-existing config-writer issue: the derived `apiKeyEnv` starts with a digit and fails dotenv validation. The equivalent `localhost` path completed successfully. This PR does not change provider-id derivation.