### PR TITLE
docs: split dev STYLE contracts and enforce Markdown prose-wrap policy

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -u
+
+if ! command -v bun >/dev/null 2>&1; then
+	echo >&2 "Markdown wrap advisory could not run: bun was not found on PATH."
+	echo >&2 "Commit was not blocked."
+	exit 0
+fi
+
+bun run scripts/check-staged-markdown-wrap.ts || {
+	echo >&2 "Markdown wrap advisory failed unexpectedly. Commit was not blocked."
+}
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,22 @@
 # Codex Instructions for Prism Vesicle
 
-This file is the repo-local entry point for AI collaborators. Treat it as the
-navigation layer for the rest of the project docs, not as a replacement for
-them.
+This file is the repo-local entry point for AI collaborators. Treat it as the navigation layer for the rest of the project docs, not as a replacement for them.
 
 ## First Reads
 
 Always read this file before working in the repository.
 
-For any non-trivial code, prompt-runtime, TUI, provider, session, tool,
-workflow, or documentation change, also read:
+For any non-trivial code, prompt-runtime, TUI, provider, session, tool, workflow, or documentation change, also read:
 
-- `STATUS.md`: current project shape, implemented capabilities, tool surface,
-  known limits, and standard verification.
-- `docs/dev/STYLE.md`: architecture boundaries, provider adapter rules,
-  tool-runtime security, prompt/session semantics, validation, and TUI rules.
-- `docs/dev/WORKFLOW.md`: branch model, iteration loop, hotfix flow, PR shape,
-  independent CR expectations, and documentation sweep.
+- `STATUS.md`: current project shape, implemented capabilities, tool surface, known limits, and standard verification.
+- `docs/dev/STYLE.md`: source-code structure, maintainability, types, errors, naming, comments, and test design.
+- `docs/dev/ARCHITECTURE.md`: dependency direction, cross-cutting boundaries, and routing to the authoritative provider, tool, session, prompt, Agent, Skill, and TUI contracts.
+- `docs/dev/WORKFLOW.md`: branch model, iteration loop, hotfix flow, PR shape, independent CR expectations, and documentation sweep.
 - `CONTRIBUTING.md`: Conventional Commits, public repo boundary, local runtime, provider config location, documentation style, and PR checklist.
 - `README.md`: project entry point, installation, first run, concise capability overview, and documentation navigation.
 - `docs/user/zh-CN/README.md`: canonical user-manual entry point; pair user-manual changes with the matching `docs/user/en/` page.
 
-Read `CHANGELOG.md` before any user-visible behavior, config, runtime contract,
-tool surface, TUI, prompt, or documentation-status change.
+Read `CHANGELOG.md` before any user-visible behavior, config, runtime contract, tool surface, TUI, prompt, or documentation-status change.
 
 Read asset-specific docs when touching assets:
 
@@ -45,12 +39,13 @@ Use the docs by responsibility:
 | `CONTRIBUTING.md` | Contributor workflow, repo boundary, provider setup, and documentation style |
 | `CODE_SIGNING_POLICY.md` | Windows signing scope, approval, verification, and incident handling |
 | `PRIVACY.md` | Local data, external-service transfers, uninstall behavior, and deletion |
-| `docs/dev/STYLE.md` | Code architecture and runtime boundaries |
+| `docs/dev/STYLE.md` | Source-code structure, maintainability, types, errors, naming, comments, and test design |
+| `docs/dev/ARCHITECTURE.md` | Layering, dependency direction, cross-cutting boundaries, and runtime-contract routing |
+| `docs/dev/USER_AGENCY_AND_RISK_DISCLOSURE.md` | User agency, risk disclosure, confirmation, and enforceable-boundary policy |
 | `docs/dev/WORKFLOW.md` | Branching, PRs, hotfixes, independent CR |
 | `AGENTS.md` / `CLAUDE.md` | AI collaborator startup and coordination |
 
-When one of these files becomes stale because of your change, update it in the
-same branch. Do not leave documentation drift for a later pass.
+When one of these files becomes stale because of your change, update it in the same branch. Do not leave documentation drift for a later pass.
 
 Follow the Markdown conventions in `CONTRIBUTING.md`: prose uses natural line wrapping rather than fixed-column hard wraps.
 
@@ -58,29 +53,17 @@ Follow the Markdown conventions in `CONTRIBUTING.md`: prose uses natural line wr
 
 ## Branch And PR Rules
 
-`main` is the stable milestone baseline. `develop` is the active trunk during
-rapid internal development.
+`main` is the stable milestone baseline. `develop` is the active trunk during rapid internal development.
 
-- During the rapid internal development phase, `develop` is the active trunk.
-  The Rapid Development Exception in `docs/dev/WORKFLOW.md` allows small and
-  medium low-risk changes to be committed and pushed directly to `develop` when
-  the user explicitly asks for commit/push work.
-- Use a short-lived branch and PR for high-risk changes: provider protocols,
-  streaming, model-visible tools, path guards, sessions, prompt contracts,
-  validators, engine profiles, large refactors, release-readiness work, or
-  anything needing Bot review / independent CR.
-- Branch production-style hotfixes from `main`, PR them back to `main`, then
-  forward-merge or cherry-pick to `develop`.
+- During the rapid internal development phase, `develop` is the active trunk. The Rapid Development Exception in `docs/dev/WORKFLOW.md` allows small and medium low-risk changes to be committed and pushed directly to `develop` when the user explicitly asks for commit/push work.
+- Use a short-lived branch and PR for high-risk changes: provider protocols, streaming, model-visible tools, path guards, sessions, prompt contracts, validators, engine profiles, large refactors, release-readiness work, or anything needing Bot review / independent CR.
+- Branch production-style hotfixes from `main`, PR them back to `main`, then forward-merge or cherry-pick to `develop`.
 - Do not push directly to `main`.
 - Do not force-push to `develop` unless the user explicitly asks.
 - Do not commit, push, merge, tag, or open PRs unless the user explicitly asks.
-- Use Conventional Commits when committing:
-  `feat(scope): ...`, `fix(scope): ...`, `docs(scope): ...`,
-  `test(scope): ...`, `refactor(scope): ...`, or `chore(scope): ...`.
+- Use Conventional Commits when committing: `feat(scope): ...`, `fix(scope): ...`, `docs(scope): ...`, `test(scope): ...`, `refactor(scope): ...`, or `chore(scope): ...`.
 
-Before finishing non-trivial PR work, expect an independent CR pass as
-described in `docs/dev/WORKFLOW.md`. Address Blocking and Should-fix findings
-before merge.
+Before finishing non-trivial PR work, expect an independent CR pass as described in `docs/dev/WORKFLOW.md`. Address Blocking and Should-fix findings before merge.
 
 ## Local Runtime
 
@@ -95,70 +78,42 @@ bun test
 bun run doctor
 ```
 
-The real-provider E2E test runs only when the selected provider's `apiKeyEnv`
-is available through the user-level provider `.env` or process environment.
+The real-provider E2E test runs only when the selected provider's `apiKeyEnv` is available through the user-level provider `.env` or process environment.
 
 ## Provider Configuration And Secrets
 
 Provider/model profiles are user-level host state, not project runtime state.
 
-- Provider registry path on Windows:
-  `%APPDATA%\prism-vesicle\providers.yaml`
-- Provider secret file on Windows:
-  `%APPDATA%\prism-vesicle\.env`
-- Other platforms:
-  `$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` and sibling `.env`, or
-  `~/.config/prism-vesicle/providers.yaml` and sibling `.env`.
+- Provider registry path on Windows: `%APPDATA%\prism-vesicle\providers.yaml`
+- Provider secret file on Windows: `%APPDATA%\prism-vesicle\.env`
+- Other platforms: `$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` and sibling `.env`, or `~/.config/prism-vesicle/providers.yaml` and sibling `.env`.
 
-`providers.yaml` must contain provider ids, protocols, base URLs, model entries,
-generation defaults, capability metadata, and `apiKeyEnv` names only. It must
-not contain API keys. The sibling `.env` contains the provider-specific secret
-values. Process environment variables are fallback only.
+`providers.yaml` must contain provider ids, protocols, base URLs, model entries, generation defaults, capability metadata, and `apiKeyEnv` names only. It must not contain API keys. The sibling `.env` contains the provider-specific secret values. Process environment variables are fallback only.
 
-Do not reintroduce a project-root `.env` dependency. If an old root `.env`
-appears during local work, treat it as legacy state to migrate or remove, not
-as supported configuration.
+Do not reintroduce a project-root `.env` dependency. If an old root `.env` appears during local work, treat it as legacy state to migrate or remove, not as supported configuration.
 
 ## Architecture Guardrails
 
-These are non-negotiable boundaries; see `docs/dev/STYLE.md` for detail.
+These are non-negotiable boundaries; start with `docs/dev/ARCHITECTURE.md` and follow its links to the owning domain contract for detail.
 
-- Prefer adapting proven patterns from the documented reference projects over
-  rebuilding familiar agent/runtime behavior from scratch. Record borrowed
-  behavior in public docs/tests when it affects Vesicle's runtime contract, but
-  keep private reference paths confined to ignored local notes.
-- Provider adapters convert normalized Vesicle requests to provider wire
-  format and back. They must not read/write project files, mutate sessions,
-  know Prism phases, or execute host tools.
+- Prefer adapting proven patterns from the documented reference projects over rebuilding familiar agent/runtime behavior from scratch. Record borrowed behavior in public docs/tests when it affects Vesicle's runtime contract, but keep private reference paths confined to ignored local notes.
+- Provider adapters convert normalized Vesicle requests to provider wire format and back. They must not read/write project files, mutate sessions, know Prism phases, or execute host tools.
 - Model-visible filesystem tools must stay behind `core/tools` path guards.
 - Filesystem tool paths are project-relative only; absolute paths and `..` escapes are rejected. The opt-in `shell_exec` process tool is the explicit exception: it has host-user authority, is controlled by Tool Permission Runtime, and must never be described as path-guarded or rewind-safe.
-- Write tools are limited to approved roots: `source_materials/`, `workspace/`,
-  `test_runs/`, `novels/`, and `reports/`. `source_materials/` holds imported,
-  researched, or model-generated source material; deployed artifacts belong in
-  the other four roots.
-- Prompt assets are runtime files under `assets/`; do not hardcode Prism
-  prompts into TypeScript source.
-- Host-specific prompts, coding-agent identities, and tool assumptions must
-  not leak into Prism engine prompts except as explicit negative examples.
-- `request_confirmation` is a workflow gate declared by engine profile
-  `stopGates`, not a generic permission prompt.
+- Write tools are limited to approved roots: `source_materials/`, `workspace/`, `test_runs/`, `novels/`, and `reports/`. `source_materials/` holds imported, researched, or model-generated source material; deployed artifacts belong in the other four roots.
+- Prompt assets are runtime files under `assets/`; do not hardcode Prism prompts into TypeScript source.
+- Host-specific prompts, coding-agent identities, and tool assumptions must not leak into Prism engine prompts except as explicit negative examples.
+- `request_confirmation` is a workflow gate declared by engine profile `stopGates`, not a generic permission prompt.
 - Permission modes change approval friction but never widen tool capabilities or disable path guards, MCP/Agent scope, timeout, environment filtering, output limits, or process cleanup. YOLO cannot be persisted as a default; `--dangerously-skip-permissions` is process-scoped.
-- If model behavior claims a file was written, verify the corresponding
-  `write_file` result or inspect the artifact on disk.
-- Validators are advisory product signals. They should surface findings without
-  aborting ordinary turns unless a feature explicitly changes that contract.
+- If model behavior claims a file was written, verify the corresponding `write_file` result or inspect the artifact on disk.
+- Validators are advisory product signals. They should surface findings without aborting ordinary turns unless a feature explicitly changes that contract.
 
 ## TUI And Session Rules
 
-- One interactive TUI run should keep one active session until the user starts
-  or resumes another session.
-- Session JSONL records are append-only and should preserve user, assistant,
-  tool, provider/model, validation, and gate information needed for replay.
-- Provider/model switching and artifact workbench commands are host actions;
-  they should not call the provider unless the command explicitly starts a
-  revision prompt.
-- Keep the TUI operational and readable at 80 columns. Gate and picker panels
-  own the bottom area while active.
+- One interactive TUI run should keep one active session until the user starts or resumes another session.
+- Session JSONL records are append-only and should preserve user, assistant, tool, provider/model, validation, and gate information needed for replay.
+- Provider/model switching and artifact workbench commands are host actions; they should not call the provider unless the command explicitly starts a revision prompt.
+- Keep the TUI operational and readable at 80 columns. Gate and picker panels own the bottom area while active.
 
 ## Verification And Documentation Sweep
 
@@ -189,8 +144,7 @@ Before adding or substantially adapting a test, identify the behavior or contrac
 
 For provider, gate, TUI, session, tool, validator, or artifact behavior, add or update focused tests only when the change creates a real coverage need under the rules above. When practical and proportionate, also run a real TUI, provider, package, binary, or installer smoke at the boundary actually affected.
 
-Before finishing behavior/config/docs changes, run a targeted stale-term pass.
-Examples:
+Before finishing behavior/config/docs changes, run a targeted stale-term pass. Examples:
 
 ```bash
 rg "VESICLE_|providers.yaml|apiKeyEnv|session|write_file|tool_calls|OpenTUI" README*.md STATUS.md CHANGELOG.md CONTRIBUTING*.md docs assets
@@ -209,5 +163,4 @@ Never commit secrets or local runtime state:
 - generated workspaces or model output beyond tracked `.gitkeep` stubs
 - private provider URLs, API keys, tokens, or local prompt experiments
 
-Keep generated artifact roots and session state out of git unless a task
-explicitly asks for a tracked fixture.
+Keep generated artifact roots and session state out of git unless a task explicitly asks for a tracked fixture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,52 +1,39 @@
 # Claude Instructions for Prism Vesicle
 
-`AGENTS.md` is the shared repo-local coordination authority for AI
-collaborators. Read it first and follow its branch, commit, push, PR,
-verification, secret-handling, and documentation-sweep rules.
+`AGENTS.md` is the shared repo-local coordination authority for AI collaborators. Read it first and follow its branch, commit, push, PR, verification, secret-handling, and documentation-sweep rules.
 
-During the rapid internal development phase, `develop` is the active trunk.
-`docs/dev/WORKFLOW.md` defines when small and medium low-risk changes may be
-committed directly to `develop` after explicit user approval, and when a
-short-lived branch + PR is still required.
+During the rapid internal development phase, `develop` is the active trunk. `docs/dev/WORKFLOW.md` defines when small and medium low-risk changes may be committed directly to `develop` after explicit user approval, and when a short-lived branch + PR is still required.
 
 ## Required Startup Reads
 
 For non-trivial work, read these before editing:
 
 - `AGENTS.md`: AI collaborator entry point and doc map.
-- `STATUS.md`: current implementation state, known limits, tool surface, and
-  verification commands.
-- `docs/dev/STYLE.md`: architecture boundaries for providers, tools, prompts,
-  sessions, validation, and TUI behavior.
-- `docs/dev/WORKFLOW.md`: branching, hotfixes, PR body shape, independent CR,
-  and documentation sweep.
+- `STATUS.md`: current implementation state, known limits, tool surface, and verification commands.
+- `docs/dev/STYLE.md`: source-code structure, maintainability, types, errors, naming, comments, and test design.
+- `docs/dev/ARCHITECTURE.md`: dependency direction, cross-cutting boundaries, and links to the authoritative provider, tool, session, prompt, Agent, Skill, and TUI contracts.
+- `docs/dev/WORKFLOW.md`: branching, hotfixes, PR body shape, independent CR, and documentation sweep.
 - `CONTRIBUTING.md`: Conventional Commits, public repo boundary, provider config location, documentation style, and local development flow.
 
 Also read:
 
-- `README.md` when setup, user-facing commands, provider configuration, or
-  capabilities are affected.
+- `README.md` when setup, user-facing commands, provider configuration, or capabilities are affected.
 - `docs/user/zh-CN/README.md` (canonical) and the affected English/Chinese page pair when beginner onboarding or user-manual behavior is affected.
-- `CHANGELOG.md` before user-visible behavior, config, runtime, prompt, TUI,
-  docs-status, or tool-surface changes.
+- `CHANGELOG.md` before user-visible behavior, config, runtime, prompt, TUI, docs-status, or tool-surface changes.
 - `assets/README.md` before editing copied Prism assets.
 - `docs/examples/providers.yaml` before changing provider config behavior.
-- `docs/examples/provider.env.example` before changing provider secret loading
-  behavior.
+- `docs/examples/provider.env.example` before changing provider secret loading behavior.
 
 For architecture, provider, TUI, session, or command-UX changes, first check whether the documented reference projects already solved a similar problem. Ignored local notes under `dev/docs/` may describe private reference locations; when present, start with `dev/docs/REFERENCE_PROJECTS.md` to find those local absolute paths and the current working/decision/archive routes. Use the notes, but treat archived plans as historical context and never copy local absolute paths or machine-private details into public docs.
 
 ## High-Risk Boundaries
 
-- Prefer proven reference-project patterns over needless reinvention, while
-  preserving Vesicle's Prism-host product boundary.
+- Prefer proven reference-project patterns over needless reinvention, while preserving Vesicle's Prism-host product boundary.
 - Do not store provider secrets in `providers.yaml`.
-- Do not depend on a project-root `.env`; provider secrets belong beside the
-  user-level `providers.yaml`.
+- Do not depend on a project-root `.env`; provider secrets belong beside the user-level `providers.yaml`.
 - Do not let provider adapters read/write files or run host tools.
 - Do not hardcode Prism prompts into TypeScript source.
-- Do not expose model-visible filesystem access outside `core/tools` path
-  guards.
+- Do not expose model-visible filesystem access outside `core/tools` path guards.
 - Do not commit or push unless the user explicitly asks.
 
 ## Standard Verification

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,9 @@ Keep root-document responsibilities distinct:
 - `STATUS.md` is the authoritative current implementation inventory, including tool surface, validators, verification, and known limits.
 - `CHANGELOG.md` records notable released and unreleased changes.
 - `CONTRIBUTING.md` owns contributor setup, repository boundaries, and documentation conventions.
-- `docs/dev/STYLE.md` and `docs/dev/WORKFLOW.md` own architecture and development workflow respectively.
+- `docs/dev/STYLE.md` owns source-code structure and maintainability rules.
+- `docs/dev/ARCHITECTURE.md` owns layering, dependency direction, and links to the authoritative runtime contracts.
+- `docs/dev/WORKFLOW.md` owns development and publication workflow.
 
 Prefer links to the authoritative document over duplicating detailed inventories in multiple root files.
 
@@ -93,7 +95,7 @@ Keep commands, paths, configuration keys, code, and product identifiers unchange
 
 - Explain the behavior change and why it belongs in the current milestone.
 - Include verification commands in the PR description.
-- Update `README.md`, `STATUS.md`, `CHANGELOG.md`, or `docs/dev/STYLE.md` when the user-visible behavior, runtime contract, or architecture boundary changes.
+- Update `README.md`, `STATUS.md`, `CHANGELOG.md`, `docs/dev/ARCHITECTURE.md`, or the owning domain contract when user-visible behavior, runtime behavior, or an architecture boundary changes. Update `docs/dev/STYLE.md` only when source-code conventions change.
 - Keep generated `.vesicle/` sessions out of git.
 - Keep new or edited Markdown prose naturally wrapped.
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -75,7 +75,9 @@ Markdown 正文使用自然换行。每个段落或列表项在源文件中保�
 - `STATUS.md` 是当前实现清单的权威来源，包括工具接口、验证器、验证方式和已知限制。
 - `CHANGELOG.md` 记录值得关注的已发布和未发布变更。
 - `CONTRIBUTING.md` 负责贡献者配置、仓库边界和文档约定。
-- `docs/dev/STYLE.md` 和 `docs/dev/WORKFLOW.md` 分别负责架构与开发工作流。
+- `docs/dev/STYLE.md` 负责源代码结构与可维护性规范。
+- `docs/dev/ARCHITECTURE.md` 负责分层、依赖方向以及各项运行时权威契约的导航。
+- `docs/dev/WORKFLOW.md` 负责开发与发布工作流。
 
 详细清单应链接到对应的权威文档，而不是在多个根目录文件中重复维护。
 
@@ -93,7 +95,7 @@ Markdown 正文使用自然换行。每个段落或列表项在源文件中保�
 
 - 说明行为发生了什么变化，以及它为何属于当前里程碑。
 - 在 PR 描述中列出验证命令。
-- 用户可见行为、运行时契约或架构边界变化时，同步更新 `README.md`、`STATUS.md`、`CHANGELOG.md` 或 `docs/dev/STYLE.md`。
+- 用户可见行为、运行时行为或架构边界变化时，同步更新 `README.md`、`STATUS.md`、`CHANGELOG.md`、`docs/dev/ARCHITECTURE.md` 或对应的领域契约。仅在源代码规范变化时更新 `docs/dev/STYLE.md`。
 - 不要把生成的 `.vesicle/` 会话提交到 Git。
 - 新增或编辑的 Markdown 正文应使用自然换行。
 

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ Pull requests and `develop` pushes call one reusable Linux/Windows release build
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Contributor setup, repository boundaries, and documentation style |
 | [`CODE_SIGNING_POLICY.md`](./CODE_SIGNING_POLICY.md) | Windows signing scope, approval, verification, and incident handling |
 | [`PRIVACY.md`](./PRIVACY.md) | Local data, external-service transfers, uninstall behavior, and deletion |
-| [`docs/dev/STYLE.md`](./docs/dev/STYLE.md) | Architecture and runtime boundaries |
+| [`docs/dev/STYLE.md`](./docs/dev/STYLE.md) | Source-code structure and maintainability rules |
+| [`docs/dev/ARCHITECTURE.md`](./docs/dev/ARCHITECTURE.md) | Architecture boundaries and developer-contract navigation |
 | [`docs/dev/WORKFLOW.md`](./docs/dev/WORKFLOW.md) | Branching, review, release, and documentation sweep |
 | [`docs/dev/ASSETS.md`](./docs/dev/ASSETS.md) | Bundled V10 inventory, host extension layer, lineage, and update rules |
 | [`docs/dev/QUALITY_BENCHMARK.md`](./docs/dev/QUALITY_BENCHMARK.md) | Developer-only Semantic Judge measurement, caps, resume, and evidence boundary |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -206,7 +206,8 @@ Pull request 和向 `develop` 的推送会调用同一套 Linux/Windows 可复�
 | [`CONTRIBUTING.zh-CN.md`](./CONTRIBUTING.zh-CN.md) | 贡献者配置、仓库边界和文档规范 |
 | [`CODE_SIGNING_POLICY.zh-CN.md`](./CODE_SIGNING_POLICY.zh-CN.md) | Windows 签名范围、批准、验证与事件处理 |
 | [`PRIVACY.zh-CN.md`](./PRIVACY.zh-CN.md) | 本地数据、外部服务传输、卸载行为与删除方式 |
-| [`docs/dev/STYLE.md`](./docs/dev/STYLE.md) | 架构与运行时边界 |
+| [`docs/dev/STYLE.md`](./docs/dev/STYLE.md) | 源代码结构与可维护性规范 |
+| [`docs/dev/ARCHITECTURE.md`](./docs/dev/ARCHITECTURE.md) | 架构边界与开发者契约导航 |
 | [`docs/dev/WORKFLOW.md`](./docs/dev/WORKFLOW.md) | 分支、审查、发布和文档扫描流程 |
 | [`docs/dev/ASSETS.md`](./docs/dev/ASSETS.md) | 内置 V10 清单、宿主扩展层、来源和更新规则 |
 | [`docs/dev/QUALITY_BENCHMARK.md`](./docs/dev/QUALITY_BENCHMARK.md) | 仅供开发者使用的 Semantic Judge 评测、上限、恢复和证据边界 |

--- a/STATUS.md
+++ b/STATUS.md
@@ -52,7 +52,7 @@ The 1.0 alpha makes Vesicle a credible direct API host for the Prism Engine, not
 
 Public user-facing documentation is intentionally limited during the alpha. Treat the [`docs/user/`](./docs/user/) manual, the [README](./README.md) installation and first-run guide, `vesicle doctor`, `vesicle prompt shape --engine <id>`, and [`docs/examples/`](./docs/examples/) as the supported onboarding references; other behavior is subject to alpha-level change while feature and fix work remains the priority.
 
