### PR TITLE
refactor(session): isolate interaction recovery

### DIFF
--- a/src/core/session/interaction-recovery.ts
+++ b/src/core/session/interaction-recovery.ts
@@ -1,0 +1,173 @@
+import { parseEngineSwitchRequest, type EngineSwitchRequest } from "../engine/switch";
+import { parseGateRequest, type GateRequest } from "../gate/types";
+import { parseHarnessDelegationDecision, type HarnessDelegationDecision } from "../harness/driver";
+import { parsePermissionRequest, type PermissionRequest } from "../permissions";
+import { parseUserQuestionRequest, type UserQuestionRequest } from "../user-question/types";
+import type { ResumedToolCall, SessionRecord } from "./record-model";
+
+export type PendingDelegationRetry = {
+  intentId: string;
+  interactionId: string;
+  failedRunId: string;
+  delegationId: string;
+  attempt: number;
+  retryCallId: string;
+};
+
+export type SessionInteractionRecovery = {
+  pendingGate?: { gate: GateRequest; toolCallId: string; assistantContent: string };
+  pendingEngineSwitch?: { request: EngineSwitchRequest; toolCallId: string; assistantContent: string };
+  pendingUserQuestion?: {
+    question: UserQuestionRequest;
+    toolCallId: string;
+    assistantContent: string;
+    delegationDecision?: HarnessDelegationDecision;
+  };
+  pendingPermission?: PermissionRequest;
+  pendingDelegationRetry?: PendingDelegationRetry;
+  pendingDelegationDecisionRecovery?: HarnessDelegationDecision;
+};
+
+export function recoverSessionInteractions(records: SessionRecord[]): SessionInteractionRecovery {
+  const answeredToolCallIds = new Set(records.flatMap((record) =>
+    record.role === "tool" && typeof record.metadata?.toolCallId === "string"
+      ? [record.metadata.toolCallId]
+      : []
+  ));
+  return {
+    ...recoverPendingToolCalls(records, answeredToolCallIds),
+    ...recoverPendingPermission(records),
+    ...recoverPendingDelegationRetry(records, answeredToolCallIds),
+    ...recoverPendingDelegationDecision(records),
+  };
+}
+
+function recoverPendingToolCalls(
+  records: SessionRecord[],
+  answeredToolCallIds: Set<string>,
+): Pick<SessionInteractionRecovery, "pendingGate" | "pendingEngineSwitch" | "pendingUserQuestion"> {
+  const record = [...records].reverse().find((candidate) => candidate.role === "assistant");
+  if (!record) return {};
+  const toolCalls = record.metadata?.toolCalls as ResumedToolCall[] | undefined;
+  const gateCall = toolCalls?.find((call) => call.name === "request_confirmation" && !answeredToolCallIds.has(call.id));
+  const switchCall = toolCalls?.find((call) => call.name === "request_engine_switch" && !answeredToolCallIds.has(call.id));
+  const questionCall = toolCalls?.find((call) => call.name === "ask_user_question" && !answeredToolCallIds.has(call.id));
+  let pendingGate: SessionInteractionRecovery["pendingGate"];
+  let pendingEngineSwitch: SessionInteractionRecovery["pendingEngineSwitch"];
+  let pendingUserQuestion: SessionInteractionRecovery["pendingUserQuestion"];
+  try {
+    if (gateCall) pendingGate = { gate: parseGateRequest(gateCall), toolCallId: gateCall.id, assistantContent: record.content };
+  } catch {
+    // Malformed pending calls cannot be restored as host interactions.
+  }
+  try {
+    if (switchCall) pendingEngineSwitch = { request: parseEngineSwitchRequest(switchCall), toolCallId: switchCall.id, assistantContent: record.content };
+  } catch {
+    // Malformed pending calls cannot be restored as host interactions.
+  }
+  try {
+    if (questionCall) {
+      const delegationDecision = record.metadata?.kind === "delegation-decision-point"
+        ? parseHarnessDelegationDecision(record.metadata.decision)
+        : undefined;
+      pendingUserQuestion = {
+        question: delegationDecision?.question ?? parseUserQuestionRequest(questionCall),
+        toolCallId: questionCall.id,
+        assistantContent: record.content,
+        ...(delegationDecision ? { delegationDecision } : {}),
+      };
+    }
+  } catch {
+    // Malformed pending calls cannot be restored as host interactions.
+  }
+  return {
+    ...(pendingGate ? { pendingGate } : {}),
+    ...(pendingEngineSwitch ? { pendingEngineSwitch } : {}),
+    ...(pendingUserQuestion ? { pendingUserQuestion } : {}),
+  };
+}
+
+function recoverPendingPermission(records: SessionRecord[]): Pick<SessionInteractionRecovery, "pendingPermission"> {
+  const resolved = new Set<string>();
+  for (const record of records) {
+    if (record.metadata?.kind !== "permission-resolution") continue;
+    const requestId = record.metadata.requestId;
+    if (typeof requestId === "string") resolved.add(requestId);
+  }
+  for (let index = records.length - 1; index >= 0; index--) {
+    const record = records[index];
+    if (record.metadata?.kind !== "permission-request") continue;
+    const request = parsePermissionRequest(record.metadata.request);
+    if (request && !resolved.has(request.id)) return { pendingPermission: request };
+  }
+  return {};
+}
+
+function recoverPendingDelegationRetry(
+  records: SessionRecord[],
+  answeredToolCallIds: Set<string>,
+): Pick<SessionInteractionRecovery, "pendingDelegationRetry"> {
+  const intents = new Map<string, PendingDelegationRetry>();
+  const authorized = new Set<string>();
+  for (const record of records) {
+    if (record.metadata?.kind === "delegation-retry-intent") {
+      const intent = parsePendingDelegationRetry(record.metadata.retryIntent);
+      if (intent) intents.set(intent.intentId, intent);
+    }
+    const retryIntentId = record.metadata?.retryIntentId;
+    if (typeof retryIntentId !== "string") continue;
+    if (record.metadata?.kind === "delegation-decision-resolution" && record.metadata.optionId === "retry") {
+      authorized.add(retryIntentId);
+    }
+  }
+  const pending = [...intents.values()].reverse().find((intent) =>
+    authorized.has(intent.intentId) && !answeredToolCallIds.has(intent.retryCallId)
+  );
+  return pending ? { pendingDelegationRetry: pending } : {};
+}
+
+function recoverPendingDelegationDecision(
+  records: SessionRecord[],
+): Pick<SessionInteractionRecovery, "pendingDelegationDecisionRecovery"> {
+  const persisted = new Map<string, HarnessDelegationDecision>();
+  const restored = new Set<string>();
+  for (const record of records) {
+    if (record.role === "tool" && record.metadata?.delegationDecision) {
+      try {
+        const decision = parseHarnessDelegationDecision(record.metadata.delegationDecision);
+        persisted.set(decision.failed.runId, decision);
+      } catch {
+        // Invalid host metadata cannot be restored as an executable decision.
+      }
+    }
+    if (record.role === "assistant" && record.metadata?.kind === "delegation-decision-point") {
+      try {
+        restored.add(parseHarnessDelegationDecision(record.metadata.decision).failed.runId);
+      } catch {
+        // The malformed decision point remains unusable and does not mask recovery.
+      }
+    }
+  }
+  const pending = [...persisted.values()].reverse().find((decision) => !restored.has(decision.failed.runId));
+  return pending ? { pendingDelegationDecisionRecovery: pending } : {};
+}
+
+function parsePendingDelegationRetry(value: unknown): PendingDelegationRetry | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+  const source = value as Record<string, unknown>;
+  if (typeof source.id !== "string"
+    || typeof source.interactionId !== "string"
+    || typeof source.failedRunId !== "string"
+    || typeof source.delegationId !== "string"
+    || !Number.isInteger(source.attempt)
+    || Number(source.attempt) < 1
+    || typeof source.retryCallId !== "string") return undefined;
+  return {
+    intentId: source.id,
+    interactionId: source.interactionId,
+    failedRunId: source.failedRunId,
+    delegationId: source.delegationId,
+    attempt: Number(source.attempt),
+    retryCallId: source.retryCallId,
+  };
+}

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -1,20 +1,16 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { parseGateRequest } from "../gate/types";
 import type { GateRequest } from "../gate/types";
 import type { EngineId } from "../engine/profile";
