### PR TITLE
feat(session): execution identity + compact-checkpoint-v1 foundation (#107 PR1)

### DIFF
--- a/src/core/agent-loop/assistant-recorder.ts
+++ b/src/core/agent-loop/assistant-recorder.ts
@@ -1,6 +1,7 @@
 import type { VesicleMessage, VesicleResponse } from "../../providers/shared/types";
 import type { EngineProfile } from "../engine/profile";
 import type { SessionStore } from "../session/store";
+import { withExecutionRound } from "../session/store";
 import type { ToolCall } from "../tools";
 
 export async function recordAssistantToolCalls(options: {
@@ -24,7 +25,7 @@ export async function recordAssistantToolCalls(options: {
   await options.session.append({
     role: "assistant",
     content: response.content,
-    metadata: {
+    metadata: withExecutionRound(options.session.sessionId, {
       engine: options.profile.id,
       model: options.model,
       providerResponseId: response.id,
@@ -34,7 +35,7 @@ export async function recordAssistantToolCalls(options: {
       ...(response.usage ? { usage: response.usage } : {}),
       ...(options.metadata ?? {}),
       toolCalls,
-    },
+    }),
   });
   return parentMessages;
 }

--- a/src/core/agent-loop/continuation-context.ts
+++ b/src/core/agent-loop/continuation-context.ts
@@ -7,6 +7,7 @@ import type { EngineId } from "../engine/profile";
 import { defaultPermissionRuntime } from "../permissions";
 import type { PermissionRuntimeOptions } from "../permissions";
 import { createSessionStore, loadSessionSnapshot } from "../session/store";
+import { bindExecutionRound, recoverActiveIdentity } from "../session/store";
 import { composeInstructionBlocks, composeSystemPromptWithInstructions } from "../instructions";
 import { freezeInstructionBlocks, readFrozenInstructionBlocks } from "../instructions/instruction-context";
 import { changedAssetPaths, loadEngineAssetRuntime } from "../runtime/engine-assets";
@@ -86,6 +87,13 @@ export async function loadContinuationContext(
     permission.shellInterpreter,
   );
   const session = await createSessionStore(rootDir, options.sessionId);
+  // Recover the logical turn + provider round the paused interaction belongs to
+  // and re-bind them as the active round, so every resolution record this
+  // continuation appends carries the original ids and a resumed pause never
+  // creates a new logical turn. Legacy sessions without identity fall back to
+  // the old append behavior (no round bound → no stamping).
+  const identity = recoverActiveIdentity(snapshot.records);
+  if (identity) bindExecutionRound(session.sessionId, identity);
   return {
     rootDir,
     permission,
@@ -100,6 +108,7 @@ export async function loadContinuationContext(
     harness,
     assets,
     experimentalQuality,
+    ...(identity ? { identity } : {}),
   };
 }
 

--- a/src/core/agent-loop/engine-switch-continuation.ts
+++ b/src/core/agent-loop/engine-switch-continuation.ts
@@ -5,7 +5,7 @@ import { ENGINE_HANDOFF_KIND, createModelEngineTransition, renderEngineHandoffPa
 import type { EngineContextPolicy } from "../engine/transition";
 import type { GateResolution } from "../gate/types";
 import type { ToolPermissionBroker } from "../permissions";
-import { createSessionStore } from "../session/store";
+import { createSessionStore, withExecutionRound } from "../session/store";
 import type { AgentLoopEvent, EngineSwitchConfirmedResult, ResolveEngineSwitchResult } from "./types";
 import type { ContinuationContextOptions } from "./continuation-context";
 import { loadContinuationContext } from "./continuation-context";
@@ -54,7 +54,7 @@ export async function resolveEngineSwitch(options: ResolveEngineSwitchOptions): 
   await session.append({
     role: "tool",
     content: toolResultContent,
-    metadata: {
+    metadata: withExecutionRound(session.sessionId, {
       engine: options.engine,
       name: "request_engine_switch",
       ok: true,
@@ -64,7 +64,7 @@ export async function resolveEngineSwitch(options: ResolveEngineSwitchOptions): 
       decision: options.resolution.decision,
       ...(options.resolution.feedback ? { feedback: options.resolution.feedback } : {}),
       transition,
-    },
+    }),
   });
 
   if (confirmed) {
@@ -81,6 +81,7 @@ export async function resolveEngineSwitch(options: ResolveEngineSwitchOptions): 
     mcpRegistry: continuation.toolSurface.mcp,
     messages,
     session,
+    logicalTurnId: continuation.identity?.logicalTurnId,
     profile: continuation.profile,
     generation: continuation.generation,
     checkpoint: await FileCheckpointManager.resumeLatest(continuation.rootDir, session),

--- a/src/core/agent-loop/gate-continuation.ts
+++ b/src/core/agent-loop/gate-continuation.ts
@@ -7,6 +7,7 @@ import { generationMetadata } from "./generation";
 import { runLoop } from "./turn-loop";
 import type { ToolPermissionBroker } from "../permissions";
 import { FileCheckpointManager } from "../checkpoints/file-history";
+import { withExecutionRound } from "../session/store";
 import type { AgentManager } from "../agents/manager";
 
 type ResolveGateOptions = ContinuationContextOptions & {
@@ -31,7 +32,7 @@ export async function resolveGate(options: ResolveGateOptions): Promise<RunPromp
   await context.session.append({
     role: "tool",
     content: toolResultContent,
-    metadata: {
+    metadata: withExecutionRound(context.session.sessionId, {
       kind: "gate-resolution",
       engine: options.engine,
       name: "request_confirmation",
@@ -39,7 +40,7 @@ export async function resolveGate(options: ResolveGateOptions): Promise<RunPromp
       toolCallId: options.toolCallId,
       gate: options.gate.gate,
       decision: options.resolution.decision,
-    },
+    }),
   });
 
   const userFollowUp = gateFollowUpMessage(options.gate, options.resolution);
@@ -47,14 +48,14 @@ export async function resolveGate(options: ResolveGateOptions): Promise<RunPromp
   await context.session.append({
     role: "user",
     content: userFollowUp,
-    metadata: {
+    metadata: withExecutionRound(context.session.sessionId, {
       kind: "gate-resolution",
       engine: options.engine,
       provider: context.config.provider,
       providerId: context.config.providerId,
       model: context.config.model,
       ...generationMetadata(context.generation),
-    },
+    }),
   });
 
   return runLoop({
@@ -67,6 +68,7 @@ export async function resolveGate(options: ResolveGateOptions): Promise<RunPromp
     mcpRegistry: context.toolSurface.mcp,
     messages,
     session: context.session,
+    logicalTurnId: context.identity?.logicalTurnId,
     profile: context.profile,
     generation: context.generation,
     checkpoint: await FileCheckpointManager.resumeLatest(context.rootDir, context.session),

--- a/src/core/agent-loop/permission-continuation.ts
+++ b/src/core/agent-loop/permission-continuation.ts
@@ -5,7 +5,7 @@ import { FileCheckpointManager } from "../checkpoints/file-history";
 import type { PermissionRequest, PermissionResolution, ToolPermissionBroker } from "../permissions";
 import { createPermissionRequest } from "../permissions";
 import { getProcessManager } from "../process/manager";
-import { loadSessionRecords } from "../session/store";
+import { loadSessionRecords, withExecutionRound } from "../session/store";
 import type { ToolCall, ToolResult } from "../tools";
 import { executeHostTool } from "../tools";
 import { executionPlanHash, parseShellExecPlan } from "../tools/shell";
@@ -98,13 +98,13 @@ async function preparePermissionResolution(options: ResolvePermissionOptions) {
     await context.session.append({
       role: "system",
       content: "",
-      metadata: { kind: "quality-check-pending", qualityRewrite: pendingState },
+      metadata: withExecutionRound(context.session.sessionId, { kind: "quality-check-pending", qualityRewrite: pendingState }),
     });
   }
   await context.session.append({
     role: "system",
     content: `Permission ${options.resolution.decision} for ${call.name}.`,
-    metadata: {
+    metadata: withExecutionRound(context.session.sessionId, {
       kind: "permission-resolution",
       requestId: options.request.id,
       toolCallId: call.id,
@@ -115,7 +115,7 @@ async function preparePermissionResolution(options: ResolvePermissionOptions) {
       decisionSource: "user",
       capabilityAvailable,
       ...(options.resolution.decision === "reject" && options.resolution.feedback ? { feedback: options.resolution.feedback } : {}),
-    },
+    }),
   });
   return { context, messages, call, approvedShellPlanHash, qualityState };
 }
@@ -189,6 +189,7 @@ async function continuePermissionSequence(
     mcpRegistry: context.toolSurface.mcp,
     messages,
     session: context.session,
+    logicalTurnId: context.identity?.logicalTurnId,
     profile: context.profile,
     generation: context.generation,
     checkpoint: context.checkpoint,
@@ -255,7 +256,7 @@ async function executeApprovedEntry(
     await context.session.append({
       role: "system",
       content: "Approved shell process started.",
-      metadata: { kind: "process-started", requestId: entry.request.id, toolCallId: call.id, planHash: approvedShellPlanHash, checkpointTainted: true },
+      metadata: withExecutionRound(context.session.sessionId, { kind: "process-started", requestId: entry.request.id, toolCallId: call.id, planHash: approvedShellPlanHash, checkpointTainted: true }),
     });
   }
   if (agentToolNames.has(call.name)) {
@@ -321,7 +322,7 @@ async function createPermissionPause(
     ),
     ...(qualityState ? { qualityState } : {}),
   };
-  await context.session.append({ role: "system", content: `Permission required for ${call.name}.`, metadata: { kind: "permission-request", request } });
+  await context.session.append({ role: "system", content: `Permission required for ${call.name}.`, metadata: withExecutionRound(context.session.sessionId, { kind: "permission-request", request }) });
   onEvent?.({ type: "permission_pending", request });
   return {
     kind: "needs_permission",

--- a/src/core/agent-loop/provider-round.ts
+++ b/src/core/agent-loop/provider-round.ts
@@ -3,6 +3,7 @@ import { materializeMessageImages } from "../attachments/store";
 import type { EngineId } from "../engine/profile";
 import type { ProviderSelection } from "../../config/providers";
 import type { SessionStore } from "../session/store";
+import { withExecutionRound } from "../session/store";
 import type { ToolDefinition } from "../tools";
 import type { ProcessManager } from "../process/manager";
 import type { AgentLoopEvent } from "./types";
@@ -38,7 +39,10 @@ export async function completeProviderRound(options: ProviderRoundOptions): Prom
     await options.session.append({
       role: "user",
       content,
-      metadata: { kind: "background-process-results", taskIds: backgroundNotifications.map((task) => task.taskId) },
+      metadata: withExecutionRound(options.session.sessionId, {
+        kind: "background-process-results",
+        taskIds: backgroundNotifications.map((task) => task.taskId),
+      }),
     });
   }
 

--- a/src/core/agent-loop/quality-continuation-bootstrap.ts
+++ b/src/core/agent-loop/quality-continuation-bootstrap.ts
@@ -68,6 +68,7 @@ export async function runQualityContinuation(input: {
     mcpRegistry: context.toolSurface.mcp,
     messages: input.messages,
     session: context.session,
+    logicalTurnId: context.identity?.logicalTurnId,
     profile: context.profile,
     generation: context.generation,
     checkpoint: await FileCheckpointManager.resumeLatest(context.rootDir, context.session),

--- a/src/core/agent-loop/quality-decision-settlement.ts
+++ b/src/core/agent-loop/quality-decision-settlement.ts
@@ -9,6 +9,7 @@ import {
   loadSessionSnapshot,
   type SessionSnapshot,
   type SessionStore,
+  withExecutionRound,
 } from "../session/store";
 import {
   assertExperimentalJudgeIdentity,
@@ -36,11 +37,11 @@ export async function retryQualityDecision(
   await context.session.append({
     role: "system",
     content: "",
-    metadata: {
+    metadata: withExecutionRound(context.session.sessionId, {
       kind: "quality-retry-intent",
       warningId: point.warning.id,
       attempt: point.qualityState.attempts + 1,
-    },
+    }),
   });
   if (point.phase === "before-mutations") {
     await appendRejectedCandidate(context.session, messages, snapshot, point, feedback);

--- a/src/core/agent-loop/tool-result-recorder.ts
+++ b/src/core/agent-loop/tool-result-recorder.ts
@@ -2,6 +2,7 @@ import type { VesicleMessage } from "../../providers/shared/types";
 import { persistedImageAttachments } from "../attachments/store";
 import type { ProcessManager } from "../process/manager";
 import type { SessionStore } from "../session/store";
+import { withExecutionRound } from "../session/store";
 import type { ToolResult } from "../tools";
 import { trackBackgroundProcessCompletion } from "./background-process";
 import type { AgentLoopEvent } from "./types";
@@ -28,7 +29,7 @@ export async function recordToolResult(options: RecordToolResultOptions): Promis
   await options.session.append({
     role: "tool",
     content,
-    metadata: {
+    metadata: withExecutionRound(options.session.sessionId, {
       name: result.name,
       ok: result.ok,
       toolCallId: result.callId,
@@ -39,7 +40,7 @@ export async function recordToolResult(options: RecordToolResultOptions): Promis
       ...(result.instructionEvent ? { instructionEvent: result.instructionEvent } : {}),
       ...(result.images ? { images: persistedImageAttachments(result.images) } : {}),
       ...(options.metadata ?? {}),
-    },
+    }),
   });
   if (options.processManager) {
     trackBackgroundProcessCompletion(options.processManager, options.session, result);

--- a/src/core/agent-loop/turn-bootstrap.ts
+++ b/src/core/agent-loop/turn-bootstrap.ts
@@ -9,7 +9,7 @@ import { composeInstructionBlocks } from "../instructions";
 import { freezeInstructionBlocks } from "../instructions/instruction-context";
 import { defaultPermissionRuntime } from "../permissions";
 import { loadEngineAssetRuntime } from "../runtime/engine-assets";
-import { createSessionStore } from "../session/store";
+import { bindExecutionRound, createSessionStore, executionIdentityMetadata, newLogicalTurnId, newProviderRoundId } from "../session/store";
 import { createTurnAgentManager } from "./agent-manager";
 import { emitAssetDriftIfNeeded } from "./continuation-context";
 import { generationMetadata, mergeGeneration } from "./generation";
@@ -68,6 +68,14 @@ export async function bootstrapTurn(options: RunPromptOptions): Promise<RunLoopA
     Object.hasOwn(options, "sessionParentUuid") ? { parentUuid: options.sessionParentUuid ?? null } : {},
   );
 
+  // A new top-level Agent Loop gets a fresh logical turn id, and its first
+  // provider round is allocated alongside the initiating input. Binding the
+  // round now means every recorder and injected input this turn appends will
+  // stamp it, so segmentation can group the turn and its rounds later.
+  const logicalTurnId = newLogicalTurnId();
+  const providerRoundId = newProviderRoundId();
+  bindExecutionRound(session.sessionId, { logicalTurnId, providerRoundId });
+
   if (isNewSession) {
     await session.append({
       role: "system",
@@ -112,6 +120,7 @@ export async function bootstrapTurn(options: RunPromptOptions): Promise<RunLoopA
       content: options.input,
       metadata: {
         ...(options.inputMetadata ?? {}),
+        ...executionIdentityMetadata({ logicalTurnId, providerRoundId }),
         engine,
         provider: config.provider,
         providerId: config.providerId,
@@ -142,6 +151,8 @@ export async function bootstrapTurn(options: RunPromptOptions): Promise<RunLoopA
     mcpRegistry: toolSurface.mcp,
     messages,
     session,
+    logicalTurnId,
+    providerRoundId,
     profile,
     generation,
     checkpoint,

--- a/src/core/agent-loop/turn-bootstrap.ts
+++ b/src/core/agent-loop/turn-bootstrap.ts
@@ -69,12 +69,12 @@ export async function bootstrapTurn(options: RunPromptOptions): Promise<RunLoopA
   );
 
   // A new top-level Agent Loop gets a fresh logical turn id, and its first
-  // provider round is allocated alongside the initiating input. Binding the
-  // round now means every recorder and injected input this turn appends will
-  // stamp it, so segmentation can group the turn and its rounds later.
+  // provider round is allocated alongside the initiating input. The ids stamp
+  // the user record directly; the active-round map is bound only after all
+  // fallible bootstrap appends succeed (just before return) so a failed append
+  // can never leak a stale entry that runLoop's finally would never clear.
   const logicalTurnId = newLogicalTurnId();
   const providerRoundId = newProviderRoundId();
-  bindExecutionRound(session.sessionId, { logicalTurnId, providerRoundId });
 
   if (isNewSession) {
     await session.append({
@@ -135,6 +135,10 @@ export async function bootstrapTurn(options: RunPromptOptions): Promise<RunLoopA
   // Freeze only after bootstrap's fallible persistence work is complete. From
   // here, runLoop owns cleanup on completion or failure, while pauses retain it.
   freezeInstructionBlocks(session.sessionId, composeInstructionBlocks(instructional.selection));
+  // Bind the active round last, after every fallible append above has succeeded.
+  // runLoop's finally clears it on completion/pause/error; a throw before this
+  // point leaves no leaked entry.
+  bindExecutionRound(session.sessionId, { logicalTurnId, providerRoundId });
   const messages: VesicleMessage[] = options.messages ?? [{
     role: "user",
     content: options.input,

--- a/src/core/agent-loop/turn-finalizer.ts
+++ b/src/core/agent-loop/turn-finalizer.ts
@@ -1,6 +1,7 @@
 import type { VesicleMessage, VesicleResponse } from "../../providers/shared/types";
 import type { EngineProfile } from "../engine/profile";
 import type { SessionStore } from "../session/store";
+import { withExecutionRound } from "../session/store";
 import { validateContent } from "../validators/registry";
 import type { AgentLoopEvent, RunPromptResult, ValidatorOutcome } from "./types";
 import type { QualityOutcome } from "../quality";
@@ -26,14 +27,14 @@ export async function finalizeTurn(options: {
     const record = await options.session.append({
       role: "assistant",
       content: response.content,
-      metadata: {
+      metadata: withExecutionRound(options.session.sessionId, {
         engine: options.profile.id,
         model: options.model,
         providerResponseId: response.id,
         ...(response.reasoningContent ? { reasoningContent: response.reasoningContent } : {}),
         ...(response.thinkingBlocks ? { thinkingBlocks: response.thinkingBlocks } : {}),
         ...(response.usage ? { usage: response.usage } : {}),
-      },
+      }),
     });
     assistantRecordUuid = record.uuid;
   }

--- a/src/core/agent-loop/turn-loop.ts
+++ b/src/core/agent-loop/turn-loop.ts
@@ -459,6 +459,6 @@ async function recordNoProgressBreak(session: SessionStore, consecutiveFailures:
   await session.append({
     role: "system",
     content: `Tool loop stopped after ${consecutiveFailures} consecutive rounds of failing tool results.`,
-    metadata: { kind: "no-progress-breaker" },
+    metadata: withExecutionRound(session.sessionId, { kind: "no-progress-breaker" }),
   });
 }

--- a/src/core/agent-loop/turn-loop.ts
+++ b/src/core/agent-loop/turn-loop.ts
@@ -9,6 +9,7 @@ import { defaultPermissionRuntime } from "../permissions";
 import type { PermissionRuntimeOptions, ToolPermissionBroker } from "../permissions";
 import { getProcessManager, type ProcessManager } from "../process/manager";
 import type { SessionStore } from "../session/store";
+import { bindExecutionRound, clearExecutionRound, newProviderRoundId, withExecutionRound } from "../session/store";
 import type { ToolDefinition } from "../tools";
 import { createTurnAgentManager } from "./agent-manager";
 import { recordAssistantToolCalls } from "./assistant-recorder";
@@ -65,6 +66,20 @@ export type RunLoopArgs = {
   mcpRegistry: McpRegistry;
   messages: VesicleMessage[];
   session: SessionStore;
+  /**
+   * Stable id for the whole top-level Agent Loop. Present for any turn the
+   * bootstrap started (fresh turn) or a continuation recovered from persisted
+   * records (resumed pause). Absent only for a legacy session whose records
+   * pre-date identity stamping; in that case the loop appends without stamping.
+   */
+  logicalTurnId?: string;
+  /**
+   * First provider round for iteration 0 (a fresh turn — the bootstrap
+   * allocated it with the user input). Absent for continuations, which advance
+   * to a fresh round before their first request because the resolution just
+   * completed the previous round.
+   */
+  providerRoundId?: string;
   profile: EngineProfile;
   generation?: VesicleRequest["generation"];
   checkpoint?: FileCheckpointManager;
@@ -90,6 +105,8 @@ type LoopRuntime = {
   checkpoint?: FileCheckpointManager;
   checkpointMutationTail: Promise<void>;
   quality: QualityRoundState;
+  logicalTurnId: string | undefined;
+  providerRoundId: string | undefined;
 };
 
 export async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
@@ -98,6 +115,12 @@ export async function runLoop(args: RunLoopArgs): Promise<RunPromptResult> {
   } catch (error) {
     clearFrozenInstructionBlocks(args.session.sessionId);
     throw error;
+  } finally {
+    // The active provider round is process-local. Clear it on every exit
+    // (completion, pause, or error): a continuation re-binds the recovered
+    // round before appending, and a non-loop append (e.g. /compact) must never
+    // inherit a stale round.
+    clearExecutionRound(args.session.sessionId);
   }
 }
 
@@ -120,7 +143,15 @@ async function runLoopInternal(args: RunLoopArgs): Promise<RunPromptResult> {
   let response: VesicleResponse | undefined;
   let consecutiveFailures = 0;
 
-  if (args.injectPendingBeforeFirstProvider) await processInputBoundary(args, runtime);
+  // A fresh turn reuses the provider round the bootstrap allocated with the
+  // user input. A continuation (injectPendingBeforeFirstProvider) just appended
+  // the resolution that completed the previous round, so the first request here
+  // is a new provider round; advance before draining queued inputs so they (and
+  // the request) stamp the new round id.
+  if (args.injectPendingBeforeFirstProvider) {
+    advanceProviderRound(args, runtime);
+    await processInputBoundary(args, runtime);
+  }
 
   // Recompose from the frozen instruction snapshot before the first round. This
   // matters for a MANUAL/INERTIA resume: the approved update_instructions ran
@@ -138,6 +169,10 @@ async function runLoopInternal(args: RunLoopArgs): Promise<RunPromptResult> {
     // provider round observes the new instructions. Stage has no instruction
     // tools and must keep its frozen character-context suffix, so it is skipped.
     refreshLiveSystemPrompt(args);
+    // The next provider request is a new provider/tool round; advance before
+    // queued steering/background input is materialized so those injected inputs
+    // carry the next round id, then drain them.
+    advanceProviderRound(args, runtime);
     await processInputBoundary(args, runtime);
 
     consecutiveFailures = round.anyFailed ? consecutiveFailures + 1 : 0;
@@ -363,7 +398,24 @@ function createLoopRuntime(args: RunLoopArgs): LoopRuntime {
     checkpoint: args.checkpoint,
     checkpointMutationTail: Promise.resolve(),
     quality: createQualityRoundState(args.qualityState),
+    logicalTurnId: args.logicalTurnId,
+    providerRoundId: args.providerRoundId,
   };
+}
+
+/**
+ * Allocate the next provider/tool round id and bind it as the active round so
+ * recorders and injected-input appends stamp it. The logical turn id is stable
+ * for the whole turn; only the provider round id advances. A legacy turn with
+ * no logical turn id is left unstamped so its records stay legacy.
+ */
+function advanceProviderRound(args: RunLoopArgs, runtime: LoopRuntime): void {
+  if (!runtime.logicalTurnId) return;
+  runtime.providerRoundId = newProviderRoundId();
+  bindExecutionRound(args.session.sessionId, {
+    logicalTurnId: runtime.logicalTurnId,
+    providerRoundId: runtime.providerRoundId,
+  });
 }
 
 function trackCheckpointMutation(runtime: LoopRuntime, paths: string[]): Promise<void> {
@@ -381,7 +433,7 @@ async function injectPendingUserInputs(args: RunLoopArgs, runtime: LoopRuntime):
     const record = await args.session.append({
       role: "user",
       content,
-      metadata: {
+      metadata: withExecutionRound(args.session.sessionId, {
         kind: "queued-user-message",
         engine: args.profile.id,
         provider: args.config.provider,
@@ -389,7 +441,7 @@ async function injectPendingUserInputs(args: RunLoopArgs, runtime: LoopRuntime):
         model: args.config.model,
         ...generationMetadata(args.generation),
         ...(input.images?.length ? { images: persistedImageAttachments(input.images) } : {}),
-      },
+      }),
     });
     const checkpoint = new FileCheckpointManager(args.rootDir, args.session, record.uuid);
     await checkpoint.createSnapshot();

--- a/src/core/agent-loop/user-question-continuation.ts
+++ b/src/core/agent-loop/user-question-continuation.ts
@@ -7,6 +7,7 @@ import { loadContinuationContext } from "./continuation-context";
 import { generationMetadata } from "./generation";
 import { runLoop } from "./turn-loop";
 import { FileCheckpointManager } from "../checkpoints/file-history";
+import { withExecutionRound } from "../session/store";
 import type { AgentManager } from "../agents/manager";
 import type { AgentMetadata } from "../agents/types";
 import { AgentStore } from "../agents/store";
@@ -44,7 +45,7 @@ export async function resolveUserQuestion(options: ResolveUserQuestionOptions): 
     await context.session.append({
       role: "system",
       content: "",
-      metadata: {
+      metadata: withExecutionRound(context.session.sessionId, {
         kind: "delegation-retry-intent",
         retryIntent: {
           id: preparedRetry.intentId,
@@ -54,7 +55,7 @@ export async function resolveUserQuestion(options: ResolveUserQuestionOptions): 
           attempt: preparedRetry.failed.delegation!.attempt + 1,
           retryCallId: preparedRetry.retryCall.id,
         },
-      },
+      }),
     });
   }
   const toolResultContent = JSON.stringify({
@@ -80,7 +81,7 @@ export async function resolveUserQuestion(options: ResolveUserQuestionOptions): 
   await context.session.append({
     role: "tool",
     content: toolResultContent,
-    metadata: {
+    metadata: withExecutionRound(context.session.sessionId, {
       engine: options.engine,
       name: "ask_user_question",
       ok: true,
@@ -99,7 +100,7 @@ export async function resolveUserQuestion(options: ResolveUserQuestionOptions): 
         ...(preparedRetry ? { retryIntentId: preparedRetry.intentId } : {}),
       } : options.answer.kind ? { kind: options.answer.kind } : {}),
       ...(options.answer.freeformText ? { freeformText: options.answer.freeformText } : {}),
-    },
+    }),
   });
 
   const userFollowUp = userQuestionFollowUpMessage(options.question, options.answer);
@@ -107,7 +108,7 @@ export async function resolveUserQuestion(options: ResolveUserQuestionOptions): 
   await context.session.append({
     role: "user",
     content: userFollowUp,
-    metadata: {
+    metadata: withExecutionRound(context.session.sessionId, {
       engine: options.engine,
       provider: context.config.provider,
       providerId: context.config.providerId,
@@ -123,7 +124,7 @@ export async function resolveUserQuestion(options: ResolveUserQuestionOptions): 
         optionId: contractOption.id,
         ...(preparedRetry ? { retryIntentId: preparedRetry.intentId } : {}),
       } : {}),
-    },
+    }),
   });
 
   const manager = options.agentManager ?? createTurnAgentManager(context.rootDir, options.onEvent);
@@ -153,6 +154,7 @@ export async function resolveUserQuestion(options: ResolveUserQuestionOptions): 
     mcpRegistry: context.toolSurface.mcp,
     messages,
     session: context.session,
+    logicalTurnId: context.identity?.logicalTurnId,
     profile: context.profile,
     generation: context.generation,
     checkpoint,
@@ -199,7 +201,7 @@ async function executeAuthorizedDelegationRetry(options: {
   await options.context.session.append({
     role: "assistant",
     content: "",
-    metadata: {
+    metadata: withExecutionRound(options.context.session.sessionId, {
       kind: "delegation-user-retry",
       retryIntentId: intentId,
       engine: options.context.profile.id,
@@ -208,7 +210,7 @@ async function executeAuthorizedDelegationRetry(options: {
       delegationId: failed.delegation.id,
       attempt: failed.delegation.attempt + 1,
       toolCalls: [retryCall],
-    },
+    }),
   });
   const child = await options.manager.spawn({
     profileId: failed.profileId,

--- a/src/core/session/compact-checkpoint.ts
+++ b/src/core/session/compact-checkpoint.ts
@@ -1,0 +1,197 @@
+import type { ResumedMessage } from "./store";
+
+/**
+ * The durable, versioned replacement-history checkpoint installed by every
+ * portable compaction. One system-role record with `metadata.kind =
+ * "compact-checkpoint-v1"` carries this payload. The record — not regenerated
+ * prose — is the authority for the provider-visible replacement history; the
+ * original append-only transcript stays intact above it for transcript, rewind,
+ * and audit. See `AUTO_COMPACTION_IMPLEMENTATION_PLAN.md` §3 (Frozen contract).
+ */
+export type CompactCheckpointTrigger = "manual" | "auto";
+export type CompactCheckpointPhase = "pre-turn" | "mid-turn" | "manual";
+export type CompactCheckpointReason = "requested" | "soft-threshold" | "hard-ceiling" | "model-switch";
+
+export type PortableCompactCheckpointV1 = {
+  version: 1;
+  strategy: "portable-summary";
+  trigger: CompactCheckpointTrigger;
+  phase: CompactCheckpointPhase;
+  reason: CompactCheckpointReason;
+  sourceHeadUuid: string;
+  createdWith: {
+    providerId: string;
+    model: string;
+    engine: string;
+  };
+  replacementMessages: ResumedMessage[];
+  summary: {
+    text: string;
+    evictedLogicalTurnIds: string[];
+    evictedProviderRoundIds: string[];
+  };
+  retained: {
+    logicalTurnIds: string[];
+    providerRoundIds: string[];
+  };
+  accounting: {
+    contextWindow?: number;
+    softTriggerTokens?: number;
+    hardInputCeilingTokens?: number;
+    beforeTokens?: number;
+    beforeSource: "provider" | "estimated" | "unknown";
+    projectedAfterTokens?: number;
+  };
+};
+
+export const COMPACT_CHECKPOINT_KIND = "compact-checkpoint-v1";
+
+const KNOWN_VERSIONS = new Set<number>([1]);
+const TRIGGERS = new Set<CompactCheckpointTrigger>(["manual", "auto"]);
+const PHASES = new Set<CompactCheckpointPhase>(["pre-turn", "mid-turn", "manual"]);
+const REASONS = new Set<CompactCheckpointReason>(["requested", "soft-threshold", "hard-ceiling", "model-switch"]);
+const BEFORE_SOURCES = new Set(["provider", "estimated", "unknown"]);
+
+export function isCompactCheckpointRecord(record: { metadata?: Record<string, unknown> | undefined }): boolean {
+  return record.metadata?.kind === COMPACT_CHECKPOINT_KIND;
+}
+
+/**
+ * Validate and parse a persisted checkpoint payload. An unknown future version
+ * fails with an actionable session error rather than being silently ignored,
+ * and a malformed v1 payload never partially projects. Callers must surface the
+ * error instead of falling back to raw history.
+ */
+export function parseCompactCheckpoint(payload: unknown): PortableCompactCheckpointV1 {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Session compact checkpoint is malformed: expected an object.");
+  }
+  const source = payload as Record<string, unknown>;
+  const version = source.version;
+  if (typeof version !== "number" || !KNOWN_VERSIONS.has(version)) {
+    throw new Error(
+      `Session compact checkpoint version ${typeof version === "number" ? version : "unknown"} is not supported by this version of Vesicle. Update Vesicle or resume from a session before the checkpoint.`,
+    );
+  }
+  requireString(source, "strategy", "portable-summary");
+  requireEnum(source, "trigger", TRIGGERS, "checkpoint trigger");
+  requireEnum(source, "phase", PHASES, "checkpoint phase");
+  requireEnum(source, "reason", REASONS, "checkpoint reason");
+  requireString(source, "sourceHeadUuid");
+
+  const createdWith = requireObject(source, "createdWith");
+  requireString(createdWith, "providerId");
+  requireString(createdWith, "model");
+  requireString(createdWith, "engine");
+
+  const replacementMessages = requireArray(source, "replacementMessages");
+  const validatedMessages: ResumedMessage[] = replacementMessages.map((entry, index) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(`Session compact checkpoint replacementMessages[${index}] is malformed.`);
+    }
+    const message = entry as Record<string, unknown>;
+    if (typeof message.role !== "string" || typeof message.content !== "string") {
+      throw new Error(`Session compact checkpoint replacementMessages[${index}] is missing role/content.`);
+    }
+    return message as unknown as ResumedMessage;
+  });
+
+  const summary = requireObject(source, "summary");
+  requireString(summary, "text");
+  const evictedLogicalTurnIds = requireStringArray(summary, "evictedLogicalTurnIds");
+  const evictedProviderRoundIds = requireStringArray(summary, "evictedProviderRoundIds");
+
+  const retained = requireObject(source, "retained");
+  const retainedLogicalTurnIds = requireStringArray(retained, "logicalTurnIds");
+  const retainedProviderRoundIds = requireStringArray(retained, "providerRoundIds");
+
+  const accounting = requireObject(source, "accounting");
+  const contextWindow = optionalPositiveInteger(accounting, "contextWindow");
+  const softTriggerTokens = optionalPositiveInteger(accounting, "softTriggerTokens");
+  const hardInputCeilingTokens = optionalPositiveInteger(accounting, "hardInputCeilingTokens");
+  const beforeTokens = optionalPositiveInteger(accounting, "beforeTokens");
+  requireEnum(accounting, "beforeSource", BEFORE_SOURCES, "checkpoint beforeSource");
+  const projectedAfterTokens = optionalPositiveInteger(accounting, "projectedAfterTokens");
+
+  return {
+    version: 1,
+    strategy: "portable-summary",
+    trigger: source.trigger as CompactCheckpointTrigger,
+    phase: source.phase as CompactCheckpointPhase,
+    reason: source.reason as CompactCheckpointReason,
+    sourceHeadUuid: source.sourceHeadUuid as string,
+    createdWith: {
+      providerId: createdWith.providerId as string,
+      model: createdWith.model as string,
+      engine: createdWith.engine as string,
+    },
+    replacementMessages: validatedMessages,
+    summary: {
+      text: summary.text as string,
+      evictedLogicalTurnIds,
+      evictedProviderRoundIds,
+    },
+    retained: {
+      logicalTurnIds: retainedLogicalTurnIds,
+      providerRoundIds: retainedProviderRoundIds,
+    },
+    accounting: {
+      ...(contextWindow !== undefined ? { contextWindow } : {}),
+      ...(softTriggerTokens !== undefined ? { softTriggerTokens } : {}),
+      ...(hardInputCeilingTokens !== undefined ? { hardInputCeilingTokens } : {}),
+      ...(beforeTokens !== undefined ? { beforeTokens } : {}),
+      beforeSource: accounting.beforeSource as "provider" | "estimated" | "unknown",
+      ...(projectedAfterTokens !== undefined ? { projectedAfterTokens } : {}),
+    },
+  };
+}
+
+function requireString(record: Record<string, unknown>, key: string, expected?: string): void {
+  const value = record[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`Session compact checkpoint ${key} is malformed.`);
+  }
+  if (expected !== undefined && value !== expected) {
+    throw new Error(`Session compact checkpoint ${key} "${value}" is not supported (expected ${expected}).`);
+  }
+}
+
+function requireEnum(record: Record<string, unknown>, key: string, allowed: Set<string>, label: string): void {
+  const value = record[key];
+  if (typeof value !== "string" || !allowed.has(value)) {
+    throw new Error(`Session compact checkpoint ${label} is malformed.`);
+  }
+}
+
+function requireObject(record: Record<string, unknown>, key: string): Record<string, unknown> {
+  const value = record[key];
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`Session compact checkpoint ${key} is malformed.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function requireArray(record: Record<string, unknown>, key: string): unknown[] {
+  const value = record[key];
+  if (!Array.isArray(value)) {
+    throw new Error(`Session compact checkpoint ${key} is malformed.`);
+  }
+  return value;
+}
+
+function requireStringArray(record: Record<string, unknown>, key: string): string[] {
+  const value = requireArray(record, key);
+  for (const entry of value) {
+    if (typeof entry !== "string") throw new Error(`Session compact checkpoint ${key} contains a non-string entry.`);
+  }
+  return value as string[];
+}
+
+function optionalPositiveInteger(record: Record<string, unknown>, key: string): number | undefined {
+  if (!Object.hasOwn(record, key)) return undefined;
+  const value = record[key];
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0 || !Number.isInteger(value)) {
+    throw new Error(`Session compact checkpoint ${key} is malformed.`);
+  }
+  return value;
+}

--- a/src/core/session/execution-identity.ts
+++ b/src/core/session/execution-identity.ts
@@ -1,0 +1,105 @@
+import type { SessionRecord } from "./record-model";
+
+/**
+ * Durable identity persisted on every record that belongs to a top-level Agent
+ * Loop or a provider/tool round. One complete top-level, user-initiated Agent
+ * Loop shares a `logicalTurnId`; one complete provider/tool round within it
+ * shares a `providerRoundId`. See
+ * `dev/docs/working/AUTO_COMPACTION_IMPLEMENTATION_PLAN.md` §2 (Frozen contract).
+ *
+ * `providerRoundId` is optional on the persisted shape only because the host
+ * allocates the first round alongside the initiating input; in practice every
+ * conversational record carries both ids.
+ */
+export type SessionExecutionIdentity = {
+  logicalTurnId: string;
+  providerRoundId?: string;
+};
+
+/**
+ * The active round a recorder is appending into right now. Both ids are always
+ * present while a turn is running: the logical turn id is stable for the whole
+ * turn, and the provider round id advances once per prepared provider request.
+ */
+export type ExecutionRound = {
+  logicalTurnId: string;
+  providerRoundId: string;
+};
+
+export function newLogicalTurnId(): string {
+  return `turn_${crypto.randomUUID()}`;
+}
+
+export function newProviderRoundId(): string {
+  return `round_${crypto.randomUUID()}`;
+}
+
+export function readLogicalTurnId(record: SessionRecord): string | undefined {
+  const value = record.metadata?.logicalTurnId;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function readProviderRoundId(record: SessionRecord): string | undefined {
+  const value = record.metadata?.providerRoundId;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Metadata fields to merge onto a record so it carries the active identity. */
+export function executionIdentityMetadata(identity: ExecutionRound): { logicalTurnId: string; providerRoundId: string } {
+  return { logicalTurnId: identity.logicalTurnId, providerRoundId: identity.providerRoundId };
+}
+
+// --- active-round runtime context ------------------------------------------
+//
+// The active round is process-local and keyed by session id, mirroring the
+// frozen Persistent-Instruction snapshot in `core/instructions`. The Agent
+// Loop binds it before appending; recorders read it so identity threads through
+// every assistant/tool/interaction record without each call site repeating it.
+// A continuation re-binds the recovered round before appending its resolution,
+// so resuming a pause never creates a new logical turn.
+
+const activeRounds = new Map<string, ExecutionRound>();
+
+export function bindExecutionRound(sessionId: string, identity: ExecutionRound): void {
+  activeRounds.set(sessionId, identity);
+}
+
+export function readExecutionRound(sessionId: string): ExecutionRound | undefined {
+  return activeRounds.get(sessionId);
+}
+
+export function clearExecutionRound(sessionId: string): void {
+  activeRounds.delete(sessionId);
+}
+
+/**
+ * Merge the active round's identity into a record's metadata. Returns the
+ * metadata unchanged when no round is bound (legacy records, test fixtures, or
+ * appends outside a running turn), so existing behavior is preserved.
+ */
+export function withExecutionRound(sessionId: string, metadata: Record<string, unknown> | undefined): Record<string, unknown> {
+  const round = activeRounds.get(sessionId);
+  if (!round) return metadata ?? {};
+  return { ...(metadata ?? {}), ...executionIdentityMetadata(round) };
+}
+
+/**
+ * Recover the active logical turn + provider round for a resumed pause. The
+ * logical turn is the newest persisted `logicalTurnId`; the provider round is
+ * the round of the most recent record that carries one — the round that
+ * produced the paused interaction. Returns undefined when no identity has been
+ * persisted yet (a legacy session), so the continuation falls back to the old
+ * append behavior instead of guessing.
+ */
+export function recoverActiveIdentity(records: SessionRecord[]): ExecutionRound | undefined {
+  let logicalTurnId: string | undefined;
+  let providerRoundId: string | undefined;
+  for (const record of records) {
+    const turn = readLogicalTurnId(record);
+    if (turn) logicalTurnId = turn;
+    const round = readProviderRoundId(record);
+    if (round) providerRoundId = round;
+  }
+  if (!logicalTurnId || !providerRoundId) return undefined;
+  return { logicalTurnId, providerRoundId };
+}

--- a/src/core/session/execution-identity.ts
+++ b/src/core/session/execution-identity.ts
@@ -84,22 +84,20 @@ export function withExecutionRound(sessionId: string, metadata: Record<string, u
 }
 
 /**
- * Recover the active logical turn + provider round for a resumed pause. The
- * logical turn is the newest persisted `logicalTurnId`; the provider round is
- * the round of the most recent record that carries one — the round that
- * produced the paused interaction. Returns undefined when no identity has been
- * persisted yet (a legacy session), so the continuation falls back to the old
- * append behavior instead of guessing.
+ * Recover the active logical turn + provider round for a resumed pause. Scans
+ * backwards and returns the identity from the most recent record that carries
+ * BOTH ids together — the round that produced the paused interaction — so a
+ * host marker that happens to persist only a logical turn id can never be
+ * cobbled together with an older round id. Returns undefined when no identity
+ * has been persisted yet (a legacy session), so the continuation falls back to
+ * the old append behavior instead of guessing.
  */
 export function recoverActiveIdentity(records: SessionRecord[]): ExecutionRound | undefined {
-  let logicalTurnId: string | undefined;
-  let providerRoundId: string | undefined;
-  for (const record of records) {
-    const turn = readLogicalTurnId(record);
-    if (turn) logicalTurnId = turn;
-    const round = readProviderRoundId(record);
-    if (round) providerRoundId = round;
+  for (let index = records.length - 1; index >= 0; index--) {
+    const record = records[index]!;
+    const logicalTurnId = readLogicalTurnId(record);
+    const providerRoundId = readProviderRoundId(record);
+    if (logicalTurnId && providerRoundId) return { logicalTurnId, providerRoundId };
   }
-  if (!logicalTurnId || !providerRoundId) return undefined;
-  return { logicalTurnId, providerRoundId };
+  return undefined;
 }

--- a/src/core/session/history-projector.ts
+++ b/src/core/session/history-projector.ts
@@ -9,6 +9,7 @@ import type { FileToolEvent, McpToolEvent, ProcessToolEvent, WebToolEvent } from
 import type { PermissionMode } from "../permissions";
 import type { ReasoningDisplayMode, ResumedMessage } from "./store";
 import type { ResumedToolCall, SessionRecord } from "./record-model";
+import { COMPACT_CHECKPOINT_KIND, parseCompactCheckpoint } from "./compact-checkpoint";
 
 export type HistoryProjection = {
   messages: ResumedMessage[];
@@ -92,6 +93,18 @@ export function projectSessionHistory(records: SessionRecord[]): HistoryProjecti
       }
       if (record.metadata?.kind === FAILED_TURN_KIND) {
         dropFailedTurnInput(messages);
+        continue;
+      }
+      if (record.metadata?.kind === COMPACT_CHECKPOINT_KIND) {
+        // A valid portable checkpoint is the durable authority for the
+        // provider-visible replacement history. Reset `messages` to its exact
+        // replacement, then keep replaying the suffix recorded after it. An
+        // unknown future version or a malformed payload throws an actionable
+        // session error rather than partially projecting or silently ignoring.
+        const checkpoint = parseCompactCheckpoint(record.metadata.checkpoint);
+        messages.length = 0;
+        messages.push(...checkpoint.replacementMessages.map((message) => ({ ...message })));
+        continue;
       }
       continue;
     }

--- a/src/core/session/segmentation.ts
+++ b/src/core/session/segmentation.ts
@@ -1,6 +1,7 @@
 import { ENGINE_HANDOFF_KIND } from "../engine/transition";
 import type { SessionRecord } from "./record-model";
 import { readLogicalTurnId, readProviderRoundId } from "./execution-identity";
+import { COMPACT_CHECKPOINT_KIND } from "./compact-checkpoint";
 
 /**
  * Conservative session segmentation: the pure service that groups an active
@@ -109,7 +110,7 @@ function isTurnRelevantSystem(record: SessionRecord): boolean {
   const kind = record.metadata?.kind;
   return kind === "validation"
     || kind === "failed-turn"
-    || kind === "compact-checkpoint-v1"
+    || kind === COMPACT_CHECKPOINT_KIND
     || kind === "compact-boundary"
     || kind === "no-progress-breaker";
 }

--- a/src/core/session/segmentation.ts
+++ b/src/core/session/segmentation.ts
@@ -1,0 +1,178 @@
+import { ENGINE_HANDOFF_KIND } from "../engine/transition";
+import type { SessionRecord } from "./record-model";
+import { readLogicalTurnId, readProviderRoundId } from "./execution-identity";
+
+/**
+ * Conservative session segmentation: the pure service that groups an active
+ * branch into indivisible logical turns and provider/tool rounds. It is the
+ * foundation for the portable replacement builder and never mutates records.
+ *
+ * Explicit identity metadata (`logicalTurnId` / `providerRoundId`) is the
+ * primary oracle. Legacy records without identity are grouped conservatively:
+ * a new turn is recognized only when an authored user prompt follows a completed
+ * prior assistant boundary, tool results are reconstructed from tool-call ids,
+ * and any ambiguous adjacent run is grown into one larger indivisible unit
+ * rather than risk splitting a tool call from its result.
+ */
+
+export type SegmentedRound = {
+  providerRoundId?: string;
+  records: SessionRecord[];
+  /** True when the round has an assistant reply and every declared tool call has a result. */
+  complete: boolean;
+};
+
+export type SegmentedTurn = {
+  logicalTurnId?: string;
+  records: SessionRecord[];
+  rounds: SegmentedRound[];
+  /** True when the turn ended at a complete assistant boundary (no pending interaction). */
+  complete: boolean;
+  /** True when this turn's grouping was inferred without explicit identity metadata. */
+  inferred: boolean;
+};
+
+export type SessionSegmentation = {
+  /** Bootstrap root records (composed prompt + session metadata) — not part of any turn. */
+  bootstrap: SessionRecord[];
+  /** Ordered complete turns, oldest first. */
+  turns: SegmentedTurn[];
+  /** Trailing in-progress turn with no complete boundary; always retained verbatim. */
+  frontier?: SegmentedTurn;
+  /** True when any turn was inferred without explicit identity metadata. */
+  inferred: boolean;
+};
+
+const HOST_INJECTED_USER_KINDS = new Set([
+  "gate-resolution",
+  "user-question-answer",
+  "compact-summary",
+  "background-process-results",
+  "subagent-results",
+  "quality-rewrite-feedback",
+  ENGINE_HANDOFF_KIND,
+  "queued-user-message",
+]);
+
+export function segmentSession(records: SessionRecord[]): SessionSegmentation {
+  const bootstrapEnd = leadingBootstrapLength(records);
+  const bootstrap = records.slice(0, bootstrapEnd);
+  const body = records.slice(bootstrapEnd);
+
+  const turns: SegmentedTurn[] = [];
+  let frontier: SegmentedTurn | undefined;
+  let inferredAny = false;
+
+  let current: SegmentedTurn | undefined;
+  for (const record of body) {
+    const logicalTurnId = readLogicalTurnId(record);
+    const startsNewTurn = current === undefined || isNewTurnBoundary(current, record, logicalTurnId);
+    if (startsNewTurn) {
+      if (current) {
+        finalizeTurn(current);
+        turns.push(current);
+      }
+      const inferred = logicalTurnId === undefined;
+      if (inferred) inferredAny = true;
+      current = { ...(logicalTurnId ? { logicalTurnId } : {}), records: [], rounds: [], complete: false, inferred };
+    }
+    // After the boundary check `current` is always defined: the first record
+    // opens a turn, and every later record either continues it or opens a new one.
+    appendToTurn(current!, record);
+  }
+  if (current) {
+    finalizeTurn(current);
+    // Only the trailing turn can be the active frontier; every earlier turn
+    // closed before the next one opened and is retained in `turns` regardless.
+    if (current.complete) turns.push(current);
+    else frontier = current;
+  }
+
+  return { bootstrap, turns, ...(frontier ? { frontier } : {}), inferred: inferredAny };
+}
+
+function leadingBootstrapLength(records: SessionRecord[]): number {
+  let index = 0;
+  while (index < records.length && records[index]!.role === "system" && !isTurnRelevantSystem(records[index]!)) {
+    index += 1;
+  }
+  return index;
+}
+
+/**
+ * The very first system record is the composed-prompt session root and is never
+ * part of a logical turn. Later system records (validation output, a failed-turn
+ * marker, a compact checkpoint, or a no-progress breaker) belong to the turn
+ * they sit inside, so the bootstrap prefix stops at the first of them.
+ */
+function isTurnRelevantSystem(record: SessionRecord): boolean {
+  const kind = record.metadata?.kind;
+  return kind === "validation"
+    || kind === "failed-turn"
+    || kind === "compact-checkpoint-v1"
+    || kind === "compact-boundary"
+    || kind === "no-progress-breaker";
+}
+
+function isNewTurnBoundary(current: SegmentedTurn, record: SessionRecord, logicalTurnId: string | undefined): boolean {
+  if (logicalTurnId && current.logicalTurnId && logicalTurnId !== current.logicalTurnId) return true;
+  // An explicit identity always continues the turn it names, even for a
+  // host-injected user record stamped with the same logical turn id.
+  if (logicalTurnId && current.logicalTurnId === logicalTurnId) return false;
+  // Legacy inference: a new turn starts only at an authored user prompt.
+  return isAuthoredPrompt(record);
+}
+
+function isAuthoredPrompt(record: SessionRecord): boolean {
+  if (record.role !== "user") return false;
+  const kind = record.metadata?.kind;
+  if (typeof kind === "string" && HOST_INJECTED_USER_KINDS.has(kind)) return false;
+  return record.content.trim().length > 0;
+}
+
+function appendToTurn(turn: SegmentedTurn, record: SessionRecord): void {
+  turn.records.push(record);
+  const last = turn.rounds[turn.rounds.length - 1];
+  const providerRoundId = readProviderRoundId(record);
+  const lastHasAssistant = last?.records.some((entry) => entry.role === "assistant") ?? false;
+  // A new provider/tool round starts when the explicit providerRoundId advances
+  // (identity-stamped) or, for legacy records, when a second assistant reply
+  // arrives. A user input or queued message that carries the next round id
+  // opens that round, and the assistant that shares the id then joins it rather
+  // than splitting it.
+  const startNewRound = last === undefined
+    || (providerRoundId !== undefined && last.providerRoundId !== undefined && providerRoundId !== last.providerRoundId)
+    || (record.role === "assistant" && last.providerRoundId === undefined && lastHasAssistant);
+  if (startNewRound) {
+    turn.rounds.push({ ...(providerRoundId ? { providerRoundId } : {}), records: [record], complete: false });
+    return;
+  }
+  last.records.push(record);
+}
+
+function finalizeTurn(turn: SegmentedTurn): void {
+  for (const round of turn.rounds) {
+    round.complete = isRoundComplete(round);
+  }
+  const lastRound = turn.rounds[turn.rounds.length - 1];
+  turn.complete = lastRound !== undefined && lastRound.complete;
+}
+
+function isRoundComplete(round: SegmentedRound): boolean {
+  const assistant = round.records.find((record) => record.role === "assistant");
+  if (!assistant) return false;
+  const toolCalls = (assistant.metadata?.toolCalls as Array<{ id?: unknown }> | undefined) ?? [];
+  if (toolCalls.length === 0) return true;
+  const declared = new Set(toolCalls.map((call) => (typeof call?.id === "string" ? call.id : "")).filter((id): id is string => id.length > 0));
+  if (declared.size === 0) return true;
+  const answered = new Set<string>();
+  for (const record of round.records) {
+    if (record.role !== "tool") continue;
+    const id = record.metadata?.toolCallId;
+    if (typeof id === "string") answered.add(id);
+  }
+  for (const id of declared) {
+    if (!answered.has(id)) return false;
+  }
+  return true;
+}

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -33,6 +33,32 @@ export { createSessionStore } from "./append-store";
 export type { SessionStore } from "./append-store";
 export type { PendingDelegationRetry } from "./interaction-recovery";
 export { FAILED_TURN_KIND } from "./history-projector";
+export {
+  bindExecutionRound,
+  clearExecutionRound,
+  executionIdentityMetadata,
+  newLogicalTurnId,
+  newProviderRoundId,
+  readExecutionRound,
+  readLogicalTurnId,
+  readProviderRoundId,
+  recoverActiveIdentity,
+  withExecutionRound,
+} from "./execution-identity";
+export type { ExecutionRound, SessionExecutionIdentity } from "./execution-identity";
+export { COMPACT_CHECKPOINT_KIND, isCompactCheckpointRecord, parseCompactCheckpoint } from "./compact-checkpoint";
+export type {
+  CompactCheckpointPhase,
+  CompactCheckpointReason,
+  CompactCheckpointTrigger,
+  PortableCompactCheckpointV1,
+} from "./compact-checkpoint";
+export { segmentSession } from "./segmentation";
+export type {
+  SegmentedRound,
+  SegmentedTurn,
+  SessionSegmentation,
+} from "./segmentation";
 
 export type ReasoningDisplayMode = "hidden" | "collapsed" | "expanded";
 

--- a/tests/integration/agent-loop/execution-identity.test.ts
+++ b/tests/integration/agent-loop/execution-identity.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { runPrompt } from "../../../src/core/agent-loop/run";
-import { loadSessionRecords, recoverActiveIdentity, segmentSession } from "../../../src/core/session/store";
+import { createSessionStore, loadSessionRecords, recoverActiveIdentity, segmentSession } from "../../../src/core/session/store";
 import {
   configureTestProviderEnv,
   createPromptRoot,
@@ -143,5 +143,21 @@ describe("agent loop: execution identity", () => {
     const turnRecords = records.filter((record) => (record.metadata?.logicalTurnId as string | undefined) === logicalTurnId);
     expect(turnRecords.length).toBeGreaterThan(1);
     expect(new Set(turnRecords.map((record) => record.metadata?.logicalTurnId as string | undefined)).size).toBe(1);
+  });
+
+  test("recoverActiveIdentity returns the round carrying both ids, not a cobbled-together pair", async () => {
+    const rootDir = await createPromptRoot();
+    const store = await createSessionStore(rootDir, "recover");
+    await store.append({ role: "system", content: "prompt", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "first", metadata: { logicalTurnId: "t1", providerRoundId: "r1" } });
+    await store.append({ role: "assistant", content: "reply", metadata: { logicalTurnId: "t2", providerRoundId: "r2" } });
+    // A trailing host marker persists only a logical turn id (no round). The
+    // recovered round must be r2 (the assistant that produced the pause), not a
+    // t2/r1 cobble from scanning each id independently.
+    await store.append({ role: "system", content: "", metadata: { logicalTurnId: "t2" } });
+
+    const records = await loadSessionRecords(rootDir, store.sessionId);
+    const recovered = recoverActiveIdentity(records);
+    expect(recovered).toEqual({ logicalTurnId: "t2", providerRoundId: "r2" });
   });
 });

--- a/tests/integration/agent-loop/execution-identity.test.ts
+++ b/tests/integration/agent-loop/execution-identity.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { runPrompt } from "../../../src/core/agent-loop/run";
+import { loadSessionRecords, recoverActiveIdentity, segmentSession } from "../../../src/core/session/store";
+import {
+  configureTestProviderEnv,
+  createPromptRoot,
+  restoreAgentLoopTestState,
+} from "./fixtures/agent-loop";
+
+beforeEach(configureTestProviderEnv);
+afterEach(restoreAgentLoopTestState);
+
+describe("agent loop: execution identity", () => {
+  test("a tool-loop turn persists one logical turn id and advancing provider round ids", async () => {
+    const rootDir = await createPromptRoot();
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      if (calls === 1) {
+        return Response.json({
+          id: `chatcmpl-${calls}`,
+          choices: [{
+            message: {
+              content: "",
+              tool_calls: [{
+                id: "call-write",
+                type: "function",
+                function: {
+                  name: "write_file",
+                  arguments: JSON.stringify({ path: "workspace/note.md", content: "x" }),
+                },
+              }],
+            },
+          }],
+        });
+      }
+      return Response.json({
+        id: `chatcmpl-${calls}`,
+        choices: [{ message: { content: "done" } }],
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await runPrompt({ input: "write a note", rootDir, messages: [{ role: "user", content: "write a note" }] });
+    if (result.kind !== "complete") throw new Error("expected complete turn");
+
+    const records = await loadSessionRecords(rootDir, result.sessionId);
+    const conversational = records.filter((record) => record.role !== "system");
+    // The bootstrap system record is the session root and must not carry a turn id.
+    expect(records[0]!.role).toBe("system");
+    expect(records[0]!.metadata?.logicalTurnId).toBeUndefined();
+
+    const turnIds = new Set(conversational.map((record) => record.metadata?.logicalTurnId as string | undefined));
+    expect(turnIds.size).toBe(1);
+    const logicalTurnId = conversational[0]!.metadata?.logicalTurnId as string | undefined;
+    expect(typeof logicalTurnId).toBe("string");
+
+    // The user input, the tool-calling assistant, and its tool result share the
+    // first provider round; the final assistant reply is the next provider round.
+    const roundId = (record: { metadata?: Record<string, unknown> }) => record.metadata?.providerRoundId as string | undefined;
+    const userRecord = records.find((record) => record.role === "user")!;
+    const toolCallAssistant = records.find((record) => record.role === "assistant" && (record.metadata?.toolCalls as unknown[] | undefined)?.length);
+    const toolRecord = records.find((record) => record.role === "tool")!;
+    const finalAssistant = records.filter((record) => record.role === "assistant").at(-1)!;
+
+    expect(roundId(userRecord)).toBeDefined();
+    expect(roundId(toolCallAssistant!)).toBe(roundId(userRecord));
+    expect(roundId(toolRecord)).toBe(roundId(userRecord));
+    expect(roundId(finalAssistant)).toBeDefined();
+    expect(roundId(finalAssistant)).not.toBe(roundId(userRecord));
+
+    // Recovery sees the newest persisted round, so a resumed pause re-binds it.
+    const recovered = recoverActiveIdentity(records);
+    expect(recovered?.logicalTurnId).toBe(logicalTurnId);
+    expect(recovered?.providerRoundId).toBe(roundId(finalAssistant));
+
+    // Segmentation groups the turn into the two provider rounds above.
+    const segmentation = segmentSession(records);
+    expect(segmentation.turns).toHaveLength(1);
+    const turn = segmentation.turns[0]!;
+    expect(turn.logicalTurnId).toBe(logicalTurnId);
+    expect(turn.complete).toBe(true);
+    expect(turn.rounds).toHaveLength(2);
+    const roundRoles = (round: { records: { role: string }[] }) => round.records.filter((record) => record.role !== "system").map((record) => record.role);
+    expect(roundRoles(turn.rounds[0]!)).toEqual(["user", "assistant", "tool"]);
+    expect(roundRoles(turn.rounds[1]!)).toEqual(["assistant"]);
+  });
+
+  test("a resumed pause keeps the original logical turn across continuation rounds", async () => {
+    const rootDir = await createPromptRoot({ stopGates: ["blueprint-confirmation"] });
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      // First round: the assistant asks for blueprint confirmation (a gate).
+      if (calls === 1) {
+        return Response.json({
+          id: `chatcmpl-${calls}`,
+          choices: [{
+            message: {
+              content: "here is the blueprint",
+              tool_calls: [{
+                id: "call-gate",
+                type: "function",
+                function: {
+                  name: "request_confirmation",
+                  arguments: JSON.stringify({ gate: "blueprint-confirmation", summary: "Concept: A" }),
+                },
+              }],
+            },
+          }],
+        });
+      }
+      // After the gate is resolved the continuation runs a new provider round.
+      return Response.json({ id: `chatcmpl-${calls}`, choices: [{ message: { content: "advancing" } }] });
+    }) as unknown as typeof fetch;
+
+    const first = await runPrompt({ input: "draft a blueprint", rootDir, messages: [{ role: "user", content: "draft a blueprint" }] });
+    if (first.kind !== "needs_user") throw new Error("expected a pending gate");
+
+    const gateCallAssistant = (await loadSessionRecords(rootDir, first.sessionId)).find((record) => record.role === "assistant")!;
+    const gateRoundId = gateCallAssistant.metadata?.providerRoundId as string | undefined;
+    const logicalTurnId = gateCallAssistant.metadata?.logicalTurnId as string | undefined;
+
+    const { resolveGate } = await import("../../../src/core/agent-loop/gate-continuation");
+    const resolved = await resolveGate({
+      engine: "etl",
+      rootDir,
+      sessionId: first.sessionId,
+      gate: first.gate,
+      toolCallId: first.toolCallId,
+      resolution: { decision: "confirm" },
+      messages: first.messages,
+    });
+    if (resolved.kind !== "complete") throw new Error("expected complete after gate resolution");
+
+    const records = await loadSessionRecords(rootDir, first.sessionId);
+    const gateResolution = records.find((record) => record.metadata?.kind === "gate-resolution" && record.role === "tool")!;
+    // The gate resolution belongs to the same provider round as the gate call;
+    // resuming the pause never creates a new logical turn.
+    expect(gateResolution.metadata?.providerRoundId as string | undefined).toBe(gateRoundId);
+    expect(gateResolution.metadata?.logicalTurnId as string | undefined).toBe(logicalTurnId);
+
+    // Every record this logical turn produced shares the same logical turn id.
+    const turnRecords = records.filter((record) => (record.metadata?.logicalTurnId as string | undefined) === logicalTurnId);
+    expect(turnRecords.length).toBeGreaterThan(1);
+    expect(new Set(turnRecords.map((record) => record.metadata?.logicalTurnId as string | undefined)).size).toBe(1);
+  });
+});

--- a/tests/integration/session/compact-checkpoint.test.ts
+++ b/tests/integration/session/compact-checkpoint.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  COMPACT_CHECKPOINT_KIND,
+  createSessionStore,
+  loadSessionMessages,
+} from "../../../src/core/session/store";
+import type { PortableCompactCheckpointV1 } from "../../../src/core/session/store";
+
+function validCheckpoint(overrides: Partial<PortableCompactCheckpointV1> = {}): PortableCompactCheckpointV1 {
+  return {
+    version: 1,
+    strategy: "portable-summary",
+    trigger: "manual",
+    phase: "manual",
+    reason: "requested",
+    sourceHeadUuid: crypto.randomUUID(),
+    createdWith: { providerId: "test", model: "test-model", engine: "etl" },
+    replacementMessages: [{ role: "user", content: "[conversation summary]\nEarlier work.", kind: "compact-summary" }],
+    summary: { text: "Earlier work.", evictedLogicalTurnIds: ["t0"], evictedProviderRoundIds: ["r0"] },
+    retained: { logicalTurnIds: [], providerRoundIds: [] },
+    accounting: { beforeSource: "unknown" },
+    ...overrides,
+  };
+}
+
+describe("session: compact-checkpoint-v1 projection", () => {
+  test("a valid checkpoint resets history to its replacement and replays the suffix", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-ckpt-"));
+    const store = await createSessionStore(rootDir, "ckpt-session");
+    await store.append({ role: "system", content: "composed prompt", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "old prompt", metadata: { logicalTurnId: "t0", providerRoundId: "r0" } });
+    await store.append({ role: "assistant", content: "old reply", metadata: { logicalTurnId: "t0", providerRoundId: "r0" } });
+    await store.append({
+      role: "system",
+      content: "Conversation compacted.",
+      metadata: { kind: COMPACT_CHECKPOINT_KIND, checkpoint: validCheckpoint() },
+    });
+    await store.append({ role: "user", content: "after compact", metadata: { logicalTurnId: "t1", providerRoundId: "r1" } });
+    await store.append({ role: "assistant", content: "after reply", metadata: { logicalTurnId: "t1", providerRoundId: "r1" } });
+
+    const messages = await loadSessionMessages(rootDir, store.sessionId);
+    // The evicted prefix is gone; the checkpoint replacement is followed by the
+    // exact suffix recorded after it.
+    expect(messages.map((message) => message.content)).toEqual([
+      "[conversation summary]\nEarlier work.",
+      "after compact",
+      "after reply",
+    ]);
+  });
+
+  test("an unknown future checkpoint version fails with an actionable error instead of partially projecting", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-ckpt-unknown-"));
+    const store = await createSessionStore(rootDir, "ckpt-unknown");
+    await store.append({ role: "system", content: "prompt", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "old" });
+    await store.append({
+      role: "system",
+      content: "compacted",
+      metadata: { kind: COMPACT_CHECKPOINT_KIND, checkpoint: validCheckpoint({ version: 99 as unknown as 1 }) },
+    });
+
+    await expect(loadSessionMessages(rootDir, store.sessionId)).rejects.toThrow(/not supported/);
+  });
+
+  test("a malformed v1 checkpoint fails instead of partially projecting", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-ckpt-malformed-"));
+    const store = await createSessionStore(rootDir, "ckpt-malformed");
+    await store.append({ role: "system", content: "prompt", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "old" });
+    const malformed = validCheckpoint();
+    // Corrupt the replacement list so validation rejects the whole payload.
+    (malformed as unknown as { replacementMessages: unknown }).replacementMessages = [{ role: "user" /* missing content */ }];
+    await store.append({
+      role: "system",
+      content: "compacted",
+      metadata: { kind: COMPACT_CHECKPOINT_KIND, checkpoint: malformed },
+    });
+
+    await expect(loadSessionMessages(rootDir, store.sessionId)).rejects.toThrow(/replacementMessages|malformed/);
+  });
+
+  test("a failed turn after a checkpoint drops only the failed input, preserving the replacement", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-ckpt-failed-"));
+    const store = await createSessionStore(rootDir, "ckpt-failed");
+    await store.append({ role: "system", content: "prompt", metadata: { engine: "etl" } });
+    await store.append({
+      role: "system",
+      content: "compacted",
+      metadata: { kind: COMPACT_CHECKPOINT_KIND, checkpoint: validCheckpoint() },
+    });
+    await store.append({ role: "user", content: "failed prompt", metadata: { logicalTurnId: "t1", providerRoundId: "r1" } });
+    await store.append({ role: "system", content: "", metadata: { kind: "failed-turn" } });
+
+    const messages = await loadSessionMessages(rootDir, store.sessionId);
+    // The checkpoint's replacement (a completed-operation boundary) survives;
+    // only the failed turn's trailing input is dropped.
+    expect(messages.map((message) => message.content)).toEqual(["[conversation summary]\nEarlier work."]);
+  });
+
+  test("image attachments in the replacement history stay reachable through projection", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-ckpt-images-"));
+    const store = await createSessionStore(rootDir, "ckpt-images");
+    await store.append({ role: "system", content: "prompt", metadata: { engine: "etl" } });
+    const image = { id: "img_reachable", path: ".vesicle/attachments/img_reachable.png", mediaType: "image/png" as const, bytes: 12, sha256: "a".repeat(64), source: "clipboard" as const };
+    await store.append({
+      role: "system",
+      content: "compacted",
+      metadata: {
+        kind: COMPACT_CHECKPOINT_KIND,
+        checkpoint: validCheckpoint({
+          replacementMessages: [
+            { role: "user", content: "[conversation summary]\nEarlier work.", kind: "compact-summary" },
+            { role: "user", content: "kept turn with an image", images: [image] },
+          ],
+          retained: { logicalTurnIds: ["t1"], providerRoundIds: ["r1"] },
+        }),
+      },
+    });
+
+    const messages = await loadSessionMessages(rootDir, store.sessionId);
+    // The retained tail's attachment reference survives projection verbatim, so
+    // any reachability/GC scan of the provider-visible history still sees it.
+    expect(messages.map((message) => message.content)).toEqual([
+      "[conversation summary]\nEarlier work.",
+      "kept turn with an image",
+    ]);
+    expect(messages[1]!.images?.map((entry) => entry.id)).toEqual(["img_reachable"]);
+  });
+});

--- a/tests/integration/session/segmentation.test.ts
+++ b/tests/integration/session/segmentation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { segmentSession } from "../../../src/core/session/store";
+import type { SessionRecord } from "../../../src/core/session/record-model";
+
+function record(role: SessionRecord["role"], metadata: Record<string, unknown> = {}, content = ""): SessionRecord {
+  return { uuid: crypto.randomUUID(), parentUuid: null, ts: "2026-07-26T00:00:00Z", sessionId: "s", role, content, metadata };
+}
+
+function systemRoot(): SessionRecord {
+  return record("system", { engine: "etl", assets: { sha256: "a" } }, "composed prompt");
+}
+
+describe("session segmentation", () => {
+  test("multiple identity-stamped Agent Loops segment independently", () => {
+    const records = [
+      systemRoot(),
+      record("user", { logicalTurnId: "t1", providerRoundId: "r1" }, "first"),
+      record("assistant", { logicalTurnId: "t1", providerRoundId: "r1" }, "reply one"),
+      record("user", { logicalTurnId: "t2", providerRoundId: "r2" }, "second"),
+      record("assistant", { logicalTurnId: "t2", providerRoundId: "r2" }, "reply two"),
+    ];
+    const segmentation = segmentSession(records);
+    expect(segmentation.inferred).toBe(false);
+    expect(segmentation.turns.map((turn) => turn.logicalTurnId)).toEqual(["t1", "t2"]);
+    expect(segmentation.frontier).toBeUndefined();
+    expect(segmentation.turns.every((turn) => turn.complete)).toBe(true);
+  });
+
+  test("one parallel tool batch is a single indivisible provider round", () => {
+    const records = [
+      systemRoot(),
+      record("user", { logicalTurnId: "t1", providerRoundId: "r1" }, "do two things"),
+      record("assistant", { logicalTurnId: "t1", providerRoundId: "r1", toolCalls: [{ id: "c1" }, { id: "c2" }] }, ""),
+      record("tool", { logicalTurnId: "t1", providerRoundId: "r1", toolCallId: "c1" }, '{"ok":true}'),
+      record("tool", { logicalTurnId: "t1", providerRoundId: "r1", toolCallId: "c2" }, '{"ok":true}'),
+    ];
+    const segmentation = segmentSession(records);
+    expect(segmentation.turns).toHaveLength(1);
+    const turn = segmentation.turns[0]!;
+    expect(turn.rounds).toHaveLength(1);
+    expect(turn.rounds[0]!.complete).toBe(true);
+    expect(turn.rounds[0]!.records.map((entry) => entry.role)).toEqual(["user", "assistant", "tool", "tool"]);
+  });
+
+  test("a round missing a tool result is incomplete and stays the retained frontier", () => {
+    const records = [
+      systemRoot(),
+      record("user", { logicalTurnId: "t1", providerRoundId: "r1" }, "do a thing"),
+      record("assistant", { logicalTurnId: "t1", providerRoundId: "r1", toolCalls: [{ id: "c1" }, { id: "c2" }] }, ""),
+      record("tool", { logicalTurnId: "t1", providerRoundId: "r1", toolCallId: "c1" }, '{"ok":true}'),
+    ];
+    const segmentation = segmentSession(records);
+    expect(segmentation.turns).toHaveLength(0);
+    expect(segmentation.frontier?.logicalTurnId).toBe("t1");
+    expect(segmentation.frontier?.rounds[0]?.complete).toBe(false);
+  });
+
+  test("legacy records segment conservatively at authored prompts", () => {
+    const records = [
+      systemRoot(),
+      record("user", {}, "first"),
+      record("assistant", { toolCalls: [{ id: "c1" }] }, "reply one"),
+      record("tool", { toolCallId: "c1" }, '{"ok":true}'),
+      record("user", { kind: "gate-resolution" }, "[gate] resolved"),
+      record("user", {}, "second"),
+      record("assistant", {}, "reply two"),
+    ];
+    const segmentation = segmentSession(records);
+    expect(segmentation.inferred).toBe(true);
+    // The host-injected gate-resolution does not start a new turn.
+    expect(segmentation.turns.map((turn) => turn.records[0]!.content)).toEqual(["first", "second"]);
+    expect(segmentation.turns.every((turn) => turn.inferred)).toBe(true);
+  });
+
+  test("legacy ambiguity retains an incomplete suffix verbatim as the frontier", () => {
+    const records = [
+      systemRoot(),
+      record("user", {}, "first"),
+      record("assistant", {}, "reply one"),
+      // A trailing user prompt with no assistant reply cannot be split safely.
+      record("user", {}, "second"),
+    ];
+    const segmentation = segmentSession(records);
+    expect(segmentation.turns.map((turn) => turn.records[0]!.content)).toEqual(["first"]);
+    expect(segmentation.frontier?.records.map((entry) => entry.content)).toEqual(["second"]);
+    expect(segmentation.frontier?.complete).toBe(false);
+  });
+
+  test("the bootstrap composed-prompt root is not part of any turn", () => {
+    const records = [
+      systemRoot(),
+      record("user", { logicalTurnId: "t1", providerRoundId: "r1" }, "first"),
+      record("assistant", { logicalTurnId: "t1", providerRoundId: "r1" }, "reply"),
+    ];
+    const segmentation = segmentSession(records);
+    expect(segmentation.bootstrap.map((entry) => entry.role)).toEqual(["system"]);
+    expect(segmentation.turns[0]!.records.every((entry) => entry.role !== "system" || entry.metadata?.kind === "validation")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of 4 for #107. This is the **foundation**: durable logical-turn/provider-round identity and a versioned `compact-checkpoint-v1` record type, plus conservative session segmentation. It is implemented strictly within the PR 1 scope of `AUTO_COMPACTION_IMPLEMENTATION_PLAN.md` §Delivery sequence. **No user-visible behavior changes** — `/compact`, `/context`, projection of existing sessions, and all pause/resume paths behave exactly as before. PR 2 migrates `/compact` to the checkpoint; PR 3–4 add auto-triggering, truthful `/context`, and docs.

What landed:

- **`core/session/execution-identity.ts`** — `logicalTurnId` / `providerRoundId` helpers, a process-local active-round context (same pattern as frozen Persistent-Instruction blocks), `recoverActiveIdentity` for resumed pauses, and `withExecutionRound` so recorders stamp the active round without each call site repeating it.
- **`core/session/compact-checkpoint.ts`** — `PortableCompactCheckpointV1` payload with fail-closed validation. An unknown future version throws an actionable session error; a malformed v1 never partially projects.
- **`core/session/segmentation.ts`** — pure conservative grouping into logical turns and provider/tool rounds. Explicit ids are the primary oracle; legacy records grow the retained unit rather than risk splitting a tool call from its result.
- **`history-projector.ts`** — projection resets provider history to a valid checkpoint's exact `replacementMessages` and replays the suffix. A failed turn after a checkpoint still drops only the failed input (the replacement's `compact-summary` boundary is preserved).
- **Agent Loop** — `bootstrapTurn` allocates + binds round 1 with the user input; `runLoop` advances the provider round before each next request (and before draining queued/background input so injected inputs stamp the new round), and clears the round on every exit (completion, pause, error). All recorders, queued/background input, and every continuation (gate / permission / user-question / engine-switch / quality) stamp via `withExecutionRound`. `loadContinuationContext` recovers + rebinds the round, so **resuming a pause never creates a new logical turn**.

Legacy JSONL is untouched and still resumes without rewrite. No provider adapter owns checkpoint installation.

## Exit criteria (per plan §PR 1)

- [x] ordinary sessions and all pause/resume paths persist stable identities — `execution-identity.test.ts` (tool-loop turn + gate continuation)
- [x] legacy fixtures still resume without rewrite — full existing suite green
- [x] a synthetic checkpoint round-trips exact replacement history — `compact-checkpoint.test.ts`
- [x] malformed/unknown checkpoints fail safely — `compact-checkpoint.test.ts` (unknown version + malformed v1 throw; failed-turn + image-reachability preserved)
- [x] no provider adapter owns checkpoint installation — checkpoint lives in `core/session`; adapters unchanged

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — 1186 pass / 5 skip (acceptance) / 0 fail
- [x] `bun run doctor` — clean
- [x] `git diff --check`

New focused coverage: `tests/integration/agent-loop/execution-identity.test.ts`, `tests/integration/session/segmentation.test.ts`, `tests/integration/session/compact-checkpoint.test.ts` (segmentation groups parallel tool batches as one round; incomplete rounds stay the retained frontier; image attachments in replacement history stay reachable through projection).

## Notes / Follow-ups

- PR 2 migrates `compactConversation()` to the atomic checkpoint builder and consumes the segmentation service delivered here.
- No CHANGELOG/STATUS/STYLE entries in this PR: it has no user-visible behavior, config, tool-surface, or runtime-contract change. Those land with the PR that first produces a checkpoint (PR 2) and the PR that makes auto-compaction observable (PR 4), per the plan's documentation sweep.
- A known flaky OpenTUI/TreeSitter teardown in `tests/component/tui/workspace-page.test.tsx` occasionally fails under parallel load; it passes in isolation and is unrelated to this session/agent-loop change.