-Architecture and runtime contracts — provider adapters, tool guards, gates, sessions, prompts, TUI behavior, the SubAgent lifecycle, Harness and Quality Guard contracts, and command completion — live in [`docs/dev/STYLE.md`](./docs/dev/STYLE.md) and its sibling documents under [`docs/dev/`](./docs/dev/). This file intentionally does not restate them.
+Architecture and runtime contracts are routed from [`docs/dev/ARCHITECTURE.md`](./docs/dev/ARCHITECTURE.md) to their authoritative domain documents. Source-code conventions live separately in [`docs/dev/STYLE.md`](./docs/dev/STYLE.md). This file intentionally records current implementation state and limits rather than duplicating those contracts.
 
 The Prism asset lineage comes from the public sibling repository [`3aKHP/Neural-Narratology`](https://github.com/3aKHP/Neural-Narratology).
 
@@ -113,7 +113,7 @@ prism-vesicle/
 
 ## Tool Surface
 
-Model-visible tools and their write scope. Path-guard rules, write roots, and the full tool-runtime contract live in [`docs/dev/STYLE.md` § Tool Runtime](./docs/dev/STYLE.md#tool-runtime); the table below is the authoritative tool inventory.
+Model-visible tools and their write scope. Path guards, permissions, process authority, gates, questions, and MCP execution are defined in [`docs/dev/TOOLS.md`](./docs/dev/TOOLS.md); the table below is the authoritative current tool inventory.
 
 | Tool | Write scope |
 |------|-------------|
@@ -161,7 +161,7 @@ Read/list/stat/grep roots: `assets/`, `source_materials/`, `workspace/`, `novels
 | `phase-confirmation` | etl | Wired (Phase artifact checkpoints) |
 | `runtime-turn` | runtime | Declared in profile and prompt-bound |
 
-Engines with empty `stopGates` never offer `request_confirmation`, so their models cannot invoke a gate the host would then have to refuse. `request_engine_switch` is available to all engines as a user-confirmed handoff; transition restrictions are intentionally deferred. Gate semantics and the Confirm/Reject/summary UI contract live in [`docs/dev/STYLE.md` § Gate Runtime](./docs/dev/STYLE.md#gate-runtime).
+Engines with empty `stopGates` never offer `request_confirmation`, so their models cannot invoke a gate the host would then have to refuse. `request_engine_switch` is available to all engines as a user-confirmed handoff; transition restrictions are intentionally deferred. Gate and handoff semantics live in [`docs/dev/TOOLS.md`](./docs/dev/TOOLS.md), while presentation belongs to [`docs/dev/TUI.md`](./docs/dev/TUI.md).
 
 ## Validators
 
@@ -188,7 +188,7 @@ Grouped by subsystem. Each item states the current limit or deferral; behavioral
 
 - OpenAI-compatible Chat Completions, Anthropic Messages, and Gemini `generateContent` are implemented. **OpenAI Responses is deferred.**
 - Model discovery currently targets the OpenAI-compatible `GET /v1/models` response shape. Anthropic and Gemini use their existing profiles plus exact manual model ids until their native discovery APIs receive separate adapters. Discovery never infers capabilities from names.
-- Mid-stream SSE disconnect replay is deferred: replaying partial assistant/tool deltas requires explicit UI and tool-loop reconciliation. Transport and retryable-HTTP retry is implemented; see [`docs/dev/STYLE.md` § Provider Adapters](./docs/dev/STYLE.md#provider-adapters).
+- Mid-stream SSE disconnect replay is deferred: replaying partial assistant/tool deltas requires explicit UI and tool-loop reconciliation. Transport and retryable-HTTP retry is implemented; see [`docs/dev/PROVIDERS.md`](./docs/dev/PROVIDERS.md).
 
 ### Engines & Gates
 
@@ -211,7 +211,7 @@ Grouped by subsystem. Each item states the current limit or deferral; behavioral
 ### Host Shell
 
 - `shell_exec` is a user-authorized host command, **not an OS sandbox**. Its child environment is filtered and its process lifetime/output are bounded, but an approved command can still read or mutate project-external files and use the network. Shell-created file changes taint the turn's checkpoint completeness and are not guaranteed to rewind.
-- Process cleanup terminates the managed shell and ordinary descendants in its process group/tree; an explicitly approved command can still escape that tree through a new session or external service manager. See [`docs/dev/STYLE.md` § Tool Permission Runtime](./docs/dev/STYLE.md#tool-permission-runtime) for the runtime contract and [`docs/user/en/advanced/shell-exec.md`](./docs/user/en/advanced/shell-exec.md) for the user-facing surface.
+- Process cleanup terminates the managed shell and ordinary descendants in its process group/tree; an explicitly approved command can still escape that tree through a new session or external service manager. See [`docs/dev/TOOLS.md`](./docs/dev/TOOLS.md) for the runtime contract and [`docs/user/en/advanced/shell-exec.md`](./docs/user/en/advanced/shell-exec.md) for the user-facing surface.
 
 ### Quality Guard & Stage
 
@@ -224,7 +224,7 @@ Grouped by subsystem. Each item states the current limit or deferral; behavioral
 
 - Asset overlays do not support deletion tombstones. An absent higher-layer file falls back to the next layer; disabling packaged engines/assets will require a future explicit manifest policy rather than magic filenames.
 - With no project lock, Vesicle automatically verifies and activates the bundled `prism-engine-v10`; rollback returns to that same baseline. Sessions recorded before the V10 migration have no Harness identity and fail closed on resume.
-- See [`docs/dev/ASSETS.md`](./docs/dev/ASSETS.md) for the bundled inventory, host extension layer, lineage, and update rules, and [`docs/dev/STYLE.md` § Managed Harness Packs](./docs/dev/STYLE.md#managed-harness-packs) for the verification and contract boundary.
+- See [`docs/dev/ASSETS.md`](./docs/dev/ASSETS.md) for the bundled inventory, host extension layer, managed Pack verification, Driver bindings, Quality Guard bindings, lineage, and update rules.
 
 ### Persistent Instructions
 
@@ -265,7 +265,14 @@ Native Windows CI installs pinned Inno Setup, builds the versioned guided instal
 | [`CODE_SIGNING_POLICY.md`](./CODE_SIGNING_POLICY.md) | Windows signing scope, approval, verification, incident handling |
 | [`PRIVACY.md`](./PRIVACY.md) | Local data, external-service transfers, uninstall, deletion |
 | [`AGENTS.md`](./AGENTS.md) / [`CLAUDE.md`](./CLAUDE.md) | AI collaborator startup and coordination |
-| [`docs/dev/STYLE.md`](./docs/dev/STYLE.md) | Architecture and runtime contract boundaries |
+| [`docs/dev/STYLE.md`](./docs/dev/STYLE.md) | Source-code structure and maintainability rules |
+| [`docs/dev/ARCHITECTURE.md`](./docs/dev/ARCHITECTURE.md) | Layering, dependency direction, and runtime-contract routing |
+| [`docs/dev/PROVIDERS.md`](./docs/dev/PROVIDERS.md) | Provider adapters, protocol mapping, transport, usage, and configuration |
+| [`docs/dev/TOOLS.md`](./docs/dev/TOOLS.md) | Tool capability, path, permission, process, gate, question, web, and MCP contracts |
+| [`docs/dev/SESSIONS.md`](./docs/dev/SESSIONS.md) | Session persistence, projection, checkpoints, rewind, compaction, and recovery |
+| [`docs/dev/PERSISTENT_INSTRUCTIONS.md`](./docs/dev/PERSISTENT_INSTRUCTIONS.md) | Persistent Instruction resolution, composition, mutation, and capability limits |
+| [`docs/dev/TUI.md`](./docs/dev/TUI.md) | Terminal layout, input, rendering, commands, rewind, and side-question contracts |
+| [`docs/dev/USER_AGENCY_AND_RISK_DISCLOSURE.md`](./docs/dev/USER_AGENCY_AND_RISK_DISCLOSURE.md) | User agency, risk disclosure, confirmation, and enforceable-boundary policy |
 | [`docs/dev/WORKFLOW.md`](./docs/dev/WORKFLOW.md) | Branching, PRs, hotfixes, independent CR, release lifecycle |
 | [`docs/dev/ASSETS.md`](./docs/dev/ASSETS.md) | Bundled Harness inventory, host layer, lineage, updates |
 | [`docs/dev/SUBAGENTS.md`](./docs/dev/SUBAGENTS.md) | SubAgent lifecycle and delivery contract |

--- a/brand/README.md
+++ b/brand/README.md
@@ -1,12 +1,8 @@
 # Prism Vesicle Brand Mark
 
-One beam in, the spectrum out. A translucent vesicle holds a glass prism; an
-emerald beam enters through a pore in the membrane, refracts, and leaves as a
-soft spectrum. Light is the subject — volume, Fresnel rim, phosphor glow,
-caustics. Calm, precise, never loud.
+One beam in, the spectrum out. A translucent vesicle holds a glass prism; an emerald beam enters through a pore in the membrane, refracts, and leaves as a soft spectrum. Light is the subject — volume, Fresnel rim, phosphor glow, caustics. Calm, precise, never loud.
 
-The mark follows a fixed visual design language whose palette, motion
-grammar, and anti-patterns govern every variant. Palette of record:
+The mark follows a fixed visual design language whose palette, motion grammar, and anti-patterns govern every variant. Palette of record:
 
 - Emerald `#10b981` (deep `#047857`, bright `#34d399`) — the brand beam
 - Engine spectrum `#22d3ee` `#facc15` `#fb923c` `#f43f5e` `#e879f9`
@@ -15,34 +11,15 @@ grammar, and anti-patterns govern every variant. Palette of record:
 
 ## Files
 
-- `prism-vesicle.svg` — primary luminous mark on the dark ground. Radial
-  volume + Fresnel rim + blurred volumetric light; needs an SVG renderer with
-  `feGaussianBlur` support (all browsers, librsvg, resvg, cairosvg).
-- `prism-vesicle-light.svg` — off-white variant. The Fresnel rim inverts to
-  deep emerald and the beam deepens to `#047857`; the spectrum keeps the
-  locked hues. Never place the dark variant on pure white.
-- `prism-vesicle-mono.svg` — single-colour silhouette (`currentColor`): the
-  membrane ring broken at the two pores, prism solid inside. For favicons,
-  installer icons, engraving, and small sizes.
-- `prism-vesicle-animated.svg` — motion variant. A light spot travels the
-  membrane (14 s), the lit rim breathes (12 s), the beam drifts (10 s);
-  linear easing only, and `prefers-reduced-motion` holds the static frame.
-  Animation is CSS inside the SVG, so it plays in browsers and stays still
-  in rasterisers.
-- `exports/prism-vesicle-1024-dark.png`, `exports/prism-vesicle-1024-light.png`
-  — 1024×1024 raster exports of the two grounds.
-- `prism-vesicle.ascii.txt` — terminal character-art scheme: a 56-column
-  phosphor splash and a 24-column compact mark, derived from the actual
-  renders through a luminance ramp (` .:-=+*#%@`), plus the ANSI colour
-  layer. Pure 7-bit ASCII.
+- `prism-vesicle.svg` — primary luminous mark on the dark ground. Radial volume + Fresnel rim + blurred volumetric light; needs an SVG renderer with `feGaussianBlur` support (all browsers, librsvg, resvg, cairosvg).
+- `prism-vesicle-light.svg` — off-white variant. The Fresnel rim inverts to deep emerald and the beam deepens to `#047857`; the spectrum keeps the locked hues. Never place the dark variant on pure white.
+- `prism-vesicle-mono.svg` — single-colour silhouette (`currentColor`): the membrane ring broken at the two pores, prism solid inside. For favicons, installer icons, engraving, and small sizes.
+- `prism-vesicle-animated.svg` — motion variant. A light spot travels the membrane (14 s), the lit rim breathes (12 s), the beam drifts (10 s); linear easing only, and `prefers-reduced-motion` holds the static frame. Animation is CSS inside the SVG, so it plays in browsers and stays still in rasterisers.
+- `exports/prism-vesicle-1024-dark.png`, `exports/prism-vesicle-1024-light.png` — 1024×1024 raster exports of the two grounds.
+- `prism-vesicle.ascii.txt` — terminal character-art scheme: a 56-column phosphor splash and a 24-column compact mark, derived from the actual renders through a luminance ramp (` .:-=+*#%@`), plus the ANSI colour layer. Pure 7-bit ASCII.
 
 ## Usage
 
-- Silhouette stays legible at small sizes; below 32 px prefer the mono
-  silhouette. The luminous variants need roughly 128 px to keep the spectrum.
-- Do not recolour the beam, reorder the spectrum, add container shapes, or
-  place the mark on pure white. Do not render the beam/spectrum as hard
-  line segments — the light is volumetric; that is the identity.
-- The ASCII marks are derived, not hand-drawn: rasterise the SVG, map
-  luminance through the ramp with a floor at the ground colour, and respect
-  the ~1:2 terminal cell aspect. Re-derive after any SVG change.
+- Silhouette stays legible at small sizes; below 32 px prefer the mono silhouette. The luminous variants need roughly 128 px to keep the spectrum.
+- Do not recolour the beam, reorder the spectrum, add container shapes, or place the mark on pure white. Do not render the beam/spectrum as hard line segments — the light is volumetric; that is the identity.
+- The ASCII marks are derived, not hand-drawn: rasterise the SVG, map luminance through the ramp with a floor at the ground colour, and respect the ~1:2 terminal cell aspect. Re-derive after any SVG change.

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -1,0 +1,90 @@
+# Prism Vesicle Architecture
+
+This document defines the stable ownership and dependency boundaries of the Vesicle host. Detailed runtime behavior belongs to the linked domain contracts; current capability state and known limits belong in [`STATUS.md`](../../STATUS.md).
+
+## Layering
+
+```text
+cli/  # command dispatch only
+tui/  # OpenTUI rendering and keyboard interaction
+config/  # host configuration loading and inspection
+setup/  # guided onboarding and validated configuration transactions
+core/agent-loop/  # provider rounds, tool loop, and continuation orchestration
+core/agents/  # Agent profiles, child lifecycle, concurrency, and delivery
+core/artifacts/  # artifact discovery, preview bounds, and validation selection
+core/attachments/  # clipboard image content-addressed store
+core/checkpoints/  # per-turn file snapshots and restore
+core/compact/  # context compaction service
+core/engine/  # Engine profile loading
+core/gate/  # workflow-gate request types
+core/harness/  # Harness verification, compatibility, and installation
+core/permissions/  # Tool Permission Runtime policy and broker
+core/process/  # bounded Process Runtime and shell profiles
+core/prompt/  # prompt loading and composition
+core/quality/  # Output Quality Guard host runtime
+core/rewind/  # conversation rewind and partial summarization
+core/runtime/  # runtime asset resolution
+core/session/  # durable session persistence and projection
+core/side-question/  # tool-free side-question snapshots and service
+core/stage/  # Stage consumer bootstrap
+core/tools/  # model-visible host tool contracts and execution
+core/user-question/  # host clarification-question types
+core/validators/  # artifact validators and registry
+mcp/  # external MCP discovery and execution
+providers/  # protocol adapters only
+skills/  # Agent Skills parsing, discovery, store, and catalog
+types/  # genuinely shared host types
+assets/  # exact bundled Harness manifest inventory
+host-assets/  # restricted Vesicle prompts and generic Agent extensions
+```
+
+## Dependency Direction
+
+- `cli` may compose `tui`, `setup`, `core`, `config`, and provider types; domain layers must not import CLI dispatch.
+- `tui` may consume `core`, `config`, and normalized provider types; core runtime and provider adapters must not depend on TUI rendering.
+- `setup` may consume `config`, `mcp`, Engine and permission types, and reusable presentation primitives; installer code must not become a second configuration parser.
+- `core/agent-loop` orchestrates providers, prompts, sessions, tools, gates, Engines, validators, Agents, quality handling, and MCP without transferring ownership among them.
+- `providers` may depend on normalized provider-shared types and configuration only. Adapters must not import project tools, sessions, TUI, or Prism workflow policy.
+- `core/tools` and `mcp` may share normalized tool contracts, but neither may depend on providers or TUI.
+- `core/harness` may validate and bind Engine, Agent, tool, validator, runtime-asset, and quality contracts; those domains must not depend on a sibling source checkout.
+- `skills` receives pre-resolved discovery roots and must not import the asset resolver, provider runtime, Harness runtime, or TUI.
+- `core/gate` contains host-neutral request types. Agent-loop and TUI own continuation and presentation respectively.
+
+## Cross-Cutting Boundaries
+
+- Provider adapters translate normalized requests and responses; they do not own host policy. See [`PROVIDERS.md`](./PROVIDERS.md).
+- Model-visible tools remain behind host capability, path, permission, and process enforcement. See [`TOOLS.md`](./TOOLS.md).
+- Sessions are append-only durable history. Projection, rewind, checkpoints, compaction, and continuation recovery must preserve that invariant. See [`SESSIONS.md`](./SESSIONS.md).
+- Prompt assets are runtime files resolved through the active verified asset stack; Engine prompts are not TypeScript literals. See [`ASSETS.md`](./ASSETS.md).
+- Persistent Instructions are live host configuration and model context, not capability authority or session identity. See [`PERSISTENT_INSTRUCTIONS.md`](./PERSISTENT_INSTRUCTIONS.md).
+- SubAgents have explicit lifecycle, identity, capability, ownership, and delivery contracts. See [`SUBAGENTS.md`](./SUBAGENTS.md).
+- Skills provide bounded procedural context and resources without granting capabilities. See [`SKILLS.md`](./SKILLS.md).
+- TUI presentation and input routing observe and control host state without redefining domain semantics. See [`TUI.md`](./TUI.md).
+- Profile validators inspect Prism artifact documents rather than ordinary transition prose or every assistant turn. Artifact workbench validation reads the selected file from disk, and findings remain advisory unless a feature contract explicitly introduces a stronger policy.
+- Warning, confirmation, and risk-control design preserves informed user choice while enforcing concrete host boundaries. See [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md).
+
+## Configuration And Setup Ownership
+
+- Provider, MCP, permission, quality, and user asset configuration are user-level host state. Project runtime state must not become an alternate source for those settings.
+- `src/config` owns decoding and validation of configuration files. Consumers receive validated values and must not independently reinterpret the same schema.
+- `src/setup` owns interactive onboarding, discovery, validation, backup, and configuration transactions. The Windows installer owns only the installed application lifecycle and operating-system integration.
+- Setup configuration writes are direct host actions, not model-visible tools. They validate the complete staged shape and preserve unrelated user configuration.
+- Project launch derives its root from the invocation directory or explicit directory argument. Setup and standalone asset resolution must not change the parent process working directory to make lookup succeed.
+
+## Contract Ownership
+
+| Document | Authority |
+|---|---|
+| [`STYLE.md`](./STYLE.md) | Source-code structure, maintainability, types, errors, naming, comments, and test design |
+| [`PROVIDERS.md`](./PROVIDERS.md) | Normalized provider boundary, protocol mapping, transport, usage, and provider configuration |
+| [`TOOLS.md`](./TOOLS.md) | Model-visible tools, path guards, permissions, process authority, gates, questions, and MCP execution |
+| [`SESSIONS.md`](./SESSIONS.md) | Session persistence, projection, checkpoints, rewind, compaction, and recovery |
+| [`PERSISTENT_INSTRUCTIONS.md`](./PERSISTENT_INSTRUCTIONS.md) | Instruction resolution, prompt composition, mutation, and capability limits |
+| [`TUI.md`](./TUI.md) | Terminal layout, input ownership, commands, rendering, and side-question interaction |
+| [`ASSETS.md`](./ASSETS.md) | Bundled and managed Harness assets, host extensions, verification, and Quality Guard bindings |
+| [`SUBAGENTS.md`](./SUBAGENTS.md) | Child-Agent lifecycle, persistence, capability, concurrency, and delivery |
+| [`SKILLS.md`](./SKILLS.md) | Skill format, discovery, storage, path safety, and phased capability boundary |
+| [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md) | User agency, disclosure, confirmation, and enforceable-boundary policy |
+| [`WORKFLOW.md`](./WORKFLOW.md) | Branching, verification, review, publication, and documentation workflow |
+
+Each contract has one owner. Other documents should summarize only what their audience needs and link to that owner instead of repeating detailed rules.

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -62,6 +62,7 @@ host-assets/  # restricted Vesicle prompts and generic Agent extensions
 - TUI presentation and input routing observe and control host state without redefining domain semantics. See [`TUI.md`](./TUI.md).
 - Profile validators inspect Prism artifact documents rather than ordinary transition prose or every assistant turn. Artifact workbench validation reads the selected file from disk, and findings remain advisory unless a feature contract explicitly introduces a stronger policy.
 - Warning, confirmation, and risk-control design preserves informed user choice while enforcing concrete host boundaries. See [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md).
+- Guided Setup and the Windows installer own first-run onboarding, model discovery, configuration transactions, and OS integration within a bounded, secret-free scope. See [`SETUP.md`](./SETUP.md).
 
 ## Configuration And Setup Ownership
 
@@ -70,6 +71,8 @@ host-assets/  # restricted Vesicle prompts and generic Agent extensions
 - `src/setup` owns interactive onboarding, discovery, validation, backup, and configuration transactions. The Windows installer owns only the installed application lifecycle and operating-system integration.
 - Setup configuration writes are direct host actions, not model-visible tools. They validate the complete staged shape and preserve unrelated user configuration.
 - Project launch derives its root from the invocation directory or explicit directory argument. Setup and standalone asset resolution must not change the parent process working directory to make lookup succeed.
+
+Installer, onboarding, model-discovery, configuration-write, and project-launch rules live in [`SETUP.md`](./SETUP.md).
 
 ## Contract Ownership
 
@@ -85,6 +88,7 @@ host-assets/  # restricted Vesicle prompts and generic Agent extensions
 | [`SUBAGENTS.md`](./SUBAGENTS.md) | Child-Agent lifecycle, persistence, capability, concurrency, and delivery |
 | [`SKILLS.md`](./SKILLS.md) | Skill format, discovery, storage, path safety, and phased capability boundary |
 | [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md) | User agency, disclosure, confirmation, and enforceable-boundary policy |
+| [`SETUP.md`](./SETUP.md) | Windows installer scope, guided onboarding, model discovery, configuration transactions, and project-launch rules |
 | [`WORKFLOW.md`](./WORKFLOW.md) | Branching, verification, review, publication, and documentation workflow |
 
 Each contract has one owner. Other documents should summarize only what their audience needs and link to that owner instead of repeating detailed rules.

--- a/docs/dev/ASSETS.md
+++ b/docs/dev/ASSETS.md
@@ -36,6 +36,32 @@ Managed and bundled Harness baselines never merge file by file. A managed Pack m
 
 Every start and resume reverifies the active Harness identity. Sessions created before bundled V10 activation do not contain that identity and must start a new session rather than silently resuming under different runtime contracts.
 
+## Managed Pack Contract
+
+- Vesicle consumes a released Harness Pack or an explicitly selected local Pack directory. Runtime code and tests must not depend on a sibling source checkout, cross-repository symlink, or private local path.
+- `core/harness` owns strict `prism-harness-pack/v1` parsing, inventory and hash verification, Adapter and capability compatibility, Profile and Prompt bindings, external host assets, and immutable installation.
+- Compatibility is fail-closed. Vesicle advertises a capability only after the host enforces its complete contract; prompt guidance and a similar generic runtime are not substitutes for a declared capability.
+- Installation and activation are separate. Installation verifies before and after staging, then atomically renames an immutable Pack under the user configuration directory. Activation reverifies the installed Pack and atomically writes the project asset lock.
+- A selected managed Harness is one complete baseline. Missing files do not fall through to the bundled Pack unless the manifest declares the exact logical path as an external host asset.
+- Project locks and initial session host metadata persist Pack, manifest, Adapter, and source identity. Start and resume require the selected content to match that identity before provider continuation.
+- A persisted local decision may remain inspectable under identity drift, but any provider retry that depends on the prior Harness stays disabled until the recorded identity is restored.
+- Explicit Agent Profile allowlists in a released Pack may name Vesicle built-in host tools only. Runtime-local MCP tools and parent-provided tools are not portable explicit Pack dependencies.
+- The five generic host Agent ids are the only host-owned exemption from Driver delegation while a Harness is active. Other Harness, project, and user Agents require a matching Driver Contract.
+
+## Driver And Quality Bindings
+
+- Contract-bound delegation resolves one Driver binding from the active parent Engine and requested Agent Profile. The verified contract owns mode, purpose, retry limit, and delivery behavior; model arguments cannot widen them.
+- Delegation attempts persist their id, Agent Profile, mode, categorized outcome, and terminal state. Retry intent is durable before a user-authorized continuation, and cancellation is terminal.
+- `core/quality` loads Rule Pack and Detector assets only from the verified Harness and fails closed on unknown schemas, matchers, metrics, preprocessing, or binding semantics.
+- Quality assessment, policy outcome, and host action are separate durable concepts. Findings retain target, bounded evidence, Pack and Rule identity, outcome, and action without becoming a second permission system.
+- Artifact quality targets come only from successful structured file-mutation events and are evaluated from the complete current guarded UTF-8 post-image.
+- A later mutation supersedes the same target without erasing rejected-hash history. Clean prose or a different clean target cannot resolve a blocking target.
+- Runtime rewrite keeps rejected prose out of the displayed transcript, returns target-specific findings to the same Engine, uses the contract's bounded rewrite budget, and stops when a blocking target repeats its post-image hash.
+- Quality decisions persist before another provider request. Retry requires the same Engine, Harness, manifest, and Rule identity; accept and stop do not call the provider and retain applicable warnings.
+- Unreadable, non-UTF-8, and over-budget post-images are inconclusive warnings rather than clean assessments.
+- Observe bindings record deterministic findings without blocking ordinary work. Analyze bindings describe an Agent's own audit role and are excluded from recursive Guard enforcement.
+- `/permissions` remains the only approval layer for model-visible execution. Harness and quality bindings declare delivery policy and capability but do not create parallel trust or path-authorization systems.
+
 ## Verification
 
 Use:
@@ -53,7 +79,4 @@ The runtime asset archive and npm package must contain `harness-manifest.json`, 
 
 `assets/prompt-context-ledger.json` is a raw, static Harness prompt-asset ledger. Its 24,000-character static asset limit is verified when a Harness is activated, but it is not a provider context-window limit and never blocks a request. Runtime injections and conversation history are deliberately excluded.
 
-For Stage, `/stage` appends the frozen Module A source to the system message
-and sends the frozen Module B opening as assistant history. Those user-supplied
-values are intentionally outside the static asset ledger; their length belongs
-to provider/context management, not Harness asset review.
+For Stage, `/stage` appends the frozen Module A source to the system message and sends the frozen Module B opening as assistant history. Those user-supplied values are intentionally outside the static asset ledger; their length belongs to provider/context management, not Harness asset review.

--- a/docs/dev/PERSISTENT_INSTRUCTIONS.md
+++ b/docs/dev/PERSISTENT_INSTRUCTIONS.md
@@ -1,0 +1,56 @@
+# Persistent Instructions Runtime Contract
+
+Persistent Instructions are user-authored Markdown that customizes an Engine workflow across sessions. They are live model context, not automatic memory, capability authority, or durable session identity.
+
+## Targets And Resolution
+
+- File names are `VESICLE.md` for a general target and `VESICLE.<engine>.md` for an Engine-specific target.
+- Project scope lives at the launch project root. User scope lives in the user configuration directory beside `providers.yaml`.
+- Targets are selected from a fixed `{ scope, engine }` domain and never from an arbitrary path supplied by the model.
+- Within one scope, an existing Engine-specific target fully replaces the general target. File existence controls replacement, so an empty Engine file is an intentional empty override.
+- An invalid Engine-specific file suppresses general fallback for that scope rather than silently changing the selected target.
+- Across scopes, selected user content is followed by selected project content. Project content has higher precedence on a direct instruction conflict.
+- Neither scope can override the Engine contract, Harness identity, tool surface, permission mode, path roots, gates, validators, provider configuration, or host runtime.
+
+## Prompt Composition
+
+- Instructions are appended after the byte-identical Engine prompt as ordered host context, never as a second system authority.
+- A fixed host preamble identifies each block's scope, target, precedence, and capability boundary without altering user-authored content.
+- The Engine prompt remains the stable provider-prefix boundary. Stage character context follows Persistent Instructions.
+- Every system-prompt construction site uses one composition primitive. Continuations, provider rounds, side-question projection, and child forks inherit the already composed prompt rather than independently rebuilding it.
+- Vesicle does not auto-load coding-agent aliases such as `AGENTS.md` or `CLAUDE.md`, inject a coding-agent identity, or name those aliases in Engine prompts.
+- User-authored instruction bytes are preserved apart from stripping one leading BOM.
+
+## Freshness And Session Interaction
+
+- The host resolves current instruction files when a top-level turn begins, after process restart on resume, and after a confirmed Engine switch.
+- One turn freezes its resolved instruction snapshot. Permission, gate, question, and quality continuations reuse that snapshot so a paused tool call cannot resume under externally changed instructions.
+- A new top-level turn resolves current disk state again. Persistent Instructions therefore remain live configuration rather than session identity.
+- Restart loses the in-process snapshot, so a resumed continuation resolves current disk state and must not pretend to preserve an unavailable prior snapshot.
+- A successful `update_instructions` call is the explicit mid-turn exception: it refreshes the frozen snapshot so the next provider round observes the requested change.
+- Instruction changes do not alter the Harness asset fingerprint.
+
+## Validation And Privacy
+
+- Decode UTF-8 with fatal error handling, require a regular file, strip one leading BOM, and bound the combined selected content to 32 KiB.
+- Reject a project instruction target that is a symbolic link and skip linked user-scope targets.
+- Validation is fail-soft per scope. Invalid, linked, unreadable, or oversized content is skipped with a diagnostic while valid scopes continue; content is never truncated.
+- Diagnostics and session audit may include target identity, byte count, and content hash, but never instruction contents or absolute host paths.
+- Instruction resolution is independent from the guarded artifact path policy and runtime asset resolver.
+
+## Model-Visible Tools
+
+- `read_instructions` observes fixed instruction targets. `update_instructions` creates, replaces, or deletes a fixed target and is classified as a mutate operation by Tool Permission Runtime.
+- Stage does not expose instruction-management tools because its consumer role is deliberately tool-less.
+- `update_instructions` writes atomically, supports optimistic concurrency through `ifMatchSha256`, and rejects changes that exceed the combined Engine budget.
+- Each successful mutation keeps one recoverable previous-state backup in the owning scope and reports its location and manual recovery meaning in the tool result.
+- Instruction writes are outside guarded file checkpoints. Rewind may remove their conversation records but never restores the target file automatically.
+- These tools exist for explicit user-requested workflow management, not autonomous self-modification.
+
+## Direct Host Initialization
+
+- `/init` drafts the general project target as a direct host action.
+- It refuses an existing `VESICLE.md` before any provider request unless the user supplies `--force`.
+- Forced replacement backs up the existing target. A non-forced write also fails if the target appears while generation is in flight.
+
+User-facing setup and recovery instructions live in the mirrored Persistent Instructions tutorial and configuration reference under [`docs/user/`](../user/).

--- a/docs/dev/PROVIDERS.md
+++ b/docs/dev/PROVIDERS.md
@@ -1,0 +1,49 @@
+# Provider Runtime Contract
+
+This document defines how Vesicle selects providers, translates normalized requests, handles transport behavior, and reports normalized responses. Provider adapters are protocol boundaries, not host workflow owners.
+
+## Adapter Boundary
+
+- Adapters receive a normalized `VesicleRequest` and return a normalized `VesicleResponse`.
+- Adapters must not read or write project files, mutate sessions, execute host tools, render TUI state, or know Prism Engine phases.
+- Tool definitions and calls remain normalized. The agent loop discovers built-in and MCP tools, exposes ordinary function definitions to adapters, and dispatches returned calls through the owning host registry.
+- Core materializes durable image references before invoking an adapter. Adapters translate already-materialized data to provider-native image blocks and never read attachment files.
+- Core and TUI may select normalized generation controls. Only adapters map those controls to provider wire fields; adapters do not invent host defaults.
+
+## Usage And Metadata
+
+- Responses may report normalized context input, input, output, reasoning, cache, and effective-token counters.
+- `contextInputTokens` represents active request occupancy after protocol-specific cache accounting. OpenAI-compatible and Gemini adapters must not count cached tokens twice; Anthropic includes cache creation and read counters where the protocol reports them.
+- Provider-specific usage details may be retained under bounded provider metadata, but raw requests, headers, URLs, credentials, and secrets must never enter that metadata.
+- Pricing and billing policy live outside adapters.
+
+## Transport
+
+- Provider HTTP calls share one retry policy under `providers/shared`.
+- Retry only failures that are safe before a response is consumed: connection errors, HTTP 408, HTTP 429, and HTTP 5xx.
+- Use bounded exponential backoff with jitter, honor a bounded `Retry-After`, and allow host cancellation to interrupt both fetch and backoff.
+- Do not replay a partially consumed stream inside an adapter. Replay after visible deltas or tool calls requires agent-loop and TUI reconciliation.
+- Every provider call site forwards retry activity through its host-owned observability surface; call sites must not implement separate retry loops.
+- Application-level provider headers are centralized under `providers/shared`. Authentication is applied after the protocol fingerprint, and Bun owns `Host`, `Content-Length`, connection, and compression negotiation.
+- Streaming preserves the protocol's expected `Accept` behavior. Gemini selects SSE through `alt=sse`; a shared header layer must not force `text/event-stream` onto every protocol.
+- The only registry-configurable application header is provider-level `userAgent`. Arbitrary header overrides are not part of the provider contract.
+
+## Protocol Mapping
+
+- OpenAI-compatible adapters preserve normalized reasoning content, assistant tool calls, and tool-result pairing without leaking OpenAI-specific message shapes into core session logic.
+- Anthropic Messages adapters emit thinking blocks before text and tool-use blocks, represent tool results as user messages containing `tool_result`, and reconstruct streamed blocks by provider content-block index.
+- Gemini adapters map the system prompt to `systemInstruction`, conversation to `contents`, and tool results to `functionResponse` parts.
+- Gemini `thought` and `thoughtSignature` metadata remain attached to the original provider-native parts and are replayed as those parts on the next request instead of being reconstructed from assistant prose.
+- Provider-native thinking metadata is preserved for protocol continuity and display but must not be merged into ordinary assistant prose.
+
+## Provider Configuration
+
+- Provider profiles live in the user configuration directory, never in project `.vesicle/` state or a project-root `.env`.
+- `providers.yaml` contains provider ids, protocols, base URLs, model entries, generation defaults, capability metadata, limits, and `apiKeyEnv` names only. It must not contain secret values.
+- The sibling user-level `.env` is the primary secret source. Process environment variables are fallback only and must not let a legacy project-root `.env` override the user-level file.
+- A provider may declare `defaultModel` and `userAgent`. A default model must name an entry in the same provider catalog.
+- String model entries cover the common case. Object entries may declare `id`, `generation`, `capabilities`, and `limits`.
+- `generation.maxTokens` is a request default. `limits.contextWindow` and related limits describe model capacity and context policy; adapters receive the resulting normalized request rather than interpreting host configuration.
+- Vision is capability-gated. A non-vision model receives neither image content nor the model-visible image inspection tool.
+
+Current protocol availability and known limitations belong in [`STATUS.md`](../../STATUS.md). Example configuration shapes live under [`docs/examples/`](../examples/).

--- a/docs/dev/QUALITY_BENCHMARK.md
+++ b/docs/dev/QUALITY_BENCHMARK.md
@@ -73,4 +73,4 @@ The event log and report never contain candidate text or raw provider responses.
 
 ## Decision Boundary
 
-A successful dev benchmark is not authorization for a production held-out run, a Host Policy artifact, or semantic blocking. Follow the staged gates in `dev/docs/working/OUTPUT_QUALITY_GUARD_PR6_FEASIBILITY_ASSESSMENT.md`: freeze the rule/model scope and budget, complete the blinded held-out and preservation review, then perform the independent Policy handshake and Runtime promotion.
+A successful development benchmark is not authorization for a production held-out run, a Host Policy artifact, or semantic blocking. Production promotion requires separately governed rule and model scope, budget, blinded held-out evaluation, preservation review, independent Policy review, and Runtime integration evidence.

--- a/docs/dev/SESSIONS.md
+++ b/docs/dev/SESSIONS.md
@@ -1,0 +1,66 @@
+# Session And Context Runtime Contract
+
+This document defines durable conversation history, provider projection, file checkpoints, rewind, context compaction, and interrupted-turn recovery.
+
+## Session Identity And Persistence
+
+- One interactive TUI run keeps one active session until the user starts or resumes another session.
+- Session JSONL is append-only. Rewind, compaction, recovery, and branching append records and never truncate or rewrite prior records.
+- Conversational records carry stable `uuid` and `parentUuid` links. Legacy linear records project as an implicit parent chain.
+- Provider and Engine selection, usage metadata, validation, gates, questions, permissions, quality decisions, tool calls, and tool results persist when required for replay or recovery.
+- Host-only metadata may support replay and rendering but must not be forwarded to providers unless its record kind explicitly defines provider-visible context.
+- Child-session ownership uses separate parent session and parent tool-call identity; `parentUuid` remains an intra-session branch edge. See [`SUBAGENTS.md`](./SUBAGENTS.md).
+
+## Provider History Projection
+
+- Continuing a session includes prior provider-visible user, assistant, tool-call, and tool-result content in protocol-valid order.
+- Thinking and provider-native metadata remain separate from ordinary assistant prose while being preserved when a protocol requires replay.
+- Usage metadata is host-only and must not be sent back as conversational content.
+- Host packets such as Engine handoffs and compact summaries use explicit record kinds so the provider projection, transcript, rewind accounting, and empty-session UI can treat them consistently.
+- Projection must fail with an actionable session error when it encounters an unknown durable replacement format that cannot be interpreted safely.
+
+## Attachments And File Checkpoints
+
+- Image bytes live in the ignored content-addressed `.vesicle/attachments/` store. JSONL records ids, hashes, MIME types, sizes, and relative paths, never base64 payloads.
+- A real user prompt owns the guarded-file checkpoint for the work it initiates.
+- Mutation tools capture every affected writable path before changing it. Checkpoint metadata remains host-only.
+- Checkpoints preserve absent paths, file contents, and directory topology. Directory-tree moves capture both the source tree and target path so empty directories can be restored.
+- Rewind moves the in-memory head and restores guarded checkpoint state; the next persisted record creates a new append-only branch.
+- Host configuration changes and shell mutations outside guarded file tools are not rewind-safe. Their tools must disclose the applicable backup or recovery contract.
+
+## Failed Turns And Continuations
+
+- A top-level user turn whose provider round fails before any assistant response keeps the authored prompt in the transcript and appends a host-only failure marker.
+- Provider projection excludes the failed round's unmatched user tail so resume or resend cannot create invalid consecutive same-role messages.
+- A completed compact checkpoint remains a valid replacement boundary even when a later provider round fails.
+- A mid-loop failure after an assistant response retains the already valid alternation tail and is not rewritten as a failed top-level turn.
+- Continuation state must be persisted before another provider request so cancellation, provider failure, or restart cannot silently lose or replay a gate, question, permission, Agent delivery, or quality decision.
+
+## Compact Checkpoints
+
+- Manual and automatic compaction install one atomic `compact-checkpoint-v1` system record at the active head. The original transcript remains intact for display, rewind, and audit.
+- A portable compact checkpoint contains a summary of the evicted prefix, a verbatim retained recent tail, and the active frontier when compaction occurs mid-turn.
+- Provider-visible history resets at the newest valid checkpoint and replays its suffix. The selected-pivot rewind summary keeps its separate branch behavior.
+- Records use stable logical-turn and provider-round identity so compaction evicts only complete units and never separates a tool call from its result. Legacy records without those ids are grouped conservatively.
+- The exact replacement request must reduce the projected request and fit the hard input ceiling before the checkpoint is appended.
+- A compact provider request is standalone, exposes no tools, and cannot recursively compact itself. At most one compact operation runs at one boundary.
+- Cancellation is distinct from failure. A soft-trigger failure leaves the old head and continues; a hard-ceiling failure or insufficient reduction blocks the pending provider request without installing an ineffective checkpoint.
+
+## Automatic Compaction
+
+- Automatic compaction is opt-in and provider-neutral. It activates only from a valid model limit configuration; there is no hidden threshold.
+- The soft trigger is `floor(min(contextWindow * threshold, contextWindow - reserve))`; the hard input ceiling is `contextWindow - reserve`.
+- Reserve precedence is configured `reserveOutputTokens`, then effective turn `maxTokens`, then `limits.maxOutputTokens`, then zero. Configuration must reject a statically known reserve that leaves no positive input budget.
+- The primary estimate starts from the latest provider-confirmed context input paired with the host estimate of that same request, then adds host-estimated growth.
+- The fallback estimate includes the system prompt, messages, tool envelopes, and the active tool schema. Excluded or approximate material must be labeled rather than reported as provider-confirmed protection.
+- Pre-turn compaction runs before a new user record persists. Mid-turn checks run only at complete, recoverable boundaries before the next provider request.
+- Unresolved interactions defer compaction, but their resumed provider request still passes the exact send guard.
+- `/context` reports configured capacity, the latest provider usage or its absence, activation status, effective soft and hard limits, reserve source, strategy, and degraded or deferred state.
+
+## Activity And Streaming
+
+- Long-running turns emit host-visible activity around provider requests, tool calls, interaction pauses, compaction, quality handling, and validation.
+- Provider streaming may expose assistant deltas while still reconstructing one final normalized response for persistence and replay.
+- Observability does not change provider, process, tool, or session semantics.
+
+Persistent Instructions are deliberately outside session identity; their separate resolution and mutation contract lives in [`PERSISTENT_INSTRUCTIONS.md`](./PERSISTENT_INSTRUCTIONS.md).

--- a/docs/dev/SETUP.md
+++ b/docs/dev/SETUP.md
@@ -1,0 +1,25 @@
+# Guided Setup And Installer
+
+This document defines the Windows installer scope, interactive onboarding, model discovery, configuration transactions, and project-launch rules. Ownership and dependency direction live in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+
+## Installer Scope
+
+- The Windows installer owns only the application lifecycle: complete runtime payload, per-user install location, PATH, shortcuts, upgrade identity, and uninstall. It must not parse provider/MCP schemas, accept secrets, or mutate `%APPDATA%\prism-vesicle`.
+- The installed terminal command is the native `vesicle.exe`, renamed from the staged release binary during installation rather than wrapped in a batch file. Upgrades remove superseded executable, wrapper, and Start Menu launch entries. A detected installation exposes Reinstall, Repair, and Uninstall maintenance choices; Repair restores installed files and Windows integration without reopening Guided Setup.
+
+## Onboarding
+
+- `src/setup` owns interactive onboarding. Network discovery, masked input, configuration merge/backup, validation, optional MCP/Tavily setup, permission defaults, and project selection stay in the application so they reuse runtime contracts.
+- Setup choice pages must expose a visible backward action in addition to Escape handling, reset selection when returning to a shorter option list, and keep every rendered row clipped within compact terminal bounds.
+
+## Model Discovery
+
+- OpenAI-compatible model discovery may use the user-supplied Base URL and API key only for a bounded `GET /v1/models` request. Do not follow credential-bearing redirects, log the key, infer capabilities from model names, or make discovery success mandatory when exact manual ids are available.
+
+## Configuration Writes
+
+- Setup configuration writes are host actions, not model-visible tools. Validate the complete staged provider/MCP/environment shape, preserve unrelated secrets and profiles, create timestamped backups for existing files, and keep YOLO and `shell_exec` out of first-run persistent defaults.
+
+## Project Launch
+
+- Setup must not persist a global project pointer. An optional onboarding folder is only a one-time post-Setup launch target. Every later project launch derives its root from the invocation directory or an explicit `vesicle <directory>` argument; path-based launch starts a new process with that directory as cwd rather than changing the parent process cwd.

--- a/docs/dev/SKILLS.md
+++ b/docs/dev/SKILLS.md
@@ -1,39 +1,21 @@
 # Skills Runtime
 
-A Skill is on-demand procedural context plus bundled resources in the open
-[Agent Skills](https://agentskills.io/specification) `SKILL.md` format. A Skill
-is **not** an Engine, Agent Profile, MCP server, or permission grant. It may
-contain instructions, references, assets, and scripts. A Skill does not itself
-add tools, writable roots, shell authority, MCP servers, Agent scope, permission
-exemptions, or provider capabilities; actions it requests use the capabilities
-and permission mode the user already selected.
+A Skill is on-demand procedural context plus bundled resources in the open [Agent Skills](https://agentskills.io/specification) `SKILL.md` format. A Skill is **not** an Engine, Agent Profile, MCP server, or permission grant. It may contain instructions, references, assets, and scripts. A Skill does not itself add tools, writable roots, shell authority, MCP servers, Agent scope, permission exemptions, or provider capabilities; actions it requests use the capabilities and permission mode the user already selected.
 
-This document is the authoritative runtime boundary for Skills in Vesicle. The
-research basis, ecosystem comparison, and full phased delivery plan live in
-`dev/docs/working/SKILLS_RUNTIME_RESEARCH_AND_FEASIBILITY.md` (the ignored local
-implementation plan). Phases 0-3 are approved for implementation in order; an
-Agent directed to follow or continue that plan should execute its earliest
-incomplete phase rather than perform another feasibility pass. Git publication
-operations remain governed separately by `docs/dev/WORKFLOW.md`.
+This document is the authoritative public runtime boundary for Skills in Vesicle. Local research and implementation plans may inform changes but are not required to understand the supported contract. Git publication operations remain governed separately by [`WORKFLOW.md`](./WORKFLOW.md).
 
 ## Phase 0 scope
 
 Phase 0 delivers **format, inventory, and the Skill Store** only:
 
 - strict `SKILL.md` parser and validator (`src/skills/parser.ts`);
-- bounded discovery for the verified Harness and user scopes
-  (`src/skills/discovery.ts`);
+- bounded discovery for the verified Harness and user scopes (`src/skills/discovery.ts`);
 - collision, invalid, and unsupported-field diagnostics;
 - `vesicle skills list | validate | inspect` and `vesicle doctor` integration;
-- immutable versioned Skill Store, active index, and catalog hashing
-  (`src/skills/store.ts`, `src/skills/catalog.ts`);
+- immutable versioned Skill Store, active index, and catalog hashing (`src/skills/store.ts`, `src/skills/catalog.ts`);
 - **no model-visible activation.**
 
-Phase 0 does **not** add `activate_skill` / `read_skill_resource` tools, a
-`/skill` command, repository install commands (`install | update | rollback |
-uninstall`), project `.agents/skills/` scope, script execution, or any
-prompt-composition, session, compaction, or Engine-switch behavior. Those belong
-to later phases and must not be implied by Phase 0 surfaces.
+Phase 0 does **not** add `activate_skill` / `read_skill_resource` tools, a `/skill` command, repository install commands (`install | update | rollback | uninstall`), project `.agents/skills/` scope, script execution, or any prompt-composition, session, compaction, or Engine-switch behavior. Those belong to later phases and must not be implied by Phase 0 surfaces.
 
 ## What a Skill is (and is not)
 
@@ -46,70 +28,40 @@ to later phases and must not be implied by Phase 0 surfaces.
 | Agent Profile | Delegated worker identity and tool subset | SubAgent spawn | Within parent/Driver bounds |
 | MCP | External tools and resources | Config discovery | Yes, via configured server |
 
-A useful test: if a feature needs a new network service, tool schema, credential,
-lifecycle hook, renderer, or permission, it is not "just a Skill." It belongs in
-MCP, the host runtime, an Engine/Harness contract, or a future plugin system.
+A useful test: if a feature needs a new network service, tool schema, credential, lifecycle hook, renderer, or permission, it is not "just a Skill." It belongs in MCP, the host runtime, an Engine/Harness contract, or a future plugin system.
 
 ## Discovery scopes
 
-Phase 0 discovers two deterministic, non-merging scopes, lowest to highest
-precedence:
+Phase 0 discovers two deterministic, non-merging scopes, lowest to highest precedence:
 
-1. **Harness** — logical `assets/skills/<name>/SKILL.md`, resolved through the
-   active verified Harness asset resolver.
+1. **Harness** — logical `assets/skills/<name>/SKILL.md`, resolved through the active verified Harness asset resolver.
 2. **User** — `<user-config>/skills/<name>/SKILL.md`, direct filesystem.
 
-The `src/skills` module takes **pre-resolved roots** and does not import the asset
-resolver, providers, harness runtime, or TUI. The CLI (`src/cli/skills.ts`) owns
-Harness-root resolution and passes both root lists to `discoverSkills`.
+The `src/skills` module takes **pre-resolved roots** and does not import the asset resolver, providers, harness runtime, or TUI. The CLI (`src/cli/skills.ts`) owns Harness-root resolution and passes both root lists to `discoverSkills`.
 
-On a name collision, exactly one winner is selected by precedence (`user`
-outranks `harness`); lower-precedence entries produce one `shadowed` diagnostic
-each. Bodies and resources are never merged. Catalog and diagnostic shapes never
-carry an absolute host path — only logical source scopes and skill-relative
-paths.
+On a name collision, exactly one winner is selected by precedence (`user` outranks `harness`); lower-precedence entries produce one `shadowed` diagnostic each. Bodies and resources are never merged. Catalog and diagnostic shapes never carry an absolute host path — only logical source scopes and skill-relative paths.
 
-Reserved for later phases: host-bundled Skills, project `.agents/skills/`, and
-the installed Skill Store as a discovery source. Project Skills may enter the
-catalog when their project is opened; their source scope must remain visible,
-without a separate project-trust state.
+Reserved for later phases: host-bundled Skills, project `.agents/skills/`, and the installed Skill Store as a discovery source. Project Skills may enter the catalog when their project is opened; their source scope must remain visible, without a separate project-trust state.
 
 ## Parsing and validation
 
-`src/skills/parser.ts` is a pure function over already-decoded text. It mirrors
-the repository's pattern of a hand-written bounded YAML reader for each narrow
-schema (engine profiles, Module A/B validators) so Vesicle keeps its
-zero-YAML-dependency runtime. It rejects anything it cannot read unambiguously
-rather than splitting frontmatter ad hoc.
+`src/skills/parser.ts` is a pure function over already-decoded text. It mirrors the repository's pattern of a hand-written bounded YAML reader for each narrow schema (engine profiles, Module A/B validators) so Vesicle keeps its zero-YAML-dependency runtime. It rejects anything it cannot read unambiguously rather than splitting frontmatter ad hoc.
 
 Validated portable core:
 
-- required `name`: 1–64 lowercase alphanumeric segments joined by single
-  hyphens, matching the parent directory (no leading, trailing, or repeated
-  hyphens);
+- required `name`: 1–64 lowercase alphanumeric segments joined by single hyphens, matching the parent directory (no leading, trailing, or repeated hyphens);
 - required nonempty `description`, maximum 1024 code points;
 - optional `license`, `compatibility`, string-to-string `metadata`;
-- experimental space-separated `allowed-tools` — parsed for compatibility, then
-  ignored with one `allowed-tools-ignored` diagnostic;
-- unknown top-level fields — preserved for inspection, flagged as
-  `unsupported-field`, and ignored by runtime behavior.
+- experimental space-separated `allowed-tools` — parsed for compatibility, then ignored with one `allowed-tools-ignored` diagnostic;
+- unknown top-level fields — preserved for inspection, flagged as `unsupported-field`, and ignored by runtime behavior.
 
-Bounds (research §2): `SKILL.md` at most 64 KiB and 500 lines; at most 200
-supporting resources per Skill; individual text references at most 256 KiB.
+Bounds (research §2): `SKILL.md` at most 64 KiB and 500 lines; at most 200 supporting resources per Skill; individual text references at most 256 KiB.
 
-Loading (`src/skills/loader.ts`) is fail-soft per root: UTF-8 is decoded fatally,
-one leading BOM is stripped, the `SKILL.md` target must be a regular file (not a
-symbolic link) with a race-aware re-check, and the skill root must be a real
-directory. Any I/O or parse failure is returned as an invalid result so one bad
-Skill never hides its valid siblings.
+Loading (`src/skills/loader.ts`) is fail-soft per root: UTF-8 is decoded fatally, one leading BOM is stripped, the `SKILL.md` target must be a regular file (not a symbolic link) with a race-aware re-check, and the skill root must be a real directory. Any I/O or parse failure is returned as an invalid result so one bad Skill never hides its valid siblings.
 
 ## Path hardening
 
-`src/skills/paths.ts` is the shared virtual-root guard, reused by the parser,
-loader, store, and the future Phase 2 `read_skill_resource` tool. Every resource
-path is skill-relative and shallow; absolute paths, `..` escapes, backslashes,
-NUL, empty/dot segments, normalization ambiguity, symbolic links, devices, and
-sockets are rejected.
+`src/skills/paths.ts` is the shared virtual-root guard, reused by the parser, loader, store, and the future Phase 2 `read_skill_resource` tool. Every resource path is skill-relative and shallow; absolute paths, `..` escapes, backslashes, NUL, empty/dot segments, normalization ambiguity, symbolic links, devices, and sockets are rejected.
 
 ## Skill Store
 
@@ -123,27 +75,13 @@ sockets are rejected.
     └── <version>.provenance.json    host sidecar (source, hashes, inventory)
 ```
 
-The version directory holds only the auditable standard bundle; provenance lives
-in a sibling sidecar so the bundle stays byte-for-byte comparable with its
-source. Snapshots are staged, re-verified by hash, and atomically renamed; an
-interrupted install never leaves a live dependency on the source path or a
-half-written active version. Reinstalling identical content is idempotent by
-bundle hash; a differing bundle under the same version is a hard conflict.
+The version directory holds only the auditable standard bundle; provenance lives in a sibling sidecar so the bundle stays byte-for-byte comparable with its source. Snapshots are staged, re-verified by hash, and atomically renamed; an interrupted install never leaves a live dependency on the source path or a half-written active version. Reinstalling identical content is idempotent by bundle hash; a differing bundle under the same version is a hard conflict.
 
-Phase 0 ships the storage mechanism (`installSnapshot`) and the read APIs so
-Phase 1 can layer repository-install commands on top without re-deriving the
-immutable-snapshot contract. The store is **not yet a discovery source**.
+Phase 0 ships the storage mechanism (`installSnapshot`) and the read APIs so Phase 1 can layer repository-install commands on top without re-deriving the immutable-snapshot contract. The store is **not yet a discovery source**.
 
 ## Catalog
 
-`src/skills/catalog.ts` builds the bounded, frozen routing view from discovery
-winners. It exposes only `name`, `description`, and a logical source `scope`,
-capped to ~2% of the model context window when known or an 8 KiB fallback,
-preferring description shortening and then omission of lowest-precedence skills.
-The catalog hash is an identity fingerprint over the kept skills'
-`name\0scope\0contentSha256` — description shortening does not change it, but
-activating, omitting, or changing the content version of a skill does. Phase 0
-builds and hashes the catalog; it is not yet model-visible.
+`src/skills/catalog.ts` builds the bounded, frozen routing view from discovery winners. It exposes only `name`, `description`, and a logical source `scope`, capped to ~2% of the model context window when known or an 8 KiB fallback, preferring description shortening and then omission of lowest-precedence skills. The catalog hash is an identity fingerprint over the kept skills' `name\0scope\0contentSha256` — description shortening does not change it, but activating, omitting, or changing the content version of a skill does. Phase 0 builds and hashes the catalog; it is not yet model-visible.
 
 ## CLI surface
 
@@ -153,15 +91,11 @@ vesicle skills validate <skill-directory>
 vesicle skills inspect <name>
 ```
 
-`vesicle doctor` reports valid/invalid/shadowed counts over the Harness and user
-scopes. None of these surfaces expose an absolute host path.
+`vesicle doctor` reports valid/invalid/shadowed counts over the Harness and user scopes. None of these surfaces expose an absolute host path.
 
 ## Risk disclosure and runtime boundaries
 
-Explicit installation is the user's decision to make a Skill available. Vesicle
-must show its source, resolved version, bundled scripts, declared requirements,
-and material warnings, but it must not add a second trust ceremony or block a
-valid Skill based on a host judgment about its intent.
+Apply the cross-cutting policy in [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md). Explicit installation is the user's decision to make a Skill available. Vesicle must show its source, resolved version, bundled scripts, declared requirements, and material warnings, but it must not add a second trust ceremony or block a valid Skill based on a host judgment about its intent.
 
 | Risk or condition | Product response |
 |---|---|
@@ -174,26 +108,12 @@ valid Skill based on a host judgment about its intent.
 | Name collision | Select deterministically and show winning and shadowed scopes |
 | Catalog bloat affects context and cache behavior | Apply count/context budgets and report omitted entries |
 
-Static scanning may produce useful warnings, but it cannot certify Markdown or
-code as benign. Findings are disclosures, not a content-approval gate or an
-implied safety certification when no warning is emitted. Format validation,
-portable path rules, immutable provenance, and runtime observation protect
-correctness and auditability without replacing the user's judgment.
+Static scanning may produce useful warnings, but it cannot certify Markdown or code as benign. Findings are disclosures, not a content-approval gate or an implied safety certification when no warning is emitted. Format validation, portable path rules, immutable provenance, and runtime observation protect correctness and auditability without replacing the user's judgment.
 
 ## Phase roadmap
 
 - **Phase 0 — format, inventory, Skill Store** (this change).
-- **Phase 1 — local and GitHub repository installation**: `install | update |
-  rollback | uninstall`, staging, full-inventory validation, content hash,
-  provenance, atomic activation, dirty-worktree handling.
-- **Phase 2 — activation, resources, and scripts**: Engine-declared
-  `activate_skill` / `read_skill_resource`, bare `/skill` inventory and picker,
-  `/skill <name> [task]`, `--context-only`, and `run_skill_script` for
-  process-capable Engines through existing Process/Permission Runtime behavior;
-  structured activation/session events, TUI rendering, and exact
-  resume/compact/rewind/Engine-switch semantics.
-- **Phase 3 — authoring and project scope**: `.agents/skills` discovery with
-  visible project provenance and no separate trust state, create/edit workflow,
-  enable/disable, and refresh.
-- **Phase 4 — registries and broader distribution**: optional distribution work
-  after direct local/GitHub repository installation is established.
+- **Phase 1 — local and GitHub repository installation**: `install | update | rollback | uninstall`, staging, full-inventory validation, content hash, provenance, atomic activation, dirty-worktree handling.
+- **Phase 2 — activation, resources, and scripts**: Engine-declared `activate_skill` / `read_skill_resource`, bare `/skill` inventory and picker, `/skill <name> [task]`, `--context-only`, and `run_skill_script` for process-capable Engines through existing Process/Permission Runtime behavior; structured activation/session events, TUI rendering, and exact resume/compact/rewind/Engine-switch semantics.
+- **Phase 3 — authoring and project scope**: `.agents/skills` discovery with visible project provenance and no separate trust state, create/edit workflow, enable/disable, and refresh.
+- **Phase 4 — registries and broader distribution**: optional distribution work after direct local/GitHub repository installation is established.

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -1,61 +1,13 @@
-# Prism Vesicle Architecture And Style
+# Prism Vesicle Code Style
 
-This file records the hard rules for code shape, prompt/runtime boundaries, and
-tool behavior. It is intentionally practical: keep Vesicle small, explicit, and
-hard to fool.
+This document defines how Prism Vesicle source code should be shaped so contributors can understand, change, and verify it safely. Architecture and runtime behavior belong in the domain contracts linked from [`ARCHITECTURE.md`](./ARCHITECTURE.md); workflow and verification commands belong in [`WORKFLOW.md`](./WORKFLOW.md).
 
-## Layering
+## Tool-Enforced Baseline
 
-```text
-cli/  # command dispatch only
-tui/  # OpenTUI rendering and keyboard interaction
-config/  # environment loading and config inspection
-setup/  # guided onboarding, discovery, validated config transactions
-core/agent-loop/  # provider requests, tool loop, gate pause/resume
-core/agents/  # Agent profiles, child lifecycle, concurrency, inbox delivery
-core/artifacts/  # artifact discovery, preview bounds, validation selection
-core/attachments/  # clipboard image content-addressed store
-core/checkpoints/  # per-turn file snapshots, diff stats, restore
-core/compact/  # context compaction service
-core/engine/  # engine profile YAML loading
-core/gate/  # request_confirmation tool + GateRequest types
-core/harness/  # Harness manifest verification, compatibility, immutable install
-core/permissions/  # Tool Permission Runtime broker and policy
-core/process/  # bounded Process Runtime and shell profiles
-core/prompt/  # prompt asset loading and composition
-core/quality/  # Output Quality Guard host runtime
-core/rewind/  # conversation rewind and partial summarization
-core/runtime/  # engine and runtime asset resolution helpers
-core/session/  # durable session persistence + resume helpers
-core/side-question/  # `/btw` tool-free side question snapshot + service
-core/stage/  # Stage consumer bootstrap
-core/tools/  # host tool contracts and execution
-core/user-question/  # ask_user_question host question types
-core/validators/  # Module A/B v9 schema checks + registry
-mcp/  # external MCP tool discovery and execution
-providers/  # protocol adapters only
-skills/  # Agent Skills parser, discovery, store, catalog (Phase 0; no activation yet)
-types/  # shared host types
-assets/  # exact bundled V10 Harness manifest inventory
-host-assets/  # restricted Vesicle prompts and generic Agent extensions
-harness-manifest.json  # bundled V10 Harness identity and hashes
-```
-
-Allowed dependency direction:
-
-- `cli -> tui, core, config`
-- `tui -> core, config, providers/types`
-- `setup -> config, mcp, core engine/permission types, and reusable TUI presentation/input primitives`
-- `core/agent-loop -> providers, prompt, session, tools, gate, engine, validators, mcp`
-- `core/agents -> providers, session, tools, runtime assets, mcp`
-- `core/harness -> engine, agents, tools, validators, runtime assets, config paths`
-- `core/artifacts -> tools, validators`
-- `skills -> config paths` (it takes pre-resolved discovery roots and must not import the asset resolver, providers, harness runtime, or TUI; the CLI owns Harness-root resolution and passes roots to `discoverSkills`)
-- `providers -> providers/shared` and config only
-- `core/tools` must not depend on providers or TUI
-- `mcp` must not depend on providers or TUI; it may depend on core tool types
-  and engine ids for tool definitions and engine scoping
-- `core/gate` depends only on `core/tools` types
+- TypeScript runs in strict mode. Do not weaken compiler settings or hide an uncertain value behind `any`; narrow `unknown` at the boundary that receives it.
+- Biome owns lint diagnostics. Its formatter is intentionally disabled, so preserve the surrounding source style and avoid unrelated formatting churn.
+- Use Bun-native APIs and existing project dependencies where they already express the required behavior. Do not add a dependency or abstraction for a small local operation.
+- Keep source, tests, scripts, and runtime assets inside their established roots. Do not mix generated state or host configuration into tracked source directories.
 
 ## Responsibility And Maintainability
 
@@ -69,666 +21,112 @@ Evaluate structure from several signals together:
 - Local reasoning and testing: behavior should be understandable and testable through a narrow interface without constructing unrelated runtime state.
 - Change safety: prefer boundaries that let one concern evolve without broad edits, synchronized changes across files, or fragile ordering assumptions.
 
-Split code when these signals reveal a stable domain boundary or a recurring maintenance cost. Keep a large composition root, registry, parser, state machine, or data table intact when it remains cohesive and splitting it would scatter invariants or introduce indirect coupling. Do not create generic `helpers.ts`, `utils.ts`, or `common.ts` piles; name extracted modules by the domain responsibility they own.
+Split code when these signals reveal a stable domain boundary or a recurring maintenance cost. Keep a large composition root, registry, parser, state machine, or data table intact when it remains cohesive and splitting it would scatter invariants or introduce indirect coupling.
 
-## Provider Adapters
+Do not create generic `helpers.ts`, `utils.ts`, or `common.ts` piles. Name an extracted module after the domain responsibility or policy it owns.
 
-Provider adapters convert Vesicle's internal request model to wire format and
-back. They must not:
+## Prohibited God Structures
 
-- read or write project files
-- mutate sessions
-- know about Prism engine phases
-- implement host tools directly
+God files, god functions, and god classes are prohibited. A change that creates one, materially expands one, or moves the same mixed ownership behind a new name is blocking and must be redesigned before merge.
 
-Tool calls are normalized into `ToolCall` and executed by `core/tools`. MCP
-tools are the origin exception, not a provider-shape exception: the agent loop
-discovers them through `src/mcp`, exposes them as ordinary function tool
-definitions, and dispatches `mcp_<prefix>_<tool>` aliases back through the MCP
-registry. Provider adapters still see only normalized tool definitions and
-tool-call messages.
+- A god file owns several unrelated domains or layers, accumulates independent reasons to change, or serves as the place where new behavior is added merely because it already coordinates everything.
+- A god function performs substantial work across several concerns such as parsing, policy, persistence, provider or tool I/O, state transitions, and presentation instead of delegating through named boundaries.
+- A god class centralizes unrelated lifecycle, scheduling, persistence, policy, resource ownership, and presentation knowledge behind one mutable object or broad method surface.
+- A mega-controller, service locator, global host-state object, growing context or options bag, or generic manager is still a god structure when callers and callees must understand unrelated subsystems through it.
+- A mechanical split into several files does not resolve the smell when the extracted files remain order-dependent, share broad mutable state, reach into each other's internals, or can change only in lockstep.
 
-Provider selection is host state, not prompt state. The TUI may switch among
-configured provider/model profiles, but adapters still receive a normalized
-`VesicleRequest` and must not know about sessions, artifacts, or Prism phases.
-Provider responses may include normalized usage counters (`contextInputTokens`,
-`inputTokens`, `outputTokens`, cache read/write/hit/miss counts, reasoning
-tokens, and effective tokens). `contextInputTokens` is the request's active
-context-window occupancy after provider-specific cache accounting: do not add
-cached tokens twice for OpenAI-compatible/Gemini providers, but do include
-Anthropic cache creation/read counters. Adapters may map provider-native usage
-detail objects into `providerDetails`, but must keep raw requests, headers,
-URLs, and secrets out of that metadata. Pricing and billing policy belong
-outside adapters.
-User and tool messages may carry durable image attachment references. Core
-materializes those references into base64 before invoking an adapter;
-provider adapters map already-materialized data to native image blocks and
-must not read image files themselves. Models opt in with
-`capabilities.vision: true`; non-vision models receive neither image content
-nor the `view_image` tool.
-Generation controls follow the same rule: core/TUI may pass the normalized
-`reasoningTier` values (`off`, `low`, `medium`, `high`, `xhigh`, `max`), but
-only the provider adapter maps them to wire fields such as `thinking` and
-`reasoning_effort`. TUI commands may offer `auto`/`unset` to clear an explicit
-selection; that means no `reasoningTier` is sent.
-Provider HTTP calls share one transport retry policy under `providers/shared`.
-Retry only failures that are safe before a response is consumed: connection
-errors, 408, 429, and 5xx. Use bounded exponential backoff with jitter, honor a
-bounded `Retry-After`, and let host cancellation interrupt both fetch and
-backoff. Do not replay a partially consumed SSE stream inside an adapter; that
-requires agent-loop/TUI reconciliation so deltas and tool calls cannot be
-duplicated. The retry loop fires an `onRetry` callback on `VesicleRequest`;
-every provider call site — the main chat turn, `/init`, `/compact`, `/btw`,
-SubAgent child rounds, and the Semantic Judge — forwards that callback to the
-appropriate UI surface (status line, activity log, `/btw` overlay, or agent
-progress) so retries are observable without any site running its own retry loop.
-Application-level provider headers are centralized under `providers/shared`.
-OpenAI-compatible Chat follows the audited OpenCode header shape, Anthropic
-Messages follows the Claude Code fingerprint, and Gemini follows Gemini CLI's
-Google GenAI SDK shape. Streaming must preserve each protocol's normal
-`Accept` behavior instead of applying a shared `text/event-stream` override;
-Gemini selects SSE through `alt=sse`. Leave `Host`, `Content-Length`,
-`Connection`, and compression negotiation to Bun. Authentication headers are
-injected by the adapter after the fingerprint. The only user-configurable
-header is provider-level `userAgent`; arbitrary header overrides are not part
-of the provider registry contract.
-Anthropic Messages adapters map Vesicle messages to Anthropic content blocks:
-assistant thinking blocks must be emitted before text/tool_use blocks, and
-tool results are user messages containing `tool_result` blocks. The agent loop
-and session store must not interpret these native blocks beyond preserving
-their typed metadata. Anthropic streaming must reconstruct text, thinking, and
-tool_use blocks by provider content-block index before emitting the final
-`VesicleResponse`.
-Gemini `generateContent` adapters map Vesicle messages to `systemInstruction`
-plus `contents`, and tool results to `functionResponse` parts. If Gemini
-returns `thought` / `thoughtSignature` metadata, preserve the original model
-parts as provider-native `gemini_part` thinking blocks and replay those parts
-on the next request instead of reconstructing them from assistant prose. This
-keeps Gemini's tool-loop thought signatures attached to the exact parts that
-the provider expects.
-High-frequency thinking controls may be interactive TUI state. Lower-frequency
-generation defaults such as `temperature` and `maxTokens` belong in the
-user-level provider model config and are merged by `core/agent-loop` before
-calling adapters. Adapters should only map the normalized request shape to wire
-fields; they should not invent host policy defaults.
-Persistent provider profiles live in the user-level provider config, not in the
-project `.vesicle/` runtime state directory. The default path is
-`%APPDATA%\prism-vesicle\providers.yaml` on Windows and
-`$XDG_CONFIG_HOME/prism-vesicle/providers.yaml` or
-`~/.config/prism-vesicle/providers.yaml` elsewhere. API keys must be referenced
-via per-provider environment variables (`apiKeyEnv`) and must not be stored
-inline in the provider file. The user-level `.env` file beside
-`providers.yaml` is the default place for those secret values; process
-environment variables are fallback only so a legacy project-root `.env` loaded
-by the runtime cannot override the user-level secret file.
-`providers.yaml` supports optional provider-level `defaultModel` and
-`userAgent` fields, string model entries for the common case, and object model
-entries for `id`,
-`generation`, `capabilities`, and `limits` metadata. `generation.maxTokens` is
-the provider request default; `limits.contextWindow` is model capacity metadata
-used by `/context` and footer percentages. A `defaultModel` must name a model
-in the same provider catalog. Keep this schema small and explicit until native
-protocol adapters require more fields.
+Size, branch count, import fan-out, state-field count, and churn are screening evidence rather than standalone verdicts. The blocking decision rests on mixed ownership, cross-domain knowledge, change coupling, and inability to reason about or test one concern independently.
 
-## Guided Setup And Installer
+A focused change is not required to rewrite every pre-existing hotspot it encounters. It must not add another unrelated responsibility or deepen the coupling; when the requested behavior would do so, extracting the affected stable boundary is part of the change rather than optional cleanup.
 
-- The Windows installer owns only the application lifecycle: complete runtime payload, per-user install location, PATH, shortcuts, upgrade identity, and uninstall. It must not parse provider/MCP schemas, accept secrets, or mutate `%APPDATA%\prism-vesicle`.
-- The installed terminal command is the native `vesicle.exe`, renamed from the staged release binary during installation rather than wrapped in a batch file. Upgrades remove superseded executable, wrapper, and Start Menu launch entries. A detected installation exposes Reinstall, Repair, and Uninstall maintenance choices; Repair restores installed files and Windows integration without reopening Guided Setup.
-- `src/setup` owns interactive onboarding. Network discovery, masked input, configuration merge/backup, validation, optional MCP/Tavily setup, permission defaults, and project selection stay in the application so they reuse runtime contracts.
-- Setup choice pages must expose a visible backward action in addition to Escape handling, reset selection when returning to a shorter option list, and keep every rendered row clipped within compact terminal bounds.
-- OpenAI-compatible model discovery may use the user-supplied Base URL and API key only for a bounded `GET /v1/models` request. Do not follow credential-bearing redirects, log the key, infer capabilities from model names, or make discovery success mandatory when exact manual ids are available.
-- Setup configuration writes are host actions, not model-visible tools. Validate the complete staged provider/MCP/environment shape, preserve unrelated secrets and profiles, create timestamped backups for existing files, and keep YOLO and `shell_exec` out of first-run persistent defaults.
-- Setup must not persist a global project pointer. An optional onboarding folder is only a one-time post-Setup launch target. Every later project launch derives its root from the invocation directory or an explicit `vesicle <directory>` argument; path-based launch starts a new process with that directory as cwd rather than changing the parent process cwd.
+## Module Boundaries
 
-## Tool Runtime
+- Modularization and decoupling are requirements, not optional polish. Organize code around stable domain responsibilities and expose the narrowest contract that independent callers need.
+- Put behavior in the layer that owns the decision, not in the nearest caller that happens to need it. Follow the dependency direction in [`ARCHITECTURE.md`](./ARCHITECTURE.md).
+- Keep composition roots thin: construct dependencies, connect lifecycle callbacks, and delegate domain decisions to their owners.
+- Prefer a narrow public facade when a domain has several implementation modules. Re-export only the surface callers need; do not turn barrel files into an implicit global API.
+- Avoid circular dependencies, cross-layer reach-through, and imports of another domain's internal implementation files.
+- Keep dependencies explicit and one-directional. Pass a narrow capability or domain interface instead of an entire application object, manager, context, or unrelated state bundle.
+- Separate policy from transport and persistence, pure projection from mutation, and host runtime state from presentation whenever those concerns can evolve independently.
+- Colocate implementation and domain-specific types in the owning source domain. Place fixtures and focused tests under the corresponding subsystem within the appropriate test layer.
+- Keep provider adapters, host tools, session persistence, and TUI presentation independent. A convenience import is not sufficient reason to cross one of those boundaries.
+- Reuse existing domain constants and normalization functions instead of maintaining parallel arrays, enums, or path rules.
+- Judge an extraction by reduced knowledge and safer independent change, not by the number of files produced. Preserve a cohesive invariant in one owner when splitting it would create chatty or cyclic pseudo-modules.
 
-Model-visible tools are a security boundary.
+## Directory Structure
 
-- Only project-relative paths are allowed.
-- Absolute paths and traversal outside the project root are rejected.
-- Existing path components must not be symbolic links or linked directory junctions. For missing targets, validate the nearest existing ancestor before mutation.
-- Read/list/stat/grep roots: `assets/`, `source_materials/`, `workspace/`,
-  `test_runs/`, `novels/`, `reports/`.
-- Create/write/replace/append/delete/copy-target/move and directory-mutation roots:
-  `source_materials/`, `workspace/`, `test_runs/`, `novels/`, `reports/`.
-- The canonical generated-artifact root set and display order live in
-  `core/artifacts/roots.ts`. Filesystem write guards and artifact workbench
-  discovery must consume that shared constant instead of declaring parallel
-  arrays. `source_materials/` is a writable research/input root but is not a
-  final artifact root, so `/artifact` discovery and the Artifacts sidebar stay
-  scoped to the other four roots.
-- `read_file` remains UTF-8 text-only. Binary visual inspection uses
-  `view_image`, which shares the readable-root path guard, validates image
-  magic bytes and size, and emits a structured attachment instead of base64
-  tool text.
-- `delete_file` must delete only files, never directories or directory trees.
-- `list_directory` exposes files, directories, and symbolic-link entries without following links. Recursive listings are bounded.
-- `create_directory`, `move_directory`, and `delete_directory` operate only below writable roots; the fixed roots themselves cannot be created, moved, or deleted.
-- `delete_directory` deletes empty directories only. Recursive directory deletion is intentionally not model-visible.
-- `grep_files` regex mode is for trusted single-user model input. If Vesicle
-  ever exposes untrusted model/plugin input, regex matching needs a timeout
-  boundary such as RE2 or a worker-thread sandbox.
-- A model must not claim a file was created, written, edited, deleted, copied,
-  or moved unless the corresponding file tool returned success.
-- The `request_confirmation` gate tool is attached only when the active engine
-  profile declares at least one stop gate. Undeclared gates are refused with a
-  tool result, not paused — the model self-corrects on the next turn.
-- The `request_engine_switch` handoff tool is available to all engines. It is
-  a user-confirmed host workflow boundary, not a normal tool side effect:
-  confirmed switches update future turns and must not continue the same tool
-  loop under a different system prompt. Rejected switches must complete the
-  tool call and continue the current engine loop so the model can respond to
-  the user's feedback or ask for clarification when no feedback was supplied.
-- Engine switches use one host-level transition shape whether they come from
-  manual `/engine` commands or model-requested `request_engine_switch`
-  handoffs. Confirmed/in-session transitions may append a bounded user-role
-  `engine_handoff` packet to the conversation instead of adding a dynamic
-  history `system` message or modifying the composed system prompt. This keeps
-  the packet visible to OpenAI-compatible, Anthropic Messages, and Gemini
-  adapters while preserving the engine prompt as the stable prefix-cache
-  boundary. Runtime behavior defaults to full-context preservation; manual
-  `/engine <id> --summary [notes]` compacts first, and model-requested
-  handoffs can use the confirmation panel's `Confirm with summary` option.
-  Both record the transition as `contextPolicy: summary`. The `fresh` policy
-  remains reserved for a future explicit context-discard workflow.
-- The `ask_user_question` tool is available to all engines for one
-  user-facing single-select clarification question. The model supplies 2-4
-  concrete options; the host appends Skip and open-ended answer fallbacks while
-  preserving the model option order. The open-ended fallback exposes an inline
-  composer and continues the current engine loop after the user chooses,
-  unlike engine handoff. Do not collapse Skip and open-ended answer: neither is
-  semantically equivalent to gate rejection.
-- `web_search`, `web_fetch`, `web_map`, `web_crawl`, and `web_research` are
-  host-executed Tavily web tools, not provider adapter features. Attach them
-  only to research/audit engines that declare them, keep provider adapters
-  unaware of Tavily, and persist structured `webEvent` metadata for replay. Web
-  results do not mutate project files; engines must use file tools to write
-  synthesized notes under `source_materials/`.
-- MCP tools are host-executed external tools configured in user-level
-  `mcp.yaml` beside `providers.yaml`, or by `VESICLE_MCP_FILE`. Header values
-  may use `${ENV_VAR}` or `${ENV_VAR:-fallback}` placeholders that expand from
-  the sibling `.env` loaded for provider/Tavily secrets. Do not log or persist
-  resolved header values. The first runtime milestone supports Streamable HTTP
-  `tools/list` and `tools/call` only; stdio, classic HTTP+SSE, prompts, and
-  resources remain separate future work.
-- Tool-loop ceilings protect against genuinely stuck models, not against a
-  model that legitimately chains many tool calls. The breaker fires on
-  consecutive *failing* tool rounds, not on raw tool count.
+Flat directory layouts are discouraged once an area contains distinct domains, abstraction levels, or fixture and support roles. A growing heterogeneous directory makes ownership ambiguous, encourages generic naming, and turns proximity into an accidental dependency rule.
 
-Add tests when adding or changing a tool. Include both the successful behavior
-and the boundary check that prevents overreach.
+- Place a new file in the narrowest existing domain directory that owns its behavior. When a stable new domain has several related files, create a named directory instead of adding more unrelated peers to a crowded root.
+- Keep directory roots for deliberate entry points, public facades, registries, and a small set of genuinely peer modules. Do not use a root as a catch-all because choosing a domain is inconvenient.
+- Avoid taxonomy theatre: a directory containing one trivial file or layers of pass-through re-exports is not useful modularization.
+- Shared directories such as `tests/support/` contain cross-domain infrastructure with a clear reusable contract, not miscellaneous helpers or fixtures that merely lack an owner.
+- Tests use a level-first, domain-second structure: `unit/`, `component/`, `integration/`, `contract/`, and `acceptance/`, followed by the subsystem under test. System and release smoke may live in `scripts/` and CI when that is the real execution boundary.
+- Test fixtures belong under the nearest suite or domain that owns their meaning. Promote a fixture or helper to shared support only after independent domains genuinely reuse the same contract.
 
-## Tool Permission Runtime
+A small, cohesive directory may remain flat when its files are true peers and further grouping would add navigation without clarifying ownership. A reviewer should block new placement that enlarges a heterogeneous flat root when a stable domain or test-layer boundary is already evident.
 
-- Permission modes control approval friction and never widen the effective tool surface or bypass runtime guards. MANUAL asks for every model-visible execution, INERTIA auto-allows observation tools, MOMENTUM auto-allows every tool except `shell_exec`, and YOLO auto-allows all effective tools.
-- `request_confirmation`, `request_engine_switch`, and `ask_user_question` are interaction requests and remain outside Tool Permission Runtime. Gates continue to represent workflow discipline rather than security approval.
-- Unknown tools fail closed into the mutate class. Every provider-returned call is also checked against the current effective tool surface before permission evaluation or execution; a permission mode must never make an unavailable tool executable. Every MCP tool is mutate regardless of its remote name, description, or schema.
-- Permission requests bind to the originating session and tool call. Shell approval additionally binds to the exact normalized execution plan hash. Rejection returns a failed tool result; it does not add a synthetic user turn.
-- Child requests are routed through the parent-owned permission broker. A foreground or background child pauses at its call boundary until the parent TUI resolves the request. Child `shell_exec`, `shell_output`, and `shell_stop` remain disabled in the first runtime.
-- YOLO cannot be persisted as a user default. Interactive activation requires two red confirmations, resume downgrades a prior YOLO session to MOMENTUM, and `--dangerously-skip-permissions` applies only to the current process while keeping a visible red indicator.
-- Permission bypass never disables path guards, MCP/Agent capability scopes, argument validation, output bounds, timeout, environment filtering, process-tree cleanup, or concurrency controls.
-- `shell_exec` is opt-in through user-level `permissions.yaml`. It is a non-interactive host command with host-user filesystem and network authority, not an OS sandbox. Shell mutations must mark checkpoint completeness as tainted and must never be described as rewind-safe.
-- Shell interpreter selection uses host-owned profiles rather than model-provided executables. Resolve the interpreter before approval, bind its profile id, absolute executable path, and runtime policy version into the exact plan hash, and execute that approved plan without a later cross-profile fallback. Windows `auto` may fall back from PowerShell 7 to Windows PowerShell 5.1 only; Linux/WSL `auto` remains `/bin/sh`. Explicit unavailable profiles fail closed. Every profile owns its non-interactive arguments, output encoding policy, display name, and model-visible command dialect guidance.
-- `shell_exec` may set `runInBackground: true` to return a managed short task id immediately. Background output/status is bounded and persisted under ignored `.vesicle/processes/` state, completion is delivered as host-owned provider context at the next available turn, and `shell_output` / `shell_stop` provide explicit observation and cancellation. Background work does not survive a Vesicle host restart as a managed live process; stale running records recover as interrupted and are never replayed.
-- Foreground shell cards show bounded live tail output and elapsed time. Background shell cards retain their task id and terminal state, while active background work remains visible in the TUI header and Workspace sidebar. Observability callbacks must not alter process lifetime or tool results.
+## Types And Contracts
 
-## SubAgent Runtime
+- Model meaningful states with discriminated unions or explicit result types. Do not represent mutually exclusive runtime states with several independent booleans.
+- Keep external input `unknown` until it has been parsed and validated. Validate at provider, filesystem, configuration, session, and model-tool boundaries before passing values into trusted code.
+- Prefer immutable inputs and return values for projections and normalization. Make mutation visible in the owning API when state must change.
+- Preserve protocol and persisted-data compatibility deliberately. A tolerant reader and strict writer are acceptable only when the compatibility rule is explicit and tested at the boundary.
+- Do not expose host paths, secrets, provider-native payloads, or internal identifiers through shared types unless the public contract explicitly requires them.
+- Keep types beside the domain that owns their meaning. Move a type to a shared module only when independent consumers genuinely share the same contract.
 
-- Agent Profiles are logical runtime assets under `assets/agents/`, independent of the six Prism Engine profiles. User-global, Harness-provided, host-provided, and sparse project profiles use one loader. The only hardcoded profile ids are the exact five generic host Agents (`explore`, `general`, `plan`, `research`, and `reviewer`) because they form a security-relevant exemption from Driver delegation; do not expand that whitelist implicitly.
-- Foreground/background controls whether the parent provider loop joins the child. Sequential/parallel is separate: multiple spawn calls from one assistant response must begin before any foreground join is awaited.
-- A foreground child shares parent-turn cancellation but keeps the Bun event loop and TUI responsive. A background child owns an independent controller, returns an accepted handle immediately, and delivers its terminal result through the durable parent inbox.
-- Never append a late result to the original `spawn_agent` tool call. The accepted background handle completes that call; later completion is a host-owned user-role packet delivered by the continuation scheduler when the parent session is idle.
-- `SessionRecord.parentUuid` is only an intra-session branch edge. Persist `parentSessionId` and `parentToolCallId` separately for child ownership.
-- Keep host identity and interaction identity separate. Persist an opaque `runId` for storage/recovery and a parent-scoped `<profile>-<ordinal>` handle for model tools and user commands. Never expose new run UUIDs merely because an internal map or error message uses them; legacy ids remain input-only compatibility references.
-- Render `spawn_agent` as a first-class Agent card rather than a generic tool card. The stream card owns lifecycle/progress, while the header and sidebar retain a compact active/ready summary after the spawn position scrolls away. Background `ready`, `integrating`, and `integrated` are delivery states and must not be conflated with provider execution.
-- Agent `*` inherits the parent's effective tools. An explicit installed profile allowlist may select guarded host tools outside the parent Engine's ordinary surface; MCP tools remain subject to their configured server and Engine scope. Task arguments cannot widen the installed profile.
-- Parallel writers are supported. Claim mutated paths for the lifetime of a child and coordinate parent file-tool mutations through the same ownership table. Ownership conflicts include the same path and ancestor/descendant paths, so a directory-tree mutation cannot overlap a child file mutation. Reject conflicting ownership instead of globally forcing children to be read-only.
-- Parent completion delivery is serialized with user turns, gates, questions, and engine handoffs. Never mutate an in-flight provider request.
+## Control Flow And Errors
 
-See `docs/dev/SUBAGENTS.md` for the complete lifecycle and delivery contract.
+- Return early when it makes the valid path easier to read. Avoid nesting that mixes validation, policy, I/O, and presentation in one block.
+- Catch errors only where the caller can add context, classify the failure, recover, or translate it into a stable boundary result. Do not catch and silently discard unexpected failures.
+- Preserve cancellation as a distinct outcome where the runtime supports it. Do not report user cancellation as provider failure or successful completion.
+- Use domain-specific error types when callers need structured classification; otherwise throw an `Error` with a concise, actionable message.
+- Keep retries, fallback, and fail-soft behavior at the layer that owns their policy. Lower adapters and helpers must not invent host workflow decisions.
+- Make partial success explicit. Never return a success shape when required work was skipped or a durable mutation is uncertain.
 
-## Gate Runtime
+## State And Side Effects
 
-Gates are workflow discipline, not a security permission system. They encode
-"the engine should pause here for human confirmation" — the opposite of a
-coding agent's "should I let this tool run?" prompt.
+- Keep pure parsing, normalization, and projection separate from filesystem, network, process, and session mutations when that separation improves local reasoning.
+- Give durable state one owner. Session records, checkpoints, process metadata, asset locks, and configuration transactions must not be written through competing code paths.
+- Persist the intent or state required for recovery before starting an externally visible continuation that could be interrupted.
+- Use atomic write patterns for host configuration and indexes whose partial state would be invalid. Preserve the domain's concurrency and optimistic-locking rules.
+- Do not hide filesystem, provider, process, or model calls behind names that imply a pure lookup.
+- Keep observability callbacks informational. Logging, progress, and rendering hooks must not change the result or lifetime of the operation they observe.
 
-- A gate is declared in an engine profile's `stopGates` list and triggered by
-  a `request_confirmation` tool call.
-- Engine handoff is triggered by `request_engine_switch` and confirmed through
-  the same Confirm/Reject UI pattern, with an additional Confirm with summary
-  option. It intentionally has no transition allowlist yet; concrete workflow
-  restrictions are deferred.
-- Clarifying questions are triggered by `ask_user_question` and rendered as an
-  option selector with host-owned Skip and open-ended answer fallbacks.
-  Arrow-key selection belongs to the question panel and must not scroll the
-  message history while the panel is active. Keep it distinct from
-  `request_confirmation`; question answers are ordinary information gathering,
-  not workflow gates.
-- The agent loop returns `needs_user` and hands control to the caller (TUI);
-  it does not call back into the UI. Session state is durable, so resume is
-  just reading the session.
-- `resolveGate()` writes the user's decision as the gate tool result and
-  continues the loop. `confirm` advances; `reject` does not advance and either
-  carries user feedback or explicitly asks the model to clarify what should
-  change before retrying.
-- Engines with no declared stop gates never offer the gate tool. A model
-  cannot invent a gate the host did not approve.
-- Interactive resume must preserve unresolved gate state for the TUI. A
-  non-interactive provider resume may synthesize "gate was not resolved" tool
-  results to satisfy Chat Completions tool-call pairing, but the TUI should
-  restore the decision panel when the original `request_confirmation`,
-  `request_engine_switch`, or `ask_user_question` arguments are available.
+## Naming And Source Layout
 
-## Prompt Assets
+- Use domain language consistently across source, types, tests, and documentation. Do not create near-synonyms for the same state or operation.
+- Name booleans and predicates so their truth meaning is clear. Name commands as actions and persisted records as facts that have occurred.
+- Match file names to their primary exported responsibility. A directory may use `index.ts` as a deliberate facade, but substantive behavior belongs in named modules.
+- Keep abbreviations limited to established project or protocol terms such as TUI, MCP, SSE, and HTTP.
+- Remove dead imports, types, helpers, and compatibility branches made obsolete by the current change. Do not perform unrelated cleanup in the same patch.
 
-Prompts are runtime assets, not hardcoded source literals.
+## Comments And Documentation
 
-- Vesicle host rules resolve logically as `assets/prompts/shared/vesicle-base.md` but are physically owned by the restricted `host-assets/` layer.
-- Prism engine prompts live in `assets/prompts/engines/`.
-- Specs and templates under `assets/` are read-only references for the model.
-- Host-specific references such as Codex, Claude Code, RooCode, `AGENTS.md`,
-  `CLAUDE.md`, `ask_followup_question`, and `new_task` should not leak into
-  Vesicle engine prompts except as negative host-boundary examples.
-- Treat `assets/...` as a logical read-only namespace, not as one physical project directory. Resolution order is sparse project override, user-global override, then one complete verified baseline: either a project-pinned managed Harness or the packaged/standalone bundled V10 Harness. The restricted host layer may supply only declared external host assets and the fixed generic Agent whitelist; directories merge only within the selected resolution stack.
-- Profile/prompt loaders and model-visible read tools must consume the same asset resolver. Never let the model receive APPDATA, home-directory, `node_modules`, executable, or Bun virtual filesystem paths.
-- Standalone executables must preserve the invocation cwd as the project root. Resolve executable-owned runtime/default files explicitly through `process.execPath`; do not call `process.chdir()` to make asset lookup work.
-- Session roots record a content-only fingerprint of the effective merged asset tree. Resume and active continuation warn when that fingerprint changes, while keeping prompt text, user content, absolute paths, and secrets out of drift metadata.
-- Sparse overrides are the recommended editing contract. Full snapshots remain available for compatibility but can mask future packaged updates. Version 1 intentionally has no deletion tombstones.
-
-## Persistent Instructions
-
-Persistent Instructions are user-authored Markdown that customizes an Engine's
-workflow and survives new sessions. The host loads them into the system prompt
-automatically; the user never has to ask the model to write a spec to a file
-and remind it to read it next session. This is model context, not automatic
-memory: the host never infers, summarizes, or writes instructions without a
-model tool call or a direct user edit.
-
-- File names are Vesicle-native and aligned across both scopes: `VESICLE.md`
-  (general, every Engine) and `VESICLE.<engine>.md` (Engine-specific override),
-  where `<engine>` is one of the `engineIds`. They are the Vesicle analog of a
-  coding agent's `CLAUDE.md`/`AGENTS.md`. The host must not auto-load those
-  aliases, inject coding-agent identity, or name them in Prism engine prompts or
-  the instruction envelope preamble. User-authored instruction text is preserved
-  verbatim (byte-exact apart from one stripped BOM) and may mention anything —
-  the boundary is on what the host names and loads, not on user content.
-- Project scope lives at the launch project root and travels with the project.
-  User scope lives beside `providers.yaml` (resolved through `userConfigDirectory`),
-  so it applies across every project root. Both are outside the guarded `assets/`
-  namespace and the writable artifact roots; instruction resolution must not be
-  routed through `core/tools/file/path-policy.ts` or the asset resolver, and must
-  not perturb the Harness asset fingerprint.
-- Resolution is **replacement within a scope, composition across scopes**. Within
-  one scope, an Engine-specific target fully replaces that scope's general target;
-  file existence — not nonempty content — controls replacement, so an empty Engine
-  file is an intentional empty override that suppresses general fallback. If an
-  Engine-specific file is present but invalid, fallback to the general file is
-  suppressed for that scope. Across scopes, the selected user file is followed by
-  the selected project file; project content has higher precedence on a direct
-  conflict. Neither can override the Engine contract or host runtime.
-- Instructions are appended after the byte-identical Engine prompt as ordered host
-  context, never as a second system authority. A fixed host preamble frames each
-  block with its scope, target, precedence, and the capability boundary. The
-  Engine prompt stays first so provider prefix caching keeps the stable Harness
-  prefix; Stage character context follows Persistent Instructions. Every
-  system-prompt construction site — turn bootstrap, continuation context, Stage
-  bootstrap, `/compact`, and the `/btw` snapshot resolver — composes through one
-  primitive, while continuations, the provider round, side-question projection,
-  and fork children inherit the already-composed string.
-- Persistent Instructions are live user configuration, not session identity.
-  The host resolves the active Engine selection from current disk when a
-  top-level turn begins, when a session is resumed after a process restart, and
-  on a confirmed Engine switch. Within a single turn the selection is frozen:
-  an in-process continuation (gate/permission/question/quality) reuses the
-  turn-start instruction blocks instead of re-reading disk, so a tool call
-  decided under one instruction set never continues under another after a
-  mid-turn pause. The frozen snapshot is in-process only; a Vesicle restart
-  loses it, so a resumed continuation re-reads current disk, and a new top-level
-  turn re-resolves and overwrites it. Editing an instruction file is a
-  configuration update that takes effect on the next turn, never mid-turn.
-- Validation is fail-soft per scope: decode UTF-8 with fatal error handling
-  (strip one leading BOM), require a regular file, reject a project target that
-  is a symbolic link and skip a user-scope link, and bound the combined selected
-  content to 32 KiB. An invalid, linked, or oversized scope is skipped with a
-  diagnostic while the rest of the turn continues; content is never truncated and
-  the turn is never blocked by optional instruction state. Never log instruction
-  contents; diagnostics and session audit use target, bytes, and hash only.
-- Targets are identified by a fixed enum `{ scope, engine }` and never by an
-  arbitrary path. Instruction text cannot widen the effective tool surface,
-  permission mode, path roots, stop gates, validators, Harness identity, or
-  provider configuration; the tool runtime enforces capabilities independently.
-- `read_instructions` and `update_instructions` are the model-visible surface for
-  Persistent Instructions, available on every Engine except Stage (Stage stays
-  strictly tool-less — its consumer-RP role does not benefit from
-  self-management of host configuration). `read_instructions` is an observation;
-  `update_instructions` is a mutation. They resolve only the fixed `{ scope,
-  engine }` target — never an arbitrary path — so they are a bounded host
-  exception that writes outside the model-visible writable roots, not a widened
-  filesystem surface. `update_instructions` writes atomically (temp + rename),
-  keeps one recoverable previous-state backup per target under
-  `.vesicle/instruction-backups/` (project) or beside `providers.yaml` (user),
-  honors optional `ifMatchSha256` optimistic concurrency (`"absent"` or a 64-hex
-  hash; a stale value never overwrites), and rejects any write whose new content
-  plus the other scope would exceed the 32 KiB budget for an Engine it affects.
-  It routes through the existing Tool Permission Runtime as an ordinary
-  `mutate` (MANUAL/INERTIA pause, MOMENTUM/YOLO execute) — never a second
-  approval system. These host-configuration writes are deliberately outside the
-  guarded file-checkpoint ledger: `/rewind` may remove their tool records from
-  the conversation but never restores the target file. The tool result must name
-  the single previous-state backup and identify recovery as manual. A successful
-  update is the one mid-turn reason to recompose:
-  it refreshes the in-turn frozen instruction snapshot so the next provider round
-  of the same turn observes the new content. The tools are for explicit,
-  user-requested persistent workflow management, not autonomous self-modification.
-- `/init` is the direct host action for drafting the general project target. It
-  must refuse an existing `VESICLE.md` before calling a provider unless the user
-  supplies `--force`; the forced path backs up the existing file under
-  `.vesicle/init-backups/`. A non-forced write must also fail if the target
-  appears while the provider request is in flight, so a long generation cannot
-  race an external edit into an overwrite.
-
-## Skills Runtime
-
-A Skill is on-demand procedural context plus bundled resources in the open
-Agent Skills `SKILL.md` format. It is never an Engine, Agent Profile, MCP
-server, or permission grant; it may contain instructions, references, assets,
-and scripts. A Skill cannot itself widen the effective tool surface. Actions it
-requests use the capabilities and permission mode the user already selected. See
-[`docs/dev/SKILLS.md`](./SKILLS.md) for the full boundary and
-`dev/docs/working/SKILLS_RUNTIME_RESEARCH_AND_FEASIBILITY.md` for the approved
-implementation plan and research basis.
-
-- Phase 0 delivers format, inventory, and the Skill Store only. There is no
-  model-visible activation: no `activate_skill` / `read_skill_resource` tools,
-  no `/skill` command, and no prompt-composition, session, compaction, or
-  Engine-switch changes. Repository install commands, the activation/runtime
-  surface, project `.agents/skills/` scope, and script execution are later
-  phases; scripts join activation in Phase 2 rather than a separate privileged
-  plugin tier.
-- Discovery is bounded to two deterministic, non-merging scopes: the verified
-  Harness under logical `assets/skills/` (resolved through the active asset
-  resolver) and the user configuration directory's `skills/`. Project,
-  host-bundled, and installed-store scopes are reserved for later phases and are
-  not scanned today. The `skills/` module takes pre-resolved roots and must not
-  import the asset resolver, providers, harness runtime, or TUI; the CLI owns
-  Harness-root resolution.
-- On a name collision, exactly one winner is selected by scope precedence
-  (`user` outranks `harness`) and lower-precedence entries are reported as
-  shadowed. Bodies and resources are never merged. Catalog and diagnostic shapes
-  never carry an absolute host path: only logical source scopes and
-  skill-relative paths are surfaced.
-- Parsing is strict and fail-soft. One malformed Skill is skipped with a
-  diagnostic while valid siblings remain available. The experimental standard
-  `allowed-tools` field is parsed but never enforced; the Tool Permission Runtime
-  remains the only tool-approval authority. Unknown frontmatter fields are
-  preserved for inspection but have no runtime behavior.
-- Explicit installation is the user's choice to make a Skill available. Source,
-  resolved version, bundled scripts, declared requirements, and material risks
-  must be visible, but warnings do not create a separate trust state or
-  Skill-specific approval layer. Script actions use the existing Process and
-  Tool Permission Runtime behavior for the current Engine and permission mode.
-- Supporting resources live behind a virtual Skill root: every path is
-  skill-relative, shallow, and resolved only inside that root. Absolute paths,
-  `..` escapes, backslashes, NUL, empty/dot segments, symbolic links, devices,
-  and sockets are rejected so a Skill cannot read arbitrary host files.
-- The Skill Store keeps immutable, content-addressed snapshots under
-  `<user-config>/skill-store/<name>/<version>/` (a byte-exact standard bundle)
-  plus a sibling provenance sidecar and a small active index. Snapshots are
-  staged, re-verified by hash, and atomically renamed; reinstalling identical
-  content is idempotent by bundle hash, and the stored copy never remains a live
-  dependency on its source path.
-
-## Managed Harness Packs
-
-- Neural Narratology Harness Packs are independently versioned runtime products. Vesicle must consume a released pack or explicit local pack directory; runtime code and tests must not read a sibling checkout, follow cross-repository symlinks, or embed local source paths.
-- `core/harness` owns strict `prism-harness-pack/v1` parsing, file inventory and hash verification, Adapter/capability compatibility, Profile/Prompt binding checks, external host asset checks, and immutable installation under the user configuration directory.
-- Compatibility is fail-closed. Do not advertise a capability until Vesicle enforces its full host contract; in particular, generic SubAgent availability is not sufficient for contract-bound `prism-agent/delegation@1`, and prompt guidance is not a substitute for `quality-guard/anti-ai-flavor@1`.
-- Contract-bound delegation is a Driver Adapter over the generic SubAgent runtime. Resolve a unique delegation from the active parent Engine and requested Agent Profile, then bind mode, purpose, and retry limit from the verified Driver Contract. Model arguments may provide the self-contained `prompt` and a display label but must not widen those bindings. Harness delegations are sequential within one parent session; transient failures consume the declared retry budget, while exhaustion creates the Contract-declared, append-only, resumable user decision point. A user-authorized extra retry must persist its intent before resolving that decision; if restart cannot restore the same verified Harness context, session resume blocks instead of silently dropping or replaying the retry.
-- Delegation failures use the Driver ABI categories `unsupported`, `invalid_request`, `denied`, `not_found`, `conflict`, `transient`, and `failed`. Persist the delegation id, Agent Profile, mode, attempt history, category, and terminal result in session metadata. Cancellation is terminal and does not consume or silently restart a retry.
-- `core/quality` owns the host Output Quality Guard. Load Rule Pack and Detector assets only from a verified Harness directory, check their inner artifact hashes and published schema contracts, normalize CRLF/CR to LF plus Unicode NFC, and preserve normalized-candidate UTF-16 offsets while masking fenced code, blockquotes, HTML comments, Prism HUD and host-provided protected ranges. Unknown matcher, metric, preprocessing, schema, or binding semantics fail closed; the first host does not claim `strict` mode.
-- Harness `qualityBindings` and `agentQualityBindings` are delivery policy, not permissions or Validators. Artifact targets come only from successful create/write/replace/append `FileToolEvent` records, are keyed by normalized project-relative path, and are evaluated from the complete current UTF-8 post-image through the same writable-path and symlink guards as file tools. A later successful mutation supersedes the same target without clearing its rejected hash history; clean prose or another clean path cannot resolve a blocking target. Runtime `rewrite` buffers prose, keeps rejected candidates out of the displayed transcript, returns target-specific structured findings to the same Engine, allows at most two shared rewrite rounds, and stops when a blocking target repeats its post-image hash. Quality feedback, per-target pending state, pack/rule identity and bounded events must persist before another provider request so permission pauses, cancellation, or restart cannot silently bypass the Guard.
-- Quality assessment, policy outcome, and host action are separate durable concepts. New `QualityEvent` records retain the legacy decision projection while adding the policy version, outcome/action, and bounded per-target finding summaries. Exhaustion is a `needs_quality_decision` pause backed by append-only warning, retry-intent, and resolution records; it must not be overwritten by ordinary completion or a simultaneous gate. Retry permits exactly one user-authorized provider continuation under the same Engine, Harness, manifest, and Rule Pack identity. Accept and stop do not call the provider, retain target warnings, and restore any lower-priority gate or question. Cancellation or provider failure leaves the same decision recoverable. Unreadable, non-UTF-8, and over-budget post-images are inconclusive warnings rather than clean results, and only an explicit user resolution or a later clean assessment of the same target may close a warning.
-- `observe` records deterministic findings without blocking Dyad, Weaver, Weaver-Orch or Scene Writer. Scene Writer observation runs in the child session before terminal delivery to the parent. `analyze` bindings for Evaluate and Chapter Reviewer describe their own audit role and are excluded from recursive Guard enforcement; a future model-visible analysis tool is a separate capability.
-- Explicit tool allowlists in released Harness Agent Profiles may reference only Vesicle built-in host tools, so packs remain portable across projects. Runtime-local MCP or parent-provided tools are not valid explicit pack dependencies; wildcard inheritance remains subject to the runtime child-tool scope.
-- `/permissions` is the only ask/allow/deny layer for model-visible tool calls. Harness and HAL declare capabilities and map operations; they must not duplicate permission prompts or require a second per-delegation path-authorization system. Agent Profiles narrow the effective tool surface, while Tool Runtime continues to enforce path, symlink, concurrency, timeout, environment, and process invariants independently of permission mode.
-- Installation and activation are separate. The installer accepts an already-extracted directory, verifies it before and after staging, and atomically renames it into `asset-packs/<id>/<version>/`; explicit activation reverifies that immutable directory and atomically writes `.vesicle/assets.lock.json` without mutating editable user assets.
-- The bundled V10 Harness is a first-class verified Pack selected automatically when no project lock exists. Its root `harness-manifest.json` and exact `assets/` inventory must be verified before runtime construction; project/user overrides are excluded from that integrity check.
-- A selected managed Harness is one complete baseline, not another sparse fallback layer. Project and user overrides may remain above it, but a missing pack file must not fall through to the bundled Pack unless the manifest declares that exact logical path in `externalHostAssets`. Removing a project lock returns to the whole bundled V10 baseline.
-- The three Harness workflow Agents remain Driver-contract Agents. Only the exact five generic host Agent ids may use the ordinary concurrent SubAgent path while a Harness is active. Arbitrary project/user Agent Profiles must not use the host exemption and must fail closed when the Driver Contract does not declare a matching delegation.
-- Project locks and initial session host metadata persist pack id/version, source commit, manifest hash, and Adapter identity. Every start and resume reverifies the active bundled or managed Pack and requires exact session/project identity; missing, malformed, tampered, rolled-back, or switched identities block provider continuation instead of silently changing Harness content. A persisted quality decision may still be opened under identity drift so the user can accept or stop locally, but retry remains disabled until the exact recorded Harness and Rule Pack identity is restored. Sessions created before bundled V10 activation intentionally fail this identity check and require a new session.
-
-## Session Semantics
-
-- One interactive TUI run should reuse one active session until the user starts
-  or resumes another session.
-- JSONL records are append-only.
-- Image bytes live in the ignored content-addressed
-  `.vesicle/attachments/` store. Session JSONL persists attachment ids,
-  hashes, MIME types, sizes, and relative storage/source paths, never base64
-  image payloads.
-- Conversational records carry stable `uuid` and `parentUuid` links. Rewind
-  moves the in-memory head and lets the next persisted record create a new
-  branch; it must not truncate or rewrite JSONL. Legacy linear records are
-  projected as an implicit parent chain when read.
-- A real user prompt owns the file checkpoint for the work it initiates.
-  Mutation tools must capture every affected writable path before changing it;
-  checkpoint metadata remains host-only and must not enter provider messages.
-- Checkpoints preserve absent paths, files, and directory topology. Directory-tree moves must capture the source tree and target path so rewind can restore empty directories as well as file content.
-- Provider requests must include prior user/assistant turns when continuing a
-  session.
-- A user turn whose provider round fails before any assistant reply is marked
-  with a host-only `failed-turn` system record appended after the persisted
-  prompt (issue #98 deliberately keeps the prompt in the transcript). History
-  projection drops the failed round's trailing user input — the prompt plus any
-  host-injected user input such as background-process results or a
-  quality-rewrite feedback — from provider-visible messages, so resuming or
-  resending cannot emit consecutive same-role user messages that Anthropic
-  Messages would reject. A `/compact` summary is the sole completed-operation
-  boundary that survives the marker; everything else trailing is the failed
-  round's own input. The prompt stays in `records` for the transcript and
-  `/rewind`, where it is shown as a no-reply ghost. A mid-loop failure (an
-  assistant already replied) leaves a valid alternation tail and is not marked.
-  Failed *continuation* rounds (gate, user-question, engine-switch, permission
-  resolutions) are not yet reconciled — they append a tool result too, which can
-  still surface as a consecutive-user error on resume.
-- Response usage metadata is host-only. It may be persisted on assistant
-  records and restored for TUI footer display, but must not be forwarded back
-  to providers as part of resumed `VesicleMessage` request history.
-- Tool calls and tool results should be persisted for replay/debugging.
-- Successful filesystem tool results should persist structured `fileEvent`
-  metadata on the session tool record. Callers may use this for artifact
-  audit/ledger views without parsing natural-language tool result text.
-  In `fileEvent`, `bytes` means the resulting or observed file size, and for
-  `delete_file` it means the deleted file size. Successful create/write/replace/append results also include the SHA-256 of the complete resulting file. `append_file` may also report
-  `deltaBytes`; `list_files` and `list_directory` report `entryCount`; `grep_files` reports
-  `matches`.
-- User-selected reasoning tiers should be persisted as session metadata so
-  interactive resume restores runtime generation behavior. Provider
-  thinking state is preserved as thinking blocks for protocol continuity and
-  TUI display, but it is metadata and must not be merged into normal assistant
-  prose. OpenAI-compatible `reasoning_content` is a compatibility bridge into
-  that block structure.
-- User-selected engine profiles should be persisted as session metadata so
-  interactive resume restores which Prism workflow profile future turns and
-  gate resolution should use.
-- Engine handoff packets are user-role provider context with host metadata
-  `kind: engine-handoff`. Resume should pass them back to providers as normal
-  user messages for protocol compatibility, but the TUI should render them as
-  host/system notices, and rewind/user-turn accounting must not treat them as
-  authored prompts.
-- Compact summaries are user-role provider context with host metadata
-  `kind: compact-summary`. Manual `/compact` and automatic compaction install one
-  atomic system-role `compact-checkpoint-v1` record (the durable replacement
-  authority) appended to the current active head — they do not delete old records
-  or re-parent to the session root. The checkpoint carries a validated
-  `PortableCompactCheckpointV1` payload: a portable summary of the evicted prefix
-  plus a verbatim retained recent tail plus, mid-turn, the active frontier. The
-  original append-only transcript stays intact above the checkpoint for the
-  transcript, `/rewind`, and audit; provider-visible history resets at the newest
-  valid checkpoint and replays its suffix, and an unknown future version or
-  malformed v1 fails with an actionable session error instead of partially
-  projecting. The selected-pivot `/rewind` summary keeps its separate
-  `compact-summary` branch behavior. Resume passes the replacement back to
-  providers; the TUI renders summaries as host/system notices and keeps a
-  `compact-summary` display kind so the empty-session Hero never reappears over a
-  compacted transcript; rewind/user-turn accounting skips summaries as authored
-  prompts. Records carry durable `logicalTurnId` / `providerRoundId` identity
-  (one stable id per top-level Agent Loop, one per complete provider/tool round)
-  so compaction can evict only complete units and never split a tool call from
-  its result; legacy records without identity are grouped conservatively.
-- Automatic compaction is opt-in and provider-neutral. It activates only when
-  `limits.autoCompact` exists, `enabled !== false`, `threshold ∈ (0,1)`, and
-  `contextWindow` is a positive integer; there is no hidden default threshold.
-  `softTrigger = floor(min(contextWindow·threshold, contextWindow − reserve))`
-  and `hardInputCeiling = contextWindow − reserve`, with reserve precedence
-  `reserveOutputTokens` → effective turn `maxTokens` → `limits.maxOutputTokens`
-  → 0. Provider configuration rejects statically known reserves that leave no
-  positive input budget. The primary oracle is the most recent provider
-  `contextInputTokens`, paired with the host estimate of that exact request;
-  the next projection adds only host-estimated growth after that observation.
-  The fallback estimate includes the current system prompt, messages, tool-call
-  envelopes, and full active tool schema (`ceil(utf8/2)` plus overhead); base64
-  image materialization remains excluded and therefore approximate. Estimates
-  are labeled, never reported as provider-confirmed protection. A pre-turn check compacts an existing session
-  before the new user record persists; a mid-turn soft check runs after a
-  complete tool batch and a hard check runs after queued/background input is
-  materialized, before the next request. A soft-trigger failure keeps the old
-  head and continues; a hard-ceiling failure or insufficient reduction blocks
-  the request without mutating the session and restores the draft. The compact
-  provider request is a standalone call (never a bootstrap/loop turn), so it
-  cannot recurse; at most one compact runs per boundary; after success the
-  in-memory message array is rebound to the post-checkpoint history. Before the
-  checkpoint append, the exact replacement request is re-estimated and rejected
-  if it does not reduce the request or still exceeds the hard ceiling.
-  Cancellation is distinct from failure.
-  New sessions and Stage skip the pre-turn check; unresolved interactions defer
-  compaction but their resumed first provider request still passes the exact send
-  guard. `/context` reports the configured window, latest provider usage or its
-  absence, the activation state with the precise reason when inactive, the
-  effective soft/hard limits, the reserve and its source, the active strategy,
-  and any deferred/degraded state.
-- Session lists should mark unresolved gates and interrupted or exhausted quality decisions so the user can distinguish a normal transcript from a workflow waiting for confirmation or quality recovery.
-- Long-running turns should emit host-visible activity events before and after
-  provider requests, tool calls, gate pauses, and validation. Provider
-  streaming should emit assistant deltas as they arrive while still
-  reconstructing a final provider response for session replay.
-
-## Validation Semantics
-
-- Profile validators check Prism artifact documents, not every assistant turn.
-- Ordinary phase-transition prose such as "confirmed, moving to Phase 1" must
-  not be reported as a Module A/B schema failure.
-- Artifact-shaped assistant content starts with YAML frontmatter. Artifact
-  workbench validation reads the selected artifact file from disk before
-  presenting findings, so validation reflects what was actually written rather
-  than only the last assistant message.
-
-## TUI Interaction
-
-- Keep the surface dense and operational.
-- The layout must remain readable at 80 columns. Hide secondary panes before
-  squeezing the message stream below a useful width.
-- Gate and picker panels own the bottom area while active; side panes may be
-  hidden during those modes so confirmation controls stay legible.
-- Artifact previews belong in the message stream as bounded, structure-
-  preserving cards. The sidebar is an index, not a second preview surface.
-- Markdown extension and LaTeX cleanup is a TUI display concern. Keep
-  terminal-readable formula conversion and static formatting fallbacks outside
-  fenced code blocks, and do not mutate session records, provider messages, or
-  artifact files for rendering-only cleanup. Prefer readable static fallbacks
-  for terminal-hostile constructs such as images and disclosure widgets instead
-  of pretending they are interactive.
-- Avoid shape-near command pairs such as singular/plural twins. Prefer one
-  canonical command that inspects or lists without arguments and acts when an
-  argument is present: `/artifact [n|path]` and `/engine [id]` follow this
-  contract.
-- Use `/effort` for provider generation effort and `/reasoning` for reasoning
-  visibility. Do not give `/engine` a `workflow` alias; that command name is
-  reserved for a future host-owned workflow surface.
-- `/rewind` and empty-input double Esc must open the same selector. The picker
-  defaults to a virtual `(current)` row, selects only authored user prompts,
-  and restores to immediately before the chosen prompt. Keep `/checkpoint` as
-  the Claude Code compatibility alias; do not introduce additional rewind
-  synonyms.
-- `/compact [notes]` is the standalone active-session compaction command. It
-  may call the provider, but it must not expose tools to the summarization
-  request. Keep optional custom instructions as plain text appended to the
-  compaction prompt.
-- `/btw <question>` is a one-shot, tool-free side question over the current
-  conversation. It is `immediate` because it copies the immutable
-  `SideQuestionContextSnapshot` published before each main provider request
-  (never a half-written tool round) and sends one no-tools request through a
-  side-specific AbortController independent of the main turn. The request has
-  exactly one system authority — the dedicated `assets/prompts/shared/side-question.md`
-  — and one user message: a host-rendered reference packet that quotes the
-  parent Engine prompt, the conversation, and tool results verbatim as inert
-  reference data (`src/core/side-question/reference.ts`). Parent workflow
-  intent, tool protocol (`toolCalls`/`toolCallId`/tool-role messages),
-  reasoning, and thinking blocks never become active side instructions or
-  provider protocol fields; inherited images stay reference-only in the
-  snapshot and materialize on the single user packet for vision models. No
-  tools are declared, and any structured tool call in the response (including
-  mixed text-plus-tool) fails the exchange. Side exchanges are in-memory only:
-  they must never enter session JSONL, the main `conversation()` value, the
-  visible transcript, checkpoints, validators, gates, permissions, or tool
-  execution, and must not cancel or fail the main Agent Loop. The side overlay
-  is visual priority only — a gate, permission, or question the main loop
-  raises while it is open stays pending and appears on dismissal. Bare `/btw`
-  reopens the latest in-memory exchange for the current session; with no prior
-  exchange it returns to the composer with a usage hint.
-- Escape uses an 800ms double-press window: empty input opens rewind, non-empty
-  input saves and clears the draft, and an in-flight request is aborted. Active
-  modal panels consume Escape before the prompt-level handler.
-- Provider/model switching commands and artifact workbench commands are local
-  host actions. They should add concise host notices to the transcript and must
-  not call the provider.
-- Opening rewind and restoring checkpoints are host actions. Only `/compact`
-  and the explicit `Summarize from here` restore option call the active
-  provider.
-- Slash commands with fixed argument enums should expose those values through
-  the shared argument-completion popup instead of requiring memorized input.
-  Keep completion values sourced from the runtime enum where one exists, and
-  preserve parser aliases while completing to canonical values.
-- See [`COMMAND_COMPLETION.md`](./COMMAND_COMPLETION.md) for the command-owned
-  registration contract, dynamic candidate rules, and required regression
-  coverage for slash-command argument completion.
-- Main prompt editing should go through Vesicle's host-owned composer layer,
-  not directly through OpenTUI's single-line `<input>`. Keep the core keyboard
-  semantics aligned with Claude Code's prompt input model: ordinary editing
-  keys never interrupt a running turn, `Ctrl+Enter` inserts a newline,
-  `Shift+Enter` is inert when reported distinctly, plain Enter submits, and
-  Up/Down first move within soft-wrapped or explicit multiline drafts before
-  falling back to history. The render layer should own visual wrapping,
-  cursor-following viewport selection, and adaptive composer height; the
-  keyboard state machine should stay focused on text mutation and submit/
-  history actions. Trailing backslash+Enter remains a compatibility newline
-  fallback for terminals that cannot distinguish modified Enter keys.
-- Reasoning content should follow the RikkaHub-style pattern of a separate
-  thinking block before assistant text: it is independent from the assistant
-  markdown body, collapsible or hideable, and bounded by height/tail display so
-  long thinking does not dominate the transcript.
-- Ctrl+C behavior:
-  - With a selectable OpenTUI range, copy selection.
-  - Without a selection, first press arms exit and the second press exits.
-  - Use `renderer.destroy()` for real shutdown.
-- Avoid changing layout dimensions based on dynamic text when possible.
+- Comment invariants, non-obvious compatibility constraints, and reasons a tempting alternative is unsafe. Do not narrate syntax or restate the function name.
+- Keep comments accurate when behavior changes; stale rationale is worse than no comment.
+- Public docs must not contain secrets, absolute local paths, or references that require an ignored local document to understand the supported contract.
+- Markdown prose uses natural line wrapping: keep each paragraph or list item on one source line unless Markdown structure or meaning requires a break.
+- Update the authoritative domain document when a boundary changes. Prefer a link over copying the same detailed contract into several documents.
 
 ## Tests
 
-Use Bun tests under `tests/`.
+- Add or change tests only when they protect a user-visible behavior, security or durability boundary, external contract, or plausible regression not already covered at the appropriate layer.
+- State the defect the test would catch and use an oracle derived from the product or protocol contract rather than the current implementation's statement order or source text.
+- Prefer the narrowest existing test layer that can observe the behavior. Use integration, contract, acceptance, PTY, package, or platform smoke coverage when a unit test cannot exercise the real boundary.
+- Treat skipped or unavailable coverage honestly. Do not return early and count an unexecuted conditional test as passing.
+- Refactors should reuse existing coverage unless a risky boundary lacks characterization. Do not preserve incorrect production structure merely to satisfy implementation-locked tests.
 
-Standard checks:
+Verification commands and the change-risk matrix live in [`WORKFLOW.md`](./WORKFLOW.md). Test counts and source line counts are not quality targets.
 
-```bash
-bun run typecheck
-bun test
-```
+## Review Questions
 
-Add focused tests for:
-
-- config and prompt loading
-- session history reuse
-- provider tool-call normalization
-- tool execution and path guards
-- TUI smoke rendering
+- Does each changed module still have one recognizable owner and reason to change?
+- Does the change create or expand a god file, god function, god class, mega-controller, service locator, or broad state bag?
+- Did modularization reduce cross-domain knowledge, or merely distribute the same coupling across more files?
+- Does each new file live in an intentional domain and abstraction-level directory rather than a heterogeneous flat root?
+- Can the behavior be understood and tested without constructing unrelated runtime state?
+- Are external input, side effects, persistence, and cancellation handled at explicit boundaries?
+- Did the change preserve provider, tool, session, prompt, permission, and TUI separation?
+- Is new complexity required by the current behavior, or is it speculative flexibility?
+- Are comments, tests, and domain documentation aligned with the resulting contract?

--- a/docs/dev/SUBAGENTS.md
+++ b/docs/dev/SUBAGENTS.md
@@ -56,8 +56,7 @@ The continuation scheduler serializes all parent provider turns:
 
 1. A child commits its terminal state and inbox result.
 2. If the parent is busy, delivery waits without mutating the in-flight request.
-3. When the parent becomes idle, pending results are coalesced into one
-   host-owned user-role packet.
+3. When the parent becomes idle, pending results are coalesced into one host-owned user-role packet.
 4. The packet is appended durably before the provider continuation starts.
 5. Successful consumption acknowledges the delivered inbox entries.
 

--- a/docs/dev/TOOLS.md
+++ b/docs/dev/TOOLS.md
@@ -1,0 +1,71 @@
+# Tool And Interaction Runtime Contract
+
+This document defines the capability boundary for model-visible tools, external MCP tools, process execution, and host interactions initiated through tool calls.
+
+## Filesystem Tools
+
+- Model-visible filesystem paths are project-relative. Absolute paths and traversal outside the project root are rejected.
+- Existing path components must not be symbolic links or linked directory junctions. Mutations of missing targets validate the nearest existing ancestor.
+- Read, list, stat, and grep operations are limited to `assets/`, `source_materials/`, `workspace/`, `test_runs/`, `novels/`, and `reports/`.
+- File and directory mutations are limited to `source_materials/`, `workspace/`, `test_runs/`, `novels/`, and `reports/`.
+- The canonical final-artifact root set and display order live in `core/artifacts/roots.ts`. `source_materials/` is writable research input but not a final artifact root.
+- `read_file` is UTF-8 text-only. `view_image` uses the same readable-root guard, validates image type and size, and emits a structured attachment rather than base64 tool text.
+- `delete_file` deletes files only. `delete_directory` deletes empty directories only, and fixed writable roots cannot be created, moved, or deleted.
+- Directory listing exposes symbolic-link entries without following them. Recursive operations and outputs remain bounded.
+- Regex grep is accepted only for the current trusted single-user model-input boundary. Exposure to untrusted plugin input requires a bounded regex engine or worker isolation.
+- A model must not claim that a file mutation succeeded unless the corresponding tool result reports success.
+
+## Mutation Records And Checkpoints
+
+- Successful filesystem operations persist structured `FileToolEvent` metadata rather than requiring callers to parse result prose.
+- File-event byte counts describe the resulting or observed file size; deletion records the deleted size, append may also report delta bytes, and query tools report their bounded entry or match counts.
+- Successful create, write, replace, and append operations record the SHA-256 of the complete resulting file.
+- Mutation tools capture every affected writable path before changing it so the owning user turn can restore guarded file state through its checkpoint.
+- The opt-in `shell_exec` tool is outside guarded file-tool authority. Shell mutations taint checkpoint completeness and must never be described as rewind-safe.
+
+## Permission Runtime
+
+- Permission modes change approval friction and never widen the effective tool surface or bypass runtime guards.
+- MANUAL asks for every model-visible execution, INERTIA auto-allows observation tools, MOMENTUM auto-allows every effective tool except `shell_exec`, and YOLO auto-allows all effective tools.
+- Unknown tools fail closed into the mutate class. Every returned call is checked against the active effective tool surface before permission evaluation or execution.
+- MCP tools are classified as mutate regardless of their remote names, descriptions, or schemas.
+- Permission requests bind to the originating session and tool call. Shell approval additionally binds to the exact normalized execution-plan hash.
+- Child tool calls route through the parent-owned permission broker. A foreground or background child pauses at its call boundary until the parent resolves the request; absence of an interactive broker fails closed.
+- Rejection returns a failed tool result and does not create a synthetic user turn.
+- YOLO cannot be persisted as a default. Interactive activation requires explicit high-risk confirmation, resume downgrades a prior YOLO session to MOMENTUM, and `--dangerously-skip-permissions` applies only to the current process.
+- Permission bypass never disables path guards, MCP or Agent scope, argument validation, output bounds, timeouts, environment filtering, process cleanup, or concurrency controls.
+- Warning and confirmation behavior follows [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md); subsystems must not add a second trust or approval system for an action already governed here.
+
+## Process Runtime
+
+- `shell_exec` is opt-in through user-level `permissions.yaml` and has host-user filesystem and network authority. It is not an operating-system sandbox.
+- Shell interpreters are selected from host-owned profiles rather than model-provided executable paths.
+- Resolve the interpreter before approval and bind the profile id, executable path, and runtime-policy version into the approved plan. Do not perform an unapproved cross-profile fallback after approval.
+- Foreground processes expose bounded live tail output and elapsed time without allowing observability callbacks to change process lifetime or results.
+- Background processes return a short managed task id, persist bounded state under ignored `.vesicle/processes/`, and deliver completion as host-owned context at the next available turn.
+- Managed background execution does not survive host restart. Recovery marks stale running records interrupted and never replays their commands.
+
+## Gates, Questions, And Engine Handoffs
+
+- `request_confirmation`, `request_engine_switch`, and `ask_user_question` are interaction requests, not permission checks, and remain outside Tool Permission Runtime.
+- A workflow gate is available only when the active Engine declares its id in `stopGates`. Undeclared gates return a failed tool result instead of pausing.
+- The agent loop returns a durable continuation state to its caller and never calls into TUI rendering. The TUI resolves the interaction and the agent loop persists the tool result before continuation.
+- Gate confirmation advances the declared workflow. Rejection completes the tool call under the current Engine and carries feedback or requests clarification.
+- An Engine handoff changes future turns only. It must not continue the same tool loop under a different system prompt.
+- Manual and model-requested Engine transitions share one host transition shape. Summary transitions compact first; full-context transitions preserve the current context.
+- `ask_user_question` presents one model-authored single-select question with bounded options plus host-owned Skip and open-ended fallbacks. Skip and open-ended input are distinct outcomes.
+- Resume restores unresolved interactions when their original arguments are available. Noninteractive recovery may synthesize bounded unresolved tool results only to preserve provider tool-call pairing.
+
+## Execution Limits
+
+- Tool-loop protection measures consecutive rounds containing failed tool results rather than raw tool-call count, so legitimate multi-tool work is not stopped merely for being long.
+- Tool definitions, arguments, results, concurrent execution, and persisted output remain bounded by their owning runtime contracts.
+
+## Web And MCP Tools
+
+- Tavily web tools are host-executed research tools, not provider adapter features. They persist structured web metadata and do not mutate project files directly.
+- MCP configuration is user-level host state. Secret header values expand from the sibling user `.env` and must not be logged or persisted.
+- MCP discovery and calls are normalized into ordinary host tool definitions and results; provider adapters remain unaware of MCP transport.
+- The effective Engine and server configuration scope MCP availability. Model arguments and permission modes cannot widen that scope.
+
+The current tool inventory belongs in [`STATUS.md`](../../STATUS.md); user-facing shell guidance belongs in the language-mirrored user manual.

--- a/docs/dev/TUI.md
+++ b/docs/dev/TUI.md
@@ -1,0 +1,65 @@
+# TUI Runtime Contract
+
+This document defines terminal layout, input ownership, transcript presentation, local commands, and tool-free side questions. Domain state remains owned by core runtime modules; the TUI renders and resolves it.
+
+## Layout And Ownership
+
+- Keep the surface dense, operational, and readable at 80 columns.
+- Hide secondary panes before squeezing the message stream below a useful width.
+- Gate, permission, question, and picker panels own the bottom area while active. Side panes may be hidden so the active controls remain legible.
+- Artifact previews appear as bounded structure-preserving cards in the message stream. The sidebar is an index rather than a duplicate preview surface.
+- Avoid changing stable layout dimensions from dynamic labels or transient content when a bounded region can scroll, clip, or reserve space.
+- Modal input routing has priority over prompt editing, command completion, history scrolling, and global key handling.
+
+## Rendering
+
+- Markdown extension and LaTeX cleanup are display-only transformations. They must not mutate session records, provider messages, or artifact files.
+- Rendering cleanup must stay outside fenced code blocks and use readable static fallbacks for terminal-hostile constructs.
+- Thinking content renders separately from assistant prose, before the assistant body, with bounded or collapsible presentation.
+- Tool, Agent, validation, quality, and host-action records render from structured state rather than parsing natural-language result text.
+- Theme changes refresh mounted renderables whose colors are not reactively inherited from the root palette.
+
+## Prompt Editing And Keys
+
+- Main prompt editing goes through the host-owned composer rather than OpenTUI's single-line input component.
+- Ordinary editing keys never interrupt an active turn. Plain Enter submits, `Ctrl+Enter` inserts a newline, and distinctly reported `Shift+Enter` remains inert.
+- Up and Down move within soft-wrapped or explicit multiline drafts before falling back to prompt history.
+- The render layer owns visual wrapping, cursor-following viewport selection, and adaptive composer height; the keyboard state machine owns text mutation, submission, and history actions.
+- Trailing backslash plus Enter remains a compatibility newline fallback for terminals that cannot distinguish modified Enter.
+- Escape dispatches to the active modal first. At prompt level, the bounded double-press behavior distinguishes rewind, draft clearing, and request cancellation.
+- `Ctrl+C` copies an active OpenTUI selection. Without a selection, the first press arms exit and the second exits through `renderer.destroy()`.
+
+## Commands And Host Actions
+
+- Avoid shape-near singular and plural command pairs. Prefer one canonical command that lists without arguments and acts when given a target.
+- Provider/model switching, ordinary Engine switching, artifact inspection, and rewind opening are local host actions and do not call the provider.
+- `/compact` and the explicit summarize-from-here rewind action may call the provider through their dedicated no-tools summarization contract.
+- Fixed-enum command arguments use the shared completion popup and source candidates from the runtime enum when available. See [`COMMAND_COMPLETION.md`](./COMMAND_COMPLETION.md).
+- Command scheduling follows the registration and boundary rules in [`COMMAND_QUEUE.md`](./COMMAND_QUEUE.md).
+- Host actions add concise structured notices without masquerading as authored user or assistant messages.
+
+## Rewind And Compaction UI
+
+- `/rewind` and empty-input double Escape open the same selector.
+- The rewind picker defaults to a virtual current row, selects authored user prompts, and restores to immediately before the chosen prompt.
+- Host-generated handoffs, compact summaries, Agent delivery packets, and other provider-context records do not count as authored prompts.
+- `/checkpoint` remains the compatibility alias for rewind; additional synonyms require an explicit command-design decision.
+- `/compact [notes]` appends optional user instructions as plain text to the dedicated summarization request and exposes no tools.
+- Compacted transcripts retain a host display record so the empty-session presentation cannot reappear over existing history.
+
+## Side Questions
+
+- `/btw <question>` is a one-shot, tool-free side exchange over an immutable snapshot published before a main provider request.
+- The side request has one dedicated system authority and one host-rendered user reference packet containing quoted parent context as inert data.
+- Parent workflow instructions, tool protocol fields, reasoning, and thinking blocks do not become active side instructions. Images remain reference-only and materialize only for a vision-capable side request.
+- No tools are declared. Any structured tool call in the side response, including mixed text and tool output, fails the exchange.
+- Side exchanges remain in memory and never enter session JSONL, the main conversation, transcript, checkpoints, validators, gates, permissions, or tool execution.
+- A side exchange has an independent cancellation controller and cannot cancel or fail the main Agent Loop.
+- The overlay has visual priority only. Main-loop interactions remain pending and appear after dismissal.
+- Bare `/btw` reopens the latest in-memory exchange for the active session; without one it returns to the composer with a usage hint.
+
+## Verification Boundary
+
+- Static rendering tests do not prove modal transitions, raw terminal key sequences, scrolling, or production preload behavior.
+- Interaction changes should receive focused component or PTY coverage at the real boundary when the regression risk justifies it.
+- The affected workflow must remain usable at 80 columns and at the relevant wide layout before the change is considered complete.

--- a/docs/dev/USER_AGENCY_AND_RISK_DISCLOSURE.md
+++ b/docs/dev/USER_AGENCY_AND_RISK_DISCLOSURE.md
@@ -1,0 +1,130 @@
+# User Agency And Risk Disclosure
+
+> Status: approved cross-cutting product and engineering guidance
+
+This document defines Prism Vesicle's cross-cutting design policy for user choice, risk disclosure, warnings, confirmations, and host-enforced boundaries. It applies to Skills, process execution, MCP, providers, extensions, imports, project-local configuration, and future distribution surfaces.
+
+## Core Principle
+
+Vesicle should inform users about material risk without silently replacing their decisions with host policy. A valid user-selected action should proceed under the capabilities and permission mode the user already chose unless the host cannot execute it correctly, cannot represent it faithfully, or is required to enforce a separately declared boundary.
+
+More warnings and confirmations do not automatically produce more safety. Technically experienced users can inspect sources and evaluate tradeoffs; users without that experience are not made meaningfully safer by dense jargon, repeated trust ceremonies, or a host that implies it has certified content it cannot actually understand. The product obligation is to make decision-relevant facts legible and actions observable, not to act as an infallible judge of user intent.
+
+This principle does not remove filesystem guards, protocol validation, capability checks, permission modes, data-integrity rules, or managed organizational policy. It distinguishes those enforceable runtime contracts from speculative judgments about whether a user's chosen content or workflow is acceptable.
+
+## Decision Classification
+
+Before adding a rejection, warning, confirmation, quarantine state, or hidden downgrade, classify the condition:
+
+| Condition | Product response |
+|---|---|
+| Technically invalid or unrepresentable | Reject with a precise explanation. Examples: malformed required schema, path escaping a declared root, ambiguous path normalization, corrupted state, or an unsupported filesystem object in a portable bundle. |
+| Capability unavailable | Do not pretend to execute. Explain which capability is missing and how the user can enable or choose an applicable runtime. |
+| Material ambiguity | Ask one focused question only when different interpretations would materially change the result. Do not use confirmation as a substitute for deterministic selection rules. |
+| Valid but risk-bearing | Disclose source, action, authority, side effects, and reversibility, then honor the user's choice and current permission mode. |
+| Destructive or externally consequential action | Route through the same existing permission or confirmation contract as an equivalent action from any other source. Do not add a second subsystem-specific gate without evidence that the ordinary contract is insufficient. |
+| Explicit managed policy | Enforce it and identify the authority, such as an organization policy, Engine capability contract, or platform requirement. Do not present managed policy as if it were the user's own risk preference. |
+
+A refusal must name the correctness, capability, or declared-policy boundary it protects. "Potentially unsafe" by itself is not a sufficient design justification.
+
+## Required Product Behavior
+
+### Disclose, do not certify
+
+Show the facts the user can act on: source, resolved version or identity, requested capability, bundled executable content, expected external effects, current permission mode, and available rollback or recovery. A warning is not a security certificate. The absence of a warning must never imply that instructions, code, dependencies, or remote content have been proven benign.
+
+Static analysis and heuristics may produce useful findings, but heuristic findings are informational unless they establish a concrete technical violation. The host should not convert uncertain semantic interpretation into a hidden denylist or content-approval system.
+
+### Preserve the selected permission mode
+
+The same effective action should receive the same permission treatment regardless of whether it originated in a direct user request, an activated Skill, an MCP-guided workflow, or ordinary model reasoning. An extension may not grant itself authority, but its origin alone must not silently reduce authority or force an additional approval layer.
+
+Permission modes remain authoritative. A subsystem must not claim to honor MOMENTUM or YOLO while quietly imposing mandatory per-call confirmation, and it must not bypass MANUAL or INERTIA because metadata declares an action allowed.
+
+### One decision, one gate
+
+An explicit, unambiguous command is already a user decision. Do not immediately ask the user to confirm the same fact again. Additional input is appropriate for unresolved selection, missing required information, an overwrite target, or a materially different side effect that was not visible when the command was issued.
+
+Repeated warnings should be avoided when the source, version, requested authority, and effective permission mode have not changed. Provide an inspect path for detail instead of making every user traverse the full disclosure repeatedly.
+
+### Keep equivalent actions equivalent
+
+Controls should attach to the effect, not to a label such as "third-party," "generated," "script," or "extension." Running a bundled Skill script through Process Runtime should follow the same process, environment, network, cancellation, output, and permission contracts as an equivalent process action. A new source category is not by itself evidence that a new security tier is needed.
+
+### Prefer provenance and reversibility
+
+When practical, preserve source identity, resolved commits, content hashes, diffs, durable events, immutable snapshots, and rollback. These mechanisms improve informed choice, debugging, and recovery without claiming to judge intent. Prefer making a consequential action inspectable and reversible over preventing all users from taking it.
+
+## Enforceable Host Boundaries
+
+Vesicle may and should enforce boundaries required for reliable execution:
+
+- schema and protocol validity;
+- path containment, canonicalization, and filesystem object compatibility;
+- atomic persistence, concurrency control, identity checks, and corruption detection;
+- the active Engine, Agent, provider, tool, and writable-root capability contract;
+- the existing Tool Permission Runtime and Process Runtime behavior;
+- credential handling, secret redaction, output bounds, cancellation, and process cleanup;
+- explicit platform, organization, or distribution policy;
+- honest refusal when an operation cannot be performed as represented.
+
+These are not judgments that the user selected the wrong content. They are conditions under which Vesicle can keep its own promises. Implementations should explain this distinction in diagnostics: prefer "cannot be represented inside the Skill root" over "blocked because the Skill is untrusted."
+
+## Disclosure UX
+
+A risk disclosure should answer, in plain language:
+
+1. What source or component is involved?
+2. What exact action is about to occur?
+3. Which filesystem, process, network, provider, or external-service authority can it use?
+4. Which permission mode or managed policy will govern it?
+5. What state may change, and can that change be inspected, undone, or rolled back?
+
+Use a compact summary at the decision point and an inspection surface for details. Distinguish installed content from actions that have actually executed. Do not overload non-expert users with raw hashes, dependency graphs, or generic threat language when a plain statement of effect is available; keep technical provenance accessible for users who want it.
+
+Warnings should be proportional, specific, and actionable. Avoid generic red banners for ordinary capabilities the user has already enabled. Do not use labels such as "safe," "trusted," or "verified" unless the product defines exactly what was verified and the claim is limited to that property.
+
+## Anti-Patterns
+
+Do not introduce these patterns without a concrete, reviewed reason:
+
+- a second `trusted` state after the user explicitly installed or selected valid content;
+- mandatory confirmation immediately after an unambiguous install or execution command;
+- treating all scripts as a deferred or quarantined plugin class solely because they are executable;
+- blocking content because a heuristic scanner considers its intent suspicious;
+- silently disabling network, filesystem, process, or tool behavior while claiming to use the selected permission mode;
+- making advanced users find a hidden escape hatch to perform an otherwise valid action;
+- presenting a long technical warning to non-expert users without explaining the actual effect or available recovery;
+- implying that content without warnings has been reviewed or certified;
+- multiplying prompts to demonstrate caution rather than addressing a concrete decision boundary.
+
+## Examples
+
+| Scenario | Correct treatment |
+|---|---|
+| Install a Skill from a GitHub URL | Show repository, selected Skill root, requested ref, resolved commit, bundle inventory, and scripts. Install the immutable snapshot without a redundant trust confirmation when the command is unambiguous. |
+| Execute a bundled Skill script | Show the script and effective process authority, then use the current Process and Tool Permission Runtime behavior. Do not impose a Skill-only approval mode. |
+| A Skill declares `allowed-tools` | Preserve and display the metadata for compatibility. It neither grants tools nor forces a denial; the current effective tool surface remains authoritative. |
+| A repository contains an escaping symlink or socket | Reject the affected portable bundle because it cannot be represented within the declared root, not because the repository is presumed malicious. |
+| A remote branch changes | Resolve installations to immutable commits, show the update diff, and retain rollback. This is reproducibility and recovery, not a trust score. |
+| Two nested Skills are plausible install targets | Ask the user to select one or use an explicit path. The question resolves ambiguity rather than seeking risk consent. |
+| A process action deletes or overwrites data | Apply the ordinary permission and destructive-action contract for that effect, regardless of whether a Skill suggested it. |
+
+## Review Checklist
+
+Before accepting a new protective control, ask:
+
+- Is the condition technically invalid, unavailable, ambiguous, destructive, or governed by an explicit external policy?
+- Can the refusal be tied to a concrete contract rather than a generalized fear of third-party content?
+- Has the user already made this exact decision through an unambiguous command or permission-mode choice?
+- Would the same effect receive different treatment if it came from ordinary model reasoning?
+- Does the warning tell the user what will happen, under which authority, and how to recover?
+- Can an informed user proceed without a hidden flag or unsupported workaround?
+- Does the design help a non-expert understand the effect, or merely expose more security terminology?
+- Could provenance, observability, atomicity, or rollback address the risk more directly than prohibition?
+- Does the UI avoid implying certification when only format or integrity was checked?
+- Is every additional confirmation backed by a distinct decision that has not already been made?
+
+## Relationship To Other Contracts
+
+[`ARCHITECTURE.md`](./ARCHITECTURE.md) routes architecture, capability, filesystem, provider, session, and runtime boundaries to their authoritative domain contracts. [`STYLE.md`](./STYLE.md) governs source-code structure and maintainability, while [`WORKFLOW.md`](./WORKFLOW.md) governs development and publication authorization. Feature-specific documents such as [`SKILLS.md`](./SKILLS.md) apply this policy to their domain and may add concrete disclosures or technical validity rules, but must not weaken user agency through an undeclared subsystem-specific trust model.

--- a/docs/dev/WORKFLOW.md
+++ b/docs/dev/WORKFLOW.md
@@ -1,15 +1,13 @@
 # Prism Vesicle Workflow
 
-This document adapts the PRTS-MCP branch and independent review workflow to
-Prism Vesicle's current rapid internal development stage.
+This document adapts the PRTS-MCP branch and independent review workflow to Prism Vesicle's current rapid internal development stage.
 
 ## Hard Rules
 
 - Commit only after the user explicitly asks for a commit or PR.
 - Push only after the user explicitly asks for a push.
 - Keep work reviewable: one branch/PR should have one main intent.
-- Update docs and changelog when behavior, config, tool surface, or runtime
-  contracts change.
+- Update docs and changelog when behavior, config, tool surface, or runtime contracts change.
 - Never commit secrets, generated session state, or local runtime artifacts.
 
 ## Branch Model
@@ -44,13 +42,9 @@ Examples:
 
 ## Rapid Development Exception
 
-Prism Vesicle is currently in a fast internal development phase with no public
-release pressure and no external user dependency on `main`. During this phase,
-`develop` is the active trunk.
+Prism Vesicle is currently in a fast internal development phase with no public release pressure and no external user dependency on `main`. During this phase, `develop` is the active trunk.
 
-Small and medium changes may be committed and pushed directly to `develop` when
-the user explicitly asks for commit/push work and the change is easy to review
-from the commit itself. Examples:
+Small and medium changes may be committed and pushed directly to `develop` when the user explicitly asks for commit/push work and the change is easy to review from the commit itself. Examples:
 
 - documentation-only updates
 - prompt or asset copy edits that do not change runtime contracts
@@ -69,9 +63,7 @@ Use a short-lived branch and PR for higher-risk work:
 - changes intended for `main`, a tag, or release readiness
 - changes where Bot review or independent CR is useful
 
-`main` does not need to be updated on every iteration in this phase. Update
-`main` only for milestone snapshots, release-readiness checkpoints, or explicit
-user requests.
+`main` does not need to be updated on every iteration in this phase. Update `main` only for milestone snapshots, release-readiness checkpoints, or explicit user requests.
 
 The exception does not relax these rules:
 
@@ -82,10 +74,7 @@ The exception does not relax these rules:
 - Conventional Commits still apply
 - verification must match the risk of the change
 
-For public-release paths, this exception is retired:
-release-readiness changes use a release branch and PR, require independent CR,
-and must not be tagged from an unreviewed dogfood worktree. Keep `develop` as
-the integration trunk for subsequent internal iteration.
+For public-release paths, this exception is retired: release-readiness changes use a release branch and PR, require independent CR, and must not be tagged from an unreviewed dogfood worktree. Keep `develop` as the integration trunk for subsequent internal iteration.
 
 ## Iteration Loop
 
@@ -94,8 +83,7 @@ the integration trunk for subsequent internal iteration.
 Run `bun run hooks:install` once per checkout so the tracked pre-push hook enforces `bun run lint` before remote updates.
 
 1. Align scope: state what changes, files likely touched, risks, and validation.
-2. Decide whether the Rapid Development Exception allows direct `develop`
-   work. Otherwise branch from `develop`.
+2. Decide whether the Rapid Development Exception allows direct `develop` work. Otherwise branch from `develop`.
 3. Implement in small, reviewable commits when committing is requested.
 4. Run local verification:
 
@@ -110,11 +98,10 @@ bun run doctor
    - `README.md` for user-facing usage
    - `STATUS.md` for current project shape or limits
    - `CHANGELOG.md` for user-visible changes
-   - `docs/dev/STYLE.md` for architecture rules
+   - `docs/dev/STYLE.md` for source-code conventions
+   - `docs/dev/ARCHITECTURE.md` or its linked domain contract for architecture and runtime boundaries
    - `docs/dev/WORKFLOW.md` for process changes
-6. Push directly to `develop` only when allowed by the Rapid Development
-   Exception and explicitly requested by the user; otherwise open a PR when
-   requested.
+6. Push directly to `develop` only when allowed by the Rapid Development Exception and explicitly requested by the user; otherwise open a PR when requested.
 7. Run independent CR before merge for non-trivial PRs.
 8. Address Blocking and Should-fix findings.
 9. Wait for human merge when using PR flow.
@@ -232,8 +219,7 @@ Use this for regressions that block real use, such as:
 - path guards are unsafe
 - TUI cannot exit or accept input
 
-Use the hotfix path only when `main` or a tagged milestone must be repaired.
-During rapid internal development, most urgent fixes can go through `develop`.
+Use the hotfix path only when `main` or a tagged milestone must be repaired. During rapid internal development, most urgent fixes can go through `develop`.
 
 Full hotfix flow:
 
@@ -246,8 +232,7 @@ Full hotfix flow:
 
 ## Independent CR
 
-Every non-trivial PR should be reviewed by an independent agent or reviewer that
-did not participate in the implementation conversation.
+Every non-trivial PR should be reviewed by an independent agent or reviewer that did not participate in the implementation conversation.
 
 ### Reviewer Prompt Template
 

--- a/docs/user/en/reference/configuration.md
+++ b/docs/user/en/reference/configuration.md
@@ -25,7 +25,7 @@ Files in that directory:
 | `.env` | Yes | The corresponding secret values |
 | `mcp.yaml` | No | Optional MCP tool servers |
 | `permissions.yaml` | No | Tool-approval default and the `shell_exec` switch (see [permissions](./permissions-and-security.md)) |
-| `quality.yaml` | No | Experimental Semantic Judge (`version: 2`; `mode: off` may retain a dormant provider/model/timeout tuple). See [quality guard](./quality-guard.md); `/quality` is the normal path |
+| `quality.yaml` | No | Experimental Semantic Judge (`version: 2`; `mode: off` may retain a dormant provider/model/timeout tuple). See [quality guard](../advanced/quality-guard.md); `/quality` is the normal path |
 | `settings.yaml` | No | User-level host settings (`editor:` for the Workspace `Ctrl+X` external editor; reserved for future settings) |
 | `assets/` | No | User-level asset overrides |
 | `VESICLE.md` / `VESICLE.<engine>.md` | No | Persistent Instructions (user-level, applies across all projects; see below) |

--- a/docs/user/zh-CN/reference/configuration.md
+++ b/docs/user/zh-CN/reference/configuration.md
@@ -25,7 +25,7 @@ Vesicle 的配置是**用户级**的,跟项目目录分开。一份配置管你�
 | `.env` | 是 | 上面对应的密钥值 |
 | `mcp.yaml` | 否 | 可选的 MCP 工具服务器 |
 | `permissions.yaml` | 否 | 工具批准默认与 `shell_exec` 开关(见[权限](./permissions-and-security.md)) |
-| `quality.yaml` | 否 | 实验性 Semantic Judge(`version: 2`;`mode: off` 可保留一组休眠的 provider/model/timeout)。见[质量守卫](./quality-guard.md);常规入口是 `/quality` |
+| `quality.yaml` | 否 | 实验性 Semantic Judge(`version: 2`;`mode: off` 可保留一组休眠的 provider/model/timeout)。见[质量守卫](../advanced/quality-guard.md);常规入口是 `/quality` |
 | `settings.yaml` | 否 | 用户级宿主设置(`editor:` 用于 Workspace 页 `Ctrl+X` 外部编辑器;为后续设置项预留) |
 | `assets/` | 否 | 用户级资源覆盖 |
 | `VESICLE.md` / `VESICLE.<engine>.md` | 否 | 持久化指令(用户级,跨所有项目生效;见下文) |

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,8 +1,6 @@
 # Windows installer
 
-The first public-dogfood installer uses Inno Setup 6. It installs the complete
-standalone Windows runtime per-user and launches Vesicle's own guided Setup;
-the Inno script never receives provider, Tavily, or MCP secrets.
+The first public-dogfood installer uses Inno Setup 6. It installs the complete standalone Windows runtime per-user and launches Vesicle's own guided Setup; the Inno script never receives provider, Tavily, or MCP secrets.
 
 On Windows with Inno Setup 6 installed:
 
@@ -10,17 +8,10 @@ On Windows with Inno Setup 6 installed:
 bun run build:installer
 ```
 
-The command builds `prism-vesicle.exe`, stages the exact runtime payload under
-`dist/installer-stage/`, and writes
-`dist/PrismVesicleSetup-<version>-windows-x64.exe`.
+The command builds `prism-vesicle.exe`, stages the exact runtime payload under `dist/installer-stage/`, and writes `dist/PrismVesicleSetup-<version>-windows-x64.exe`.
 
 The installer renames the staged standalone binary to the native `vesicle.exe` command, so a new terminal can run `vesicle .` from any project without a batch wrapper. Per-user Explorer directory and directory-background actions provide the same path launch without a shell. Upgrades remove the old binary, wrapper, and Start Menu project launcher. Rerunning the installer shows Reinstall / Repair / Uninstall maintenance choices; Repair restores installed files and Windows integration without reopening Guided Setup. Setup never persists a global project directory.
 
-Use `INNO_SETUP_COMPILER` to point at a non-default `ISCC.exe`. Linux/WSL can
-run `bun run build:installer:stage` to verify the staged payload; compilation
-and install/uninstall smoke run on a native Windows CI runner.
+Use `INNO_SETUP_COMPILER` to point at a non-default `ISCC.exe`. Linux/WSL can run `bun run build:installer:stage` to verify the staged payload; compilation and install/uninstall smoke run on a native Windows CI runner.
 
-The Simplified Chinese Inno messages are vendored from Inno Setup 7.0.2 so
-builds do not depend on optional compiler language files. The file declares
-compatibility with Inno Setup 6.5.0 and later. See
-`languages/LICENSE-Inno-Setup.txt` for its upstream source and license.
+The Simplified Chinese Inno messages are vendored from Inno Setup 7.0.2 so builds do not depend on optional compiler language files. The file declares compatibility with Inno Setup 6.5.0 and later. See `languages/LICENSE-Inno-Setup.txt` for its upstream source and license.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "dev": "bun run src/cli/main.ts",
     "doctor": "bun run src/cli/main.ts doctor",
+    "docs:check:staged": "bun run scripts/check-staged-markdown-wrap.ts",
     "hooks:install": "git config core.hooksPath .githooks",
     "lint": "biome lint .",
     "typecheck": "tsc --noEmit",

--- a/scripts/check-staged-markdown-wrap.ts
+++ b/scripts/check-staged-markdown-wrap.ts
@@ -1,0 +1,226 @@
+type WrapWarning = {
+  line: number;
+  reason: string;
+};
+
+const MAX_WARNINGS = 20;
+const EXCLUDED_PREFIXES = ["assets/", "host-assets/"];
+
+function stripBlockquotePrefix(line: string): string | null {
+  const match = line.match(/^\s*(?:>\s?)+(.*)$/);
+  return match ? match[1] : null;
+}
+
+function isStructuralLine(line: string): boolean {
+  return /^(?:\s{0,3}#{1,6}\s|\s{0,3}(?:[-+*]|\d+[.)])\s+|\s{0,3}(?:`{3,}|~{3,})|\s{0,3}[-*_](?:\s*[-*_]){2,}\s*$)/.test(
+    line,
+  );
+}
+
+function isTableLine(line: string): boolean {
+  return (
+    /^\s*\|/.test(line) ||
+    /\|\s*$/.test(line) ||
+    /^\s*:?-{3,}:?(?:\s*\|\s*:?-{3,}:?)+\s*$/.test(line)
+  );
+}
+
+function collectTableLines(lines: string[]): Set<number> {
+  const tableLines = new Set<number>();
+  const delimiter = /^\s*\|?\s*:?-{3,}:?\s*(?:\|\s*:?-{3,}:?\s*)+\|?\s*$/;
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    if (!lines[index].includes("|") || !delimiter.test(lines[index + 1])) continue;
+    tableLines.add(index);
+    tableLines.add(index + 1);
+    for (let row = index + 2; row < lines.length && lines[row].trim() && lines[row].includes("|"); row += 1) {
+      tableLines.add(row);
+    }
+  }
+  return tableLines;
+}
+
+function isLinkDefinition(line: string): boolean {
+  return /^\s{0,3}\[[^\]]+\]:\s/.test(line);
+}
+
+function isHtmlBlockLine(line: string): boolean {
+  return /^\s{0,3}(?:<!--|<\/?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)(?:\s|>|\/>))/i.test(
+    line,
+  );
+}
+
+function collectHtmlBlockLines(lines: string[]): Set<number> {
+  const htmlLines = new Set<number>();
+  let terminator: RegExp | "blank" | null = null;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (terminator !== null) {
+      if (terminator === "blank" && !line.trim()) {
+        terminator = null;
+        continue;
+      }
+      htmlLines.add(index);
+      if (terminator !== "blank" && terminator.test(line)) terminator = null;
+      continue;
+    }
+
+    if (/^\s{0,3}<!--/.test(line) && !/-->/.test(line)) terminator = /-->/;
+    else {
+      const rawTag = line.match(/^\s{0,3}<(script|pre|style|textarea)(?:\s|>)/i);
+      if (rawTag && !new RegExp(`</${rawTag[1]}\\s*>`, "i").test(line)) {
+        terminator = new RegExp(`</${rawTag[1]}\\s*>`, "i");
+      } else if (isHtmlBlockLine(line) && !/^\s{0,3}<\//.test(line)) {
+        terminator = "blank";
+      }
+    }
+    if (terminator !== null || isHtmlBlockLine(line)) htmlLines.add(index);
+  }
+
+  return htmlLines;
+}
+
+function hasExplicitLineBreak(line: string): boolean {
+  return / {2}$/.test(line) || /<br\s*\/?>(?:\s*)$/i.test(line);
+}
+
+function isSuspiciousBoundary(line: string, next: string): boolean {
+  if (!line.trim() || !next.trim() || hasExplicitLineBreak(line)) return false;
+
+  const quotedLine = stripBlockquotePrefix(line);
+  const quotedNext = stripBlockquotePrefix(next);
+  if (quotedLine !== null || quotedNext !== null) {
+    if (quotedLine === null || quotedNext === null || !quotedLine.trim() || !quotedNext.trim()) return false;
+    return isSuspiciousBoundary(quotedLine, quotedNext);
+  }
+
+  if (
+    isTableLine(line) ||
+    isTableLine(next) ||
+    isLinkDefinition(line) ||
+    isLinkDefinition(next) ||
+    isHtmlBlockLine(line) ||
+    isHtmlBlockLine(next)
+  ) {
+    return false;
+  }
+
+  if (/^(?: {4}|\t)/.test(line) && /^(?: {4}|\t)/.test(next)) return false;
+  if (isStructuralLine(next)) return false;
+
+  const listItem = /^\s{0,3}(?:[-+*]|\d+[.)])\s+\S/.test(line);
+  if (listItem) return /^\s{2,}\S/.test(next);
+
+  return !isStructuralLine(line) && !/^\s{0,3}</.test(line);
+}
+
+export function findSuspiciousMarkdownWraps(source: string, addedLines: ReadonlySet<number>): WrapWarning[] {
+  const lines = source.split(/\r?\n/);
+  const warnings: WrapWarning[] = [];
+  const htmlLines = collectHtmlBlockLines(lines);
+  const tableLines = collectTableLines(lines);
+  let fenceMarker: "`" | "~" | null = null;
+
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const line = lines[index];
+    const next = lines[index + 1];
+    const fence = line.match(/^\s{0,3}(`{3,}|~{3,})/);
+    if (fence) {
+      const marker = fence[1][0] as "`" | "~";
+      if (fenceMarker === null) fenceMarker = marker;
+      else if (fenceMarker === marker) fenceMarker = null;
+      continue;
+    }
+    if (fenceMarker !== null) continue;
+    if (htmlLines.has(index) || htmlLines.has(index + 1) || tableLines.has(index) || tableLines.has(index + 1)) continue;
+
+    const firstLine = index + 1;
+    const secondLine = index + 2;
+    if (!addedLines.has(firstLine) && !addedLines.has(secondLine)) continue;
+    if (!isSuspiciousBoundary(line, next)) continue;
+
+    warnings.push({
+      line: addedLines.has(secondLine) ? secondLine : firstLine,
+      reason: addedLines.has(secondLine)
+        ? "Added prose appears to continue the preceding source line."
+        : "Added prose appears to continue onto the following source line.",
+    });
+  }
+
+  return warnings;
+}
+
+async function runGit(args: string[]): Promise<string> {
+  const child = Bun.spawn(["git", ...args], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  if (exitCode !== 0) throw new Error(stderr.trim() || `git ${args[0]} failed with exit code ${exitCode}`);
+  return stdout;
+}
+
+function parseNulSeparated(output: string): string[] {
+  return output.split("\0").filter(Boolean);
+}
+
+function parseAddedLines(diff: string): Set<number> {
+  const addedLines = new Set<number>();
+  for (const line of diff.split("\n")) {
+    const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/);
+    if (!hunk) continue;
+    const start = Number.parseInt(hunk[1], 10);
+    const count = hunk[2] === undefined ? 1 : Number.parseInt(hunk[2], 10);
+    for (let offset = 0; offset < count; offset += 1) addedLines.add(start + offset);
+  }
+  return addedLines;
+}
+
+async function stagedMarkdownPaths(): Promise<string[]> {
+  const output = await runGit(["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z", "--", "*.md"]);
+  return parseNulSeparated(output).filter((path) => !EXCLUDED_PREFIXES.some((prefix) => path.startsWith(prefix)));
+}
+
+async function stagedFile(path: string): Promise<string> {
+  return runGit(["show", `:${path}`]);
+}
+
+async function addedLinesForPath(path: string): Promise<Set<number>> {
+  const diff = await runGit(["diff", "--cached", "--unified=0", "--diff-filter=ACMR", "--", path]);
+  return parseAddedLines(diff);
+}
+
+export async function checkStagedMarkdownWraps(): Promise<void> {
+  const findings: Array<WrapWarning & { path: string }> = [];
+
+  for (const path of await stagedMarkdownPaths()) {
+    const addedLines = await addedLinesForPath(path);
+    if (addedLines.size === 0) continue;
+    const source = await stagedFile(path);
+    for (const warning of findSuspiciousMarkdownWraps(source, addedLines)) findings.push({ path, ...warning });
+  }
+
+  if (findings.length === 0) return;
+
+  console.error(
+    `\nMarkdown wrap advisory: ${findings.length} suspicious staged ${findings.length === 1 ? "boundary" : "boundaries"}.\n`,
+  );
+  for (const finding of findings.slice(0, MAX_WARNINGS)) {
+    console.error(`  ${finding.path}:${finding.line}`);
+    console.error(`  ${finding.reason}\n`);
+  }
+  if (findings.length > MAX_WARNINGS) console.error(`  ...and ${findings.length - MAX_WARNINGS} more.\n`);
+  console.error("This hook is heuristic and may produce false positives. Review each warning, but if the Markdown is structurally and semantically correct, do not modify it merely to silence the hook.");
+  console.error("Commit was not blocked. Amend it only when the flagged line is an unintended hard wrap.\n");
+}
+
+if (import.meta.main) {
+  try {
+    await checkStagedMarkdownWraps();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`\nMarkdown wrap advisory could not run: ${message}`);
+    console.error("Commit was not blocked.\n");
+  }
+}

