### PR TITLE
refactor(agents): extract ownership boundaries

### DIFF
--- a/src/core/agents/handle-allocator.ts
+++ b/src/core/agents/handle-allocator.ts
@@ -1,0 +1,21 @@
+import type { AgentStore } from "./store";
+
+export class AgentHandleAllocator {
+  private readonly initializers = new Map<string, Promise<number>>();
+  private readonly nextOrdinals = new Map<string, number>();
+
+  constructor(private readonly store: Pick<AgentStore, "nextHandleOrdinal">) {}
+
+  async allocate(parentSessionId: string, profileId: string): Promise<string> {
+    const key = `${parentSessionId}\u0000${profileId}`;
+    let initializer = this.initializers.get(key);
+    if (!initializer) {
+      initializer = this.store.nextHandleOrdinal(parentSessionId, profileId);
+      this.initializers.set(key, initializer);
+    }
+    const initial = await initializer;
+    const ordinal = this.nextOrdinals.get(key) ?? initial;
+    this.nextOrdinals.set(key, ordinal + 1);
+    return `${profileId}-${ordinal}`;
+  }
+}

--- a/src/core/agents/manager.ts
+++ b/src/core/agents/manager.ts
@@ -1,5 +1,7 @@
 import { AgentStore } from "./store";
 import { normalizeHarnessAdapterError } from "../harness/driver";