-import { parseEngineSwitchRequest } from "../engine/switch";
 import type { EngineSwitchRequest } from "../engine/switch";
 import type { ProviderSelection } from "../../config/providers";
-import { parseUserQuestionRequest } from "../user-question/types";
 import type { UserQuestionRequest } from "../user-question/types";
 import type { ProviderThinkingBlock, ReasoningTier, ResponseUsage } from "../../providers/shared/types";
 import type { VesicleImageAttachment } from "../../providers/shared/types";
 import type { FileToolEvent, McpToolEvent, ProcessToolEvent, WebToolEvent } from "../tools";
 import type { AssetFingerprint } from "../runtime/assets";
-import { parsePermissionRequest } from "../permissions";
 import type { PermissionMode, PermissionRequest } from "../permissions";
-import { parseHarnessDelegationDecision, type HarnessDelegationDecision } from "../harness/driver";
+import type { HarnessDelegationDecision } from "../harness/driver";
 import {
   type DurableQualityArtifactTarget,
   type QualityDecisionCandidate,
@@ -29,11 +25,13 @@ import { buildActiveSessionBranch, normalizeSessionRecords, type ResumedToolCall
 import { projectSessionHistory } from "./history-projector";
 import { repairProviderHistory } from "./provider-history-repair";
 import { findPendingQualityDecision, findPendingQualityRewrite, findQualityEvents, findQualityWarnings } from "./quality-recovery";
+import { recoverSessionInteractions, type PendingDelegationRetry } from "./interaction-recovery";
 
 export { buildActiveSessionBranch } from "./record-model";
 export type { SessionRecord, SessionRole } from "./record-model";
 export { createSessionStore } from "./append-store";
 export type { SessionStore } from "./append-store";
+export type { PendingDelegationRetry } from "./interaction-recovery";
 
 export type ReasoningDisplayMode = "hidden" | "collapsed" | "expanded";
 
@@ -79,15 +77,6 @@ export type SessionSummary = {
     producer: EngineId;
     findingCount: number;
   };
-};
-
-export type PendingDelegationRetry = {
-  intentId: string;
-  interactionId: string;
-  failedRunId: string;
-  delegationId: string;
-  attempt: number;
-  retryCallId: string;
 };
 
 export type PendingQualityRewrite = {
@@ -150,12 +139,14 @@ export async function listSessions(
       }
     }
     if (!firstRecord || !lastRecord) continue;
-    const pendingGate = findPendingGate(records);
-    const pendingEngineSwitch = findPendingEngineSwitch(records);
-    const pendingUserQuestion = findPendingUserQuestion(records);
-    const pendingPermission = findPendingPermission(records);
-    const pendingDelegationRetry = findPendingDelegationRetry(records);
-    const pendingDelegationDecisionRecovery = findPendingDelegationDecisionRecovery(records);
+    const {
+      pendingGate,
+      pendingEngineSwitch,
+      pendingUserQuestion,
+      pendingPermission,
+      pendingDelegationRetry,
+      pendingDelegationDecisionRecovery,
+    } = recoverSessionInteractions(records);
     const pendingQualityDecision = findPendingQualityDecision(records);
     const pendingQualityRewrite = findPendingQualityRewrite(records);
     summaries.push({
@@ -314,12 +305,14 @@ export async function loadSessionSnapshot(
   const projection = projectSessionHistory(records);
   const messages = projection.messages;
 
-  const pendingGate = findPendingGate(records);
-  const pendingEngineSwitch = findPendingEngineSwitch(records);
-  const pendingUserQuestion = findPendingUserQuestion(records);
-  const pendingPermission = findPendingPermission(records);
-  const pendingDelegationRetry = findPendingDelegationRetry(records);
-  const pendingDelegationDecisionRecovery = findPendingDelegationDecisionRecovery(records);
+  const {
+    pendingGate,
+    pendingEngineSwitch,
+    pendingUserQuestion,
+    pendingPermission,
+    pendingDelegationRetry,
+    pendingDelegationDecisionRecovery,
+  } = recoverSessionInteractions(records);
   const qualityEvents = findQualityEvents(records);
   const pendingQualityRewrite = findPendingQualityRewrite(records);
   const pendingQualityDecision = findPendingQualityDecision(records);
@@ -390,183 +383,4 @@ export async function loadSessionSnapshot(
     ...(pendingQualityRewrite ? { pendingQualityRewrite } : {}),
     ...(pendingQualityDecision ? { pendingQualityDecision } : {}),
   };
-}
-
-function findPendingDelegationDecisionRecovery(records: SessionRecord[]): HarnessDelegationDecision | undefined {
-  const persisted = new Map<string, HarnessDelegationDecision>();
-  const restored = new Set<string>();
-  for (const record of records) {
-    if (record.role === "tool" && record.metadata?.delegationDecision) {
-      try {
-        const decision = parseHarnessDelegationDecision(record.metadata.delegationDecision);
-        persisted.set(decision.failed.runId, decision);
-      } catch {
-        // Invalid host metadata cannot be restored as an executable decision.
-      }
-    }
-    if (record.role === "assistant" && record.metadata?.kind === "delegation-decision-point") {
-      try {
-        restored.add(parseHarnessDelegationDecision(record.metadata.decision).failed.runId);
-      } catch {
-        // The malformed decision point remains unusable and does not mask recovery.
-      }
-    }
-  }
-  return [...persisted.values()].reverse().find((decision) => !restored.has(decision.failed.runId));
-}
-
-function findPendingDelegationRetry(records: SessionRecord[]): PendingDelegationRetry | undefined {
-  const intents = new Map<string, PendingDelegationRetry>();
-  const authorized = new Set<string>();
-  const answeredToolCallIds = new Set(records.flatMap((record) =>
-    record.role === "tool" && typeof record.metadata?.toolCallId === "string"
-      ? [record.metadata.toolCallId]
-      : []
-  ));
-  for (const record of records) {
-    if (record.metadata?.kind === "delegation-retry-intent") {
-      const intent = parsePendingDelegationRetry(record.metadata.retryIntent);
-      if (intent) intents.set(intent.intentId, intent);
-    }
-    const retryIntentId = record.metadata?.retryIntentId;
-    if (typeof retryIntentId !== "string") continue;
-    if (record.metadata?.kind === "delegation-decision-resolution" && record.metadata.optionId === "retry") {
-      authorized.add(retryIntentId);
-    }
-  }
-  return [...intents.values()].reverse().find((intent) =>
-    authorized.has(intent.intentId) && !answeredToolCallIds.has(intent.retryCallId)
-  );
-}
-
-function parsePendingDelegationRetry(value: unknown): PendingDelegationRetry | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
-  const source = value as Record<string, unknown>;
-  if (typeof source.id !== "string"
-    || typeof source.interactionId !== "string"
-    || typeof source.failedRunId !== "string"
-    || typeof source.delegationId !== "string"
-    || !Number.isInteger(source.attempt)
-    || Number(source.attempt) < 1
-    || typeof source.retryCallId !== "string") return undefined;
-  return {
-    intentId: source.id,
-    interactionId: source.interactionId,
-    failedRunId: source.failedRunId,
-    delegationId: source.delegationId,
-    attempt: Number(source.attempt),
-    retryCallId: source.retryCallId,
-  };
-}
-
-function findPendingGate(records: SessionRecord[]): { gate: GateRequest; toolCallId: string; assistantContent: string } | undefined {
-  const answeredToolCallIds = new Set<string>();
-  for (const record of records) {
-    if (record.role === "tool") {
-      const toolCallId = record.metadata?.toolCallId;
-      if (typeof toolCallId === "string") answeredToolCallIds.add(toolCallId);
-    }
-  }
-
-  for (let index = records.length - 1; index >= 0; index--) {
-    const record = records[index];
-    if (record.role !== "assistant") continue;
-    const toolCalls = record.metadata?.toolCalls as ResumedToolCall[] | undefined;
-    const gateCall = toolCalls?.find((call) => call.name === "request_confirmation" && !answeredToolCallIds.has(call.id));
-    if (!gateCall) return undefined;
-    try {
-      return {
-        gate: parseGateRequest(gateCall),
-        toolCallId: gateCall.id,
-        assistantContent: record.content,
-      };
-    } catch {
-      return undefined;
-    }
-  }
-
-  return undefined;
-}
-
-function findPendingEngineSwitch(records: SessionRecord[]): { request: EngineSwitchRequest; toolCallId: string; assistantContent: string } | undefined {
-  const answeredToolCallIds = new Set<string>();
-  for (const record of records) {
-    if (record.role === "tool") {
-      const toolCallId = record.metadata?.toolCallId;
-      if (typeof toolCallId === "string") answeredToolCallIds.add(toolCallId);
-    }
-  }
-
-  for (let index = records.length - 1; index >= 0; index--) {
-    const record = records[index];
-    if (record.role !== "assistant") continue;
-    const toolCalls = record.metadata?.toolCalls as ResumedToolCall[] | undefined;
-    const switchCall = toolCalls?.find((call) => call.name === "request_engine_switch" && !answeredToolCallIds.has(call.id));
-    if (!switchCall) return undefined;
-    try {
-      return {
-        request: parseEngineSwitchRequest(switchCall),
-        toolCallId: switchCall.id,
-        assistantContent: record.content,
-      };
-    } catch {
-      return undefined;
-    }
-  }
-
-  return undefined;
-}
-
-function findPendingUserQuestion(records: SessionRecord[]): {
-  question: UserQuestionRequest;
-  toolCallId: string;
-  assistantContent: string;
-  delegationDecision?: HarnessDelegationDecision;
-} | undefined {
-  const answeredToolCallIds = new Set<string>();
-  for (const record of records) {
-    if (record.role === "tool") {
-      const toolCallId = record.metadata?.toolCallId;
-      if (typeof toolCallId === "string") answeredToolCallIds.add(toolCallId);
-    }
-  }
-
-  for (let index = records.length - 1; index >= 0; index--) {
-    const record = records[index];
-    if (record.role !== "assistant") continue;
-    const toolCalls = record.metadata?.toolCalls as ResumedToolCall[] | undefined;
-    const questionCall = toolCalls?.find((call) => call.name === "ask_user_question" && !answeredToolCallIds.has(call.id));
-    if (!questionCall) return undefined;
-    try {
-      const delegationDecision = record.metadata?.kind === "delegation-decision-point"
-        ? parseHarnessDelegationDecision(record.metadata.decision)
-        : undefined;
-      return {
-        question: delegationDecision?.question ?? parseUserQuestionRequest(questionCall),
-        toolCallId: questionCall.id,
-        assistantContent: record.content,
-        ...(delegationDecision ? { delegationDecision } : {}),
-      };
-    } catch {
-      return undefined;
-    }
-  }
-
-  return undefined;
-}
-
-function findPendingPermission(records: SessionRecord[]): PermissionRequest | undefined {
-  const resolved = new Set<string>();
-  for (const record of records) {
-    if (record.metadata?.kind !== "permission-resolution") continue;
-    const requestId = record.metadata.requestId;
-    if (typeof requestId === "string") resolved.add(requestId);
-  }
-  for (let index = records.length - 1; index >= 0; index--) {
-    const record = records[index];
-    if (record.metadata?.kind !== "permission-request") continue;
-    const request = parsePermissionRequest(record.metadata.request);
-    if (request && !resolved.has(request.id)) return request;
-  }
-  return undefined;
 }

--- a/tests/integration/session/interaction-recovery.test.ts
+++ b/tests/integration/session/interaction-recovery.test.ts
@@ -164,4 +164,29 @@ describe("session: interaction recovery", () => {
     expect(snapshot.messages.map((m) => m.role)).toEqual(["user", "assistant"]);
   });
 
+  test("does not revive an older dangling interaction past the latest assistant turn", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-stale-interaction-"));
+    const sessionId = "2026-04-01T00-00-00-000Z-stale";
+    const store = await createSessionStore(rootDir, sessionId);
+
+    await store.append({ role: "system", content: "prompt" });
+    await store.append({ role: "user", content: "draft a blueprint" });
+    await store.append({
+      role: "assistant",
+      content: "Review this blueprint.",
+      metadata: {
+        toolCalls: [{
+          id: "call-old-gate",
+          name: "request_confirmation",
+          arguments: JSON.stringify({ gate: "blueprint-confirmation", summary: "Old request" }),
+        }],
+      },
+    });
+    await store.append({ role: "user", content: "Continue without that request." });
+    await store.append({ role: "assistant", content: "Continued." });
+
+    expect((await listSessions(rootDir))[0]?.pendingGate).toBeUndefined();
+    expect((await loadSessionSnapshot(rootDir, sessionId)).pendingGate).toBeUndefined();
+  });
+
 });


### PR DESCRIPTION
## Summary

- move gate, engine-switch, question, permission, and delegation pending recovery into `session/interaction-recovery.ts`
- share one answered-tool-call projection while preserving latest-assistant fail-closed semantics
- keep `loadSessionSnapshot()` as the single projection, provider-repair, Quality, and Stage composition entry

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test` (891 pass, 5 Windows-only skips, 0 fail)
- `bun run doctor`
- focused session/Harness/TUI recovery suites (27 pass, 0 fail)
- `git diff --check`

## Boundary

This extraction does not change JSONL schema, active-branch projection, provider-history repair, Quality recovery, or session listing behavior. A focused regression test proves that an older dangling interaction cannot be revived past a newer assistant turn.