--- a/src/core/instructions/types.ts
+++ b/src/core/instructions/types.ts
@@ -3,7 +3,7 @@ import type { EngineId } from "../engine/profile";
 /**
  * Persistent Instructions: user-authored Markdown that survives new sessions
  * and, at user scope, applies across project roots. This is the model context
- * layer described in `docs/dev/STYLE.md` § Persistent Instructions. It is not
+ * layer described in `docs/dev/PERSISTENT_INSTRUCTIONS.md`. It is not
  * automatic memory: the host never infers, summarizes, or writes instructions
  * without a model tool call (Increment B) or a direct user edit.
  */

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -2,20 +2,12 @@
 
 Vesicle's first MCP milestone is a tools-only Streamable HTTP client.
 
-- Config lives at the user-level `mcp.yaml` beside `providers.yaml`; set
-  `VESICLE_MCP_FILE` to override it.
-- A present `mcp.yaml` defaults to enabled. Use top-level `enabled: false` only
-  when you want to keep the file but disable MCP.
-- Secrets are expanded from the same sibling `.env` file used by provider and
-  Tavily keys.
-- `transport: streamable-http` and `transport: http` both select the
-  Streamable HTTP client.
-- Tools are discovered with `initialize` + paginated `tools/list`, then exposed
-  as `mcp_<prefix>_<tool>` aliases.
-- `includeTools` and `excludeTools` match either the remote tool name or the
-  Vesicle alias.
+- Config lives at the user-level `mcp.yaml` beside `providers.yaml`; set `VESICLE_MCP_FILE` to override it.
+- A present `mcp.yaml` defaults to enabled. Use top-level `enabled: false` only when you want to keep the file but disable MCP.
+- Secrets are expanded from the same sibling `.env` file used by provider and Tavily keys.
+- `transport: streamable-http` and `transport: http` both select the Streamable HTTP client.
+- Tools are discovered with `initialize` + paginated `tools/list`, then exposed as `mcp_<prefix>_<tool>` aliases.
+- `includeTools` and `excludeTools` match either the remote tool name or the Vesicle alias.
 - `enabledEngines` can scope a server to specific Prism engines.
 