+import { AgentHandleAllocator } from "./handle-allocator";
+import { PathOwnershipTable } from "./path-ownership";
 import type {
   AgentMetadata,
   AgentInvocationContext,
@@ -17,7 +19,6 @@ type ActiveAgent = {
   controller: AbortController;
   completion: Promise<AgentTerminalResult>;
   messages: string[];
-  ownedPaths: Set<string>;
 };
 
 export type SpawnedAgent = {
@@ -29,9 +30,8 @@ export type SpawnedAgent = {
 export class AgentManager {
   private readonly active = new Map<string, ActiveAgent>();
   private readonly waiters: Array<() => void> = [];
-  private readonly writeOwners = new Map<string, string>();
-  private readonly handleInitializers = new Map<string, Promise<number>>();
-  private readonly nextHandleOrdinals = new Map<string, number>();
+  private readonly handleAllocator: AgentHandleAllocator;
+  private readonly pathOwnership: PathOwnershipTable;
   private runningCount = 0;
   private readonly delegationRunning = new Set<string>();
   private readonly delegationWaiters = new Map<string, Array<() => void>>();
@@ -47,6 +47,10 @@ export class AgentManager {
     if (!Number.isInteger(this.maxConcurrent) || this.maxConcurrent < 1) {
       throw new Error("SubAgent maxConcurrent must be a positive integer.");
     }
+    this.handleAllocator = new AgentHandleAllocator(store);
+    this.pathOwnership = new PathOwnershipTable((ownerId) => ownerId.startsWith("host:")
+      ? "the parent Engine"
+      : this.active.get(ownerId)?.metadata.handle ?? "another SubAgent");
   }
 
   get maxConcurrent(): number {
@@ -55,7 +59,7 @@ export class AgentManager {
 
   async spawn(spec: AgentSpec, invocation?: AgentInvocationContext): Promise<SpawnedAgent> {
     const runId = `run_${crypto.randomUUID()}`;
-    const handle = await this.allocateHandle(spec.parentSessionId, spec.profileId);
+    const handle = await this.handleAllocator.allocate(spec.parentSessionId, spec.profileId);
     const now = new Date().toISOString();
     const metadata: AgentMetadata = {
       ...spec,
@@ -75,7 +79,7 @@ export class AgentManager {
       else invocation.parentSignal.addEventListener("abort", abortFromParent, { once: true });
     }
     const completion = this.execute(metadata, controller, invocation);
-    this.active.set(runId, { metadata, controller, completion, messages: [], ownedPaths: new Set() });
+    this.active.set(runId, { metadata, controller, completion, messages: [] });
     const cleanup = () => {
       invocation?.parentSignal?.removeEventListener("abort", abortFromParent);
       this.active.delete(runId);
@@ -115,14 +119,11 @@ export class AgentManager {
   }
 
   async claimHostMutation(ownerId: string, paths: string[]): Promise<void> {
-    this.claimPaths(`host:${ownerId}`, paths);
+    this.pathOwnership.claim(`host:${ownerId}`, paths);
   }
 
   releaseHostMutations(ownerId: string): void {
-    const owner = `host:${ownerId}`;
-    for (const [path, current] of this.writeOwners) {
-      if (current === owner) this.writeOwners.delete(path);
-    }
+    this.pathOwnership.release(`host:${ownerId}`);
   }
 
   private async execute(
@@ -306,35 +307,11 @@ export class AgentManager {
   private async claimMutation(runId: string, handle: string, paths: string[]): Promise<void> {
     const active = this.active.get(runId);
     if (!active) throw new Error(`SubAgent is no longer active: ${handle}.`);
-    this.claimPaths(runId, paths);
-    for (const path of paths) active.ownedPaths.add(path);
-  }
-
-  private claimPaths(ownerId: string, paths: string[]): void {
-    const unique = [...new Set(paths)].sort();
-    const conflict = unique.flatMap((requestedPath) =>
-      [...this.writeOwners.entries()]
-        .filter(([ownedPath, owner]) => owner !== ownerId && pathsOverlap(requestedPath, ownedPath))
-        .map(([ownedPath, owner]) => ({ requestedPath, ownedPath, owner })),
-    )[0];
-    if (conflict) {
-      const ownerLabel = conflict.owner.startsWith("host:")
-        ? "the parent Engine"
-        : this.active.get(conflict.owner)?.metadata.handle ?? "another SubAgent";
-      throw new Error(`Concurrent Agent write conflict on "${conflict.requestedPath}"; overlapping path "${conflict.ownedPath}" is owned by ${ownerLabel}.`);
-    }
-    for (const path of unique) {
-      this.writeOwners.set(path, ownerId);
-    }
+    this.pathOwnership.claim(runId, paths);
   }
 
   private releaseMutations(runId: string): void {
-    const active = this.active.get(runId);
-    if (!active) return;
-    for (const path of active.ownedPaths) {
-      if (this.writeOwners.get(path) === runId) this.writeOwners.delete(path);
-    }
-    active.ownedPaths.clear();
+    this.pathOwnership.release(runId);
   }
 
   private async finish(metadata: AgentMetadata, result: AgentTerminalResult): Promise<void> {
@@ -359,19 +336,6 @@ export class AgentManager {
     return [...this.active.values()].find((entry) => entry.metadata.handle === reference
       && entry.metadata.parentSessionId === parentSessionId
       && (!controllableOnly || isControllable(entry.metadata)));
-  }
-
-  private async allocateHandle(parentSessionId: string, profileId: string): Promise<string> {
-    const key = `${parentSessionId}\u0000${profileId}`;
-    let initializer = this.handleInitializers.get(key);
-    if (!initializer) {
-      initializer = this.store.nextHandleOrdinal(parentSessionId, profileId);
-      this.handleInitializers.set(key, initializer);
-    }
-    const initial = await initializer;
-    const ordinal = this.nextHandleOrdinals.get(key) ?? initial;
-    this.nextHandleOrdinals.set(key, ordinal + 1);
-    return `${profileId}-${ordinal}`;
   }
 
   private async acquire(signal: AbortSignal): Promise<void> {
@@ -460,8 +424,4 @@ function isAbortError(error: unknown): boolean {
 
 function isControllable(metadata: AgentMetadata): boolean {
   return metadata.status === "created" || metadata.status === "running";
-}
-
-function pathsOverlap(left: string, right: string): boolean {
-  return left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
 }

--- a/src/core/agents/manager.ts
+++ b/src/core/agents/manager.ts
@@ -48,9 +48,7 @@ export class AgentManager {
       throw new Error("SubAgent maxConcurrent must be a positive integer.");
     }
     this.handleAllocator = new AgentHandleAllocator(store);
-    this.pathOwnership = new PathOwnershipTable((ownerId) => ownerId.startsWith("host:")
-      ? "the parent Engine"
-      : this.active.get(ownerId)?.metadata.handle ?? "another SubAgent");
+    this.pathOwnership = new PathOwnershipTable();
   }
 
   get maxConcurrent(): number {
@@ -119,7 +117,7 @@ export class AgentManager {
   }
 
   async claimHostMutation(ownerId: string, paths: string[]): Promise<void> {
-    this.pathOwnership.claim(`host:${ownerId}`, paths);
+    this.pathOwnership.claim(`host:${ownerId}`, "the parent Engine", paths);
   }
 
   releaseHostMutations(ownerId: string): void {
@@ -307,7 +305,7 @@ export class AgentManager {
   private async claimMutation(runId: string, handle: string, paths: string[]): Promise<void> {
     const active = this.active.get(runId);
     if (!active) throw new Error(`SubAgent is no longer active: ${handle}.`);
-    this.pathOwnership.claim(runId, paths);
+    this.pathOwnership.claim(runId, handle, paths);
   }
 
   private releaseMutations(runId: string): void {

--- a/src/core/agents/path-ownership.ts
+++ b/src/core/agents/path-ownership.ts
@@ -1,25 +1,29 @@
 export class PathOwnershipTable {
   private readonly owners = new Map<string, string>();
   private readonly pathsByOwner = new Map<string, Set<string>>();
+  private readonly ownerLabels = new Map<string, string>();
 
-  constructor(private readonly ownerLabel: (ownerId: string) => string) {}
-
-  claim(ownerId: string, paths: string[]): void {
+  claim(ownerId: string, ownerLabel: string, paths: string[]): void {
     const unique = [...new Set(paths)].sort();
+    if (unique.length === 0) return;
     const conflict = unique.flatMap((requestedPath) =>
       [...this.owners.entries()]
         .filter(([ownedPath, owner]) => owner !== ownerId && pathsOverlap(requestedPath, ownedPath))
         .map(([ownedPath, owner]) => ({ requestedPath, ownedPath, owner })),
     )[0];
     if (conflict) {
-      throw new Error(`Concurrent Agent write conflict on "${conflict.requestedPath}"; overlapping path "${conflict.ownedPath}" is owned by ${this.ownerLabel(conflict.owner)}.`);
+      throw new Error(`Concurrent Agent write conflict on "${conflict.requestedPath}"; overlapping path "${conflict.ownedPath}" is owned by ${this.ownerLabels.get(conflict.owner) ?? "another SubAgent"}.`);
     }
-    const owned = this.pathsByOwner.get(ownerId) ?? new Set<string>();
+    let owned = this.pathsByOwner.get(ownerId);
+    if (!owned) {
+      owned = new Set<string>();
+      this.pathsByOwner.set(ownerId, owned);
+      this.ownerLabels.set(ownerId, ownerLabel);
+    }
     for (const path of unique) {
       this.owners.set(path, ownerId);
       owned.add(path);
     }
-    if (owned.size > 0) this.pathsByOwner.set(ownerId, owned);
   }
 
   release(ownerId: string): void {
@@ -29,6 +33,7 @@ export class PathOwnershipTable {
       if (this.owners.get(path) === ownerId) this.owners.delete(path);
     }
     this.pathsByOwner.delete(ownerId);
+    this.ownerLabels.delete(ownerId);
   }
 }
 

--- a/src/core/agents/path-ownership.ts
+++ b/src/core/agents/path-ownership.ts
@@ -1,0 +1,37 @@
+export class PathOwnershipTable {
+  private readonly owners = new Map<string, string>();
+  private readonly pathsByOwner = new Map<string, Set<string>>();
+
+  constructor(private readonly ownerLabel: (ownerId: string) => string) {}
+
+  claim(ownerId: string, paths: string[]): void {
+    const unique = [...new Set(paths)].sort();
+    const conflict = unique.flatMap((requestedPath) =>
+      [...this.owners.entries()]
+        .filter(([ownedPath, owner]) => owner !== ownerId && pathsOverlap(requestedPath, ownedPath))
+        .map(([ownedPath, owner]) => ({ requestedPath, ownedPath, owner })),
+    )[0];
+    if (conflict) {
+      throw new Error(`Concurrent Agent write conflict on "${conflict.requestedPath}"; overlapping path "${conflict.ownedPath}" is owned by ${this.ownerLabel(conflict.owner)}.`);
+    }
+    const owned = this.pathsByOwner.get(ownerId) ?? new Set<string>();
+    for (const path of unique) {
+      this.owners.set(path, ownerId);
+      owned.add(path);
+    }
+    if (owned.size > 0) this.pathsByOwner.set(ownerId, owned);
+  }
+
+  release(ownerId: string): void {
+    const owned = this.pathsByOwner.get(ownerId);
+    if (!owned) return;
+    for (const path of owned) {
+      if (this.owners.get(path) === ownerId) this.owners.delete(path);
+    }
+    this.pathsByOwner.delete(ownerId);
+  }
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  return left === right || left.startsWith(`${right}/`) || right.startsWith(`${left}/`);
+}


### PR DESCRIPTION
## Summary

- extract host/child mutation overlap checks and owner release into `PathOwnershipTable`
- extract durable handle initialization and per-parent/profile atomic allocation into `AgentHandleAllocator`
- keep AgentManager lifecycle, retry, persistence, events, and scheduling order unchanged

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test` (890 pass, 5 Windows-only skips, 0 fail)
- `bun run doctor`
- focused AgentManager/foreground/background/checkpoint/Harness suites (26 pass, 0 fail)
- `git diff --check`

## Scope

Concurrency and per-parent delegation scheduling remain in AgentManager for a separate Phase 4B evaluation so lifecycle regressions stay attributable.