-The client intentionally does not launch local stdio servers yet. That transport
-needs a separate process-management pass for Windows PE distribution and local
-path/env behavior.
+The client intentionally does not launch local stdio servers yet. That transport needs a separate process-management pass for Windows PE distribution and local path/env behavior.

--- a/src/skills/README.md
+++ b/src/skills/README.md
@@ -1,9 +1,6 @@
 # Skills Runtime
 
-Skills are on-demand procedural context plus bundled resources in the open
-Agent Skills `SKILL.md` format. A Skill is never an Engine, Agent Profile, MCP
-server, or permission grant. It may contain instructions, references, assets,
-and scripts, but cannot itself widen the current effective tool surface.
+Skills are on-demand procedural context plus bundled resources in the open Agent Skills `SKILL.md` format. A Skill is never an Engine, Agent Profile, MCP server, or permission grant. It may contain instructions, references, assets, and scripts, but cannot itself widen the current effective tool surface.
 
 Phase 0 (format, inventory, and Skill Store) is implemented here:
 
@@ -15,7 +12,4 @@ Phase 0 (format, inventory, and Skill Store) is implemented here:
 - `store.ts` — immutable, content-addressed Skill Store with an active index.
 - `types.ts` / `index.ts` — shared types and the public surface.
 
-There is no model-visible activation in this phase. See
-`docs/dev/SKILLS.md` for the runtime boundary and
-`dev/docs/working/SKILLS_RUNTIME_RESEARCH_AND_FEASIBILITY.md` for the approved
-implementation plan, research basis, and Phase 1-4 delivery contract.
+There is no model-visible activation in this phase. See `docs/dev/SKILLS.md` for the runtime boundary and the phase roadmap.

--- a/tests/unit/scripts/check-staged-markdown-wrap.test.ts
+++ b/tests/unit/scripts/check-staged-markdown-wrap.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import { findSuspiciousMarkdownWraps } from "../../../scripts/check-staged-markdown-wrap.ts";
+
+function added(...lines: number[]): Set<number> {
+  return new Set(lines);
+}
+
+describe("staged Markdown wrap advisory", () => {
+  test("warns when either side of a prose boundary was added", () => {
+    const source = "First source line\nSecond source line\n";
+
+    expect(findSuspiciousMarkdownWraps(source, added(2))).toEqual([
+      { line: 2, reason: "Added prose appears to continue the preceding source line." },
+    ]);
+    expect(findSuspiciousMarkdownWraps(source, added(1))).toEqual([
+      { line: 1, reason: "Added prose appears to continue onto the following source line." },
+    ]);
+  });
+
+  test("warns on an added list-item continuation", () => {
+    const source = "- One list item that should stay on one source line\n  continued prose\n";
+
+    expect(findSuspiciousMarkdownWraps(source, added(2))).toHaveLength(1);
+  });
+
+  test("does not report boundaries outside the added lines", () => {
+    const source = "Existing wrapped\nparagraph\n\nNew paragraph.\n";
+
+    expect(findSuspiciousMarkdownWraps(source, added(4))).toEqual([]);
+  });
+
+  test("preserves structural and intentional line boundaries", () => {
+    const source = [
+      "> Quoted paragraph.",
+      ">",
+      "> Next quoted paragraph.",
+      "",
+      "| Column A | Column B |",
+      "|---|---|",
+      "| Value A | Value B |",
+      "",
+      "Column A | Column B",
+      "--- | ---",
+      "Value A | Value B",
+      "Value C | Value D",
+      "",
+      "<div>",
+      "HTML content line one",
+      "HTML content line two",
+      "</div>",
+      "",
+      "Explicit hard break.  ",
+      "Next line.",
+      "",
+      "```text",
+      "code line one",
+      "code line two",
+      "```",
+      "",
+    ].join("\n");
+
+    expect(findSuspiciousMarkdownWraps(source, new Set(source.split("\n").map((_, index) => index + 1)))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Split the monolithic `docs/dev/STYLE.md` into focused authoritative dev contracts (`ARCHITECTURE`, `PROVIDERS`, `TOOLS`, `SESSIONS`, `TUI`, `PERSISTENT_INSTRUCTIONS`, `USER_AGENCY_AND_RISK_DISCLOSURE`), and update the one `src/core/instructions/types.ts` comment that pointed at the old `STYLE.md` section.
- Remove hard-wrapped prose across public docs so each paragraph/list item sits on one source line, per `STYLE.md`'s natural-wrap policy: `AGENTS.md`, `CLAUDE.md`, `brand/README.md`, `installer/README.md`, `src/mcp/README.md`, `src/skills/README.md`, `docs/dev/{SKILLS,WORKFLOW,SUBAGENTS}.md`.
- Fix two public-doc boundary issues: drop the ignored-local `dev/docs/working/...` reference in `src/skills/README.md`; correct the `quality-guard.md` link in the en/zh configuration reference to `../advanced/quality-guard.md`.
- Add a non-blocking staged-Markdown wrap advisory (`.githooks/pre-commit` → `scripts/check-staged-markdown-wrap.ts` + focused tests) that warns on likely hard-wrap boundaries in added lines without ever blocking a commit.

## Test Plan

- [x] `bun run lint`  (local: clean, 529 files)
- [x] `bun run typecheck`  (local: clean)
- [x] `bun test`  (local: 1320 pass / 5 skip / 0 fail)
- [x] `bun run doctor`  (local: clean)

## Notes / Follow-ups

- Verification run locally before push; CI will re-confirm on the PR.
- The pre-commit advisory is opt-out-by-design (`exit 0`); it discloses possible false positives to agents rather than enforcing.
- Both `docs/user/{en,zh-CN}/advanced/shell-exec.md` were reviewed and left unchanged — already compliant with the one-line-per-paragraph policy.
- No CHANGELOG entry added: this is internal/dev-contract restructuring plus contributor tooling, with only a minor user-manual link fix. Can add a `docs(user):` entry if that should be surfaced to users.