### PR TITLE
fix(skills): initialize full session identity before first /skill activation (#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/skill` as the first input of a fresh session no longer trips the Harness identity guard (#131).** Leading a brand-new TUI session with `/skill <name>`, `/skill <name> --context-only`, or a bare `/skill` picker selection previously failed with "Session Harness identity does not match the active verified project baseline": the host path minted a session id and persisted the `skill-activation` record as the session's first record, so the first provider turn saw an "existing" session with no system header and the identity guard correctly rejected it. The host path now persists a complete session identity first — a new core `initializeSessionIdentity` (shared with the turn bootstrap via a common `buildSessionHeaderRecord`) writes the full system header, including Engine/profile, provider/model, permission, generation, assets, instructions, Harness identity, and the frozen Skill catalog, before any activation record is appended; the TUI only adopts the session id once that header is durable, gates on provider-config/permission readiness like a normal first turn, and advances the branch head after a branched activation so the next turn chains after it. The activation registry is marked only after the durable append succeeds, and the hydrate/dedup/append/record transaction runs under a per-session lock that is atomic across processes, so concurrent identical activations — whether rapid repeated submission in one process or two separate processes — cannot both pass the hash dedup check (one activation lands, not two). Headerless legacy or corrupted sessions still fail closed: the guard is unchanged and nothing auto-writes a header for an existing session.
+
 ## [1.0.0-alpha.7] - 2026-07-28
 
 ### Added

--- a/scripts/smoke-skill-first-input-pty.ts
+++ b/scripts/smoke-skill-first-input-pty.ts
@@ -1,0 +1,329 @@
+/**
+ * Real-PTY smoke for issue #131: `/skill` as the FIRST input of a fresh session.
+ *
+ * Drives the real TUI inside a `script`-allocated pseudo-terminal against a
+ * local mock provider and leads a brand-new session with a Skill activation
+ * through all three command surfaces:
+ *
+ *   /skill vesicle-docs                    (activate-and-invoke)
+ *   /skill vesicle-docs --context-only     (load-only, provider deferred)
+ *   /skill  + picker selection             (bare picker, context-only)
+ *
+ * Before the fix, the host path wrote the activation record before any session
+ * header existed, so the first provider turn rejected the session with "Session
+ * Harness identity does not match the active verified project baseline."
+ *
+ * Launch target (issue #131 acceptance criterion 8 — npm artifact or Linux ELF):
+ *   - default: `bun src/cli/main.ts` (source; repo root carries the bundled
+ *     harness, assets, and host-assets);
+ *   - VESICLE_BIN=<path>: stages the real release shape (binary + assets +
+ *     host-assets + harness-manifest.json beside the executable, mirroring
+ *     scripts/smoke-binary.ts) and drives the compiled artifact. Point it at a
+ *     `bun run build:exe` ELF or an installed npm binary.
+ *
+ * Assertions are deliberately rendering-independent. The activation card is a
+ * transient in-memory message that a fast mock provider can replace before a
+ * frame commits, so the smoke proves the fix through durable state and precise
+ * provider-request accounting instead:
+ *   - the PTY output never contains the Harness identity error;
+ *   - invoke makes exactly one provider request; context-only/picker make ZERO
+ *     requests until a normal follow-up prompt, then exactly one;
+ *   - the persisted session JSONL starts with a system header carrying a
+ *     Harness identity, followed by a durable skill-activation record in the
+ *     expected mode, and (for the deferred paths) the follow-up user + assistant
+ *     records actually land.
+ *
+ * Commands are typed the way smoke-workspace-status-pty.ts does (slash alone,
+ * name char-by-char, Tab-complete, then the argument): a raw burst or a raw
+ * space to dismiss the completion menu mis-parses under a `script` PTY.
+ *
+ * Usage:
+ *   bun run scripts/smoke-skill-first-input-pty.ts [width] [height]
+ *   VESICLE_BIN=./prism-vesicle bun run scripts/smoke-skill-first-input-pty.ts
+ * Exits non-zero if the identity guard fires, the request accounting is wrong,
+ * or the durable ordering is wrong.
+ */
+import { copyFile, cp, mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ETL_PROMPT,
+  MOCK_ENV,
+  SHARED_BASE_PROMPT,
+  providersYaml,
+  stripAnsi,
+} from "./support/pty-smoke";
+
+export {};
+
+const WIDTH = Number(process.argv[2] ?? 80);
+const HEIGHT = Number(process.argv[3] ?? 24);
+const REPO_ROOT = join(import.meta.dir, "..");
+const IDENTITY_ERROR = "Harness identity does not match";
+const FOLLOW_UP_PROMPT = "continue now";
+
+// The shared smoke profile omits the Skill tools; host activation requires the
+// engine profile to declare activate_skill for the catalog to be eligible.
+const skillEngineProfileYaml = [
+  "id: etl", "displayName: Smoke ETL", "protocolVersion: v9.0-state-space",
+  "systemPrompt:", "  - assets/prompts/shared/vesicle-base.md", "  - assets/prompts/engines/etl.md",
+  "defaultTools:", "  - read_file", "  - activate_skill", "  - read_skill_resource", "  - run_skill_script",
+  "validators: []", "stopGates: []", "stateRoots:", "  - workspace", "",
+].join("\n");
+
+type SessionRecord = { role: string; content?: string; metadata?: Record<string, unknown> };
+
+type LaunchTarget = {
+  label: string;
+  innerCommand: (project: string) => string;
+  cwd: string;
+  cleanup: () => Promise<void>;
+};
+
+const shellQuote = (value: string) => `"${value.replace(/"/g, '\\"')}"`;
+
+/** Source launch by default; VESICLE_BIN stages and drives a release artifact. */
+async function prepareTarget(): Promise<LaunchTarget> {
+  const bin = process.env.VESICLE_BIN;
+  if (!bin) {
+    return {
+      label: "source (bun src/cli/main.ts)",
+      innerCommand: (project) => `bun ${shellQuote(join(REPO_ROOT, "src", "cli", "main.ts"))} ${shellQuote(project)}`,
+      cwd: REPO_ROOT,
+      cleanup: async () => {},
+    };
+  }
+  if (!(await Bun.file(bin).exists())) throw new Error(`VESICLE_BIN not found at ${bin}. Build it first (bun run build:exe).`);
+  const root = await mkdtemp(join(tmpdir(), "vesicle-skill-release-"));
+  const release = join(root, "release");
+  await mkdir(release, { recursive: true });
+  const binary = join(release, `prism-vesicle${process.platform === "win32" ? ".exe" : ""}`);
+  await cp(bin, binary);
+  await cp(join(REPO_ROOT, "assets"), join(release, "assets"), { recursive: true });
+  await cp(join(REPO_ROOT, "host-assets"), join(release, "host-assets"), { recursive: true });
+  await copyFile(join(REPO_ROOT, "harness-manifest.json"), join(release, "harness-manifest.json"));
+  return {
+    label: `release artifact (${bin})`,
+    innerCommand: (project) => `${shellQuote(binary)} ${shellQuote(project)}`,
+    cwd: release,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  };
+}
+
+type PtySession = {
+  type: (text: string) => void;
+  sleep: (ms: number) => Promise<void>;
+  typeSlow: (text: string) => Promise<void>;
+  submit: (text: string) => Promise<void>;
+  waitFor: (marker: string | RegExp, timeoutMs?: number) => Promise<boolean>;
+  waitForRecord: (predicate: (records: SessionRecord[]) => boolean, timeoutMs?: number) => Promise<boolean>;
+  calls: () => number;
+  readRecords: () => Promise<SessionRecord[]>;
+  plain: () => string;
+  teardown: () => Promise<void>;
+};
+
+async function startSession(target: LaunchTarget): Promise<PtySession> {
+  const root = await mkdtemp(join(tmpdir(), "vesicle-skill-first-pty-"));
+  const project = join(root, "project");
+  const configDir = join(root, "config");
+  await mkdir(project, { recursive: true });
+  await mkdir(configDir, { recursive: true });
+  await mkdir(join(project, "workspace"), { recursive: true });
+
+  let calls = 0;
+  const server = Bun.serve({
+    port: 0,
+    async fetch() {
+      calls += 1;
+      return Response.json({ id: `mock-${calls}`, choices: [{ message: { content: "reply 1" } }] });
+    },
+  });
+
+  await writeFile(join(configDir, "providers.yaml"), providersYaml(server.port ?? 0), "utf8");
+  await writeFile(join(configDir, ".env"), MOCK_ENV, "utf8");
+
+  const sharedDir = join(project, "assets", "prompts", "shared");
+  const engineDir = join(project, "assets", "prompts", "engines");
+  const enginesDir = join(project, "assets", "engines");
+  await mkdir(sharedDir, { recursive: true });
+  await mkdir(engineDir, { recursive: true });
+  await mkdir(enginesDir, { recursive: true });
+  await writeFile(join(sharedDir, "vesicle-base.md"), SHARED_BASE_PROMPT, "utf8");
+  await writeFile(join(engineDir, "etl.md"), ETL_PROMPT, "utf8");
+  await writeFile(join(enginesDir, "etl.profile.yaml"), skillEngineProfileYaml, "utf8");
+
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  env.VESICLE_PROVIDERS_FILE = join(configDir, "providers.yaml");
+  env.VESICLE_REDUCED_MOTION = "1";
+  env.TERM = "xterm-256color";
+
+  const child = Bun.spawn(["script", "-qfe", "-c", `stty cols ${WIDTH} rows ${HEIGHT}; ${target.innerCommand(project)}`, join(root, "pty.log")], {
+    cwd: target.cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "pipe",
+  });
+  const stdin = child.stdin!;
+  let accumulated = "";
+  const reader = child.stdout!.getReader();
+  const pump = (async () => {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      accumulated += new TextDecoder().decode(value);
+    }
+  })();
+
+  const type = (text: string) => { stdin.write(text); stdin.flush(); };
+  const sleep = (ms: number) => Bun.sleep(ms);
+  const typeSlow = async (text: string) => { for (const ch of text) { type(ch); await sleep(40); } };
+  const submit = async (text: string) => { await typeSlow(text); await sleep(150); type("\r"); };
+  const plain = () => stripAnsi(accumulated);
+  const waitFor = async (marker: string | RegExp, timeoutMs = 25000): Promise<boolean> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (new RegExp(marker).test(plain())) return true;
+      await sleep(150);
+    }
+    return false;
+  };
+  const readRecords = async (): Promise<SessionRecord[]> => {
+    const dir = join(project, ".vesicle", "sessions");
+    const files = (await readdir(dir).catch(() => [] as string[])).filter((file) => file.endsWith(".jsonl"));
+    const records: SessionRecord[] = [];
+    for (const file of files) {
+      const text = await Bun.file(join(dir, file)).text();
+      for (const line of text.split("\n")) {
+        if (!line.trim()) continue;
+        records.push(JSON.parse(line) as SessionRecord);
+      }
+    }
+    return records;
+  };
+  const waitForRecord = async (predicate: (records: SessionRecord[]) => boolean, timeoutMs = 25000): Promise<boolean> => {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (predicate(await readRecords())) return true;
+      await sleep(150);
+    }
+    return false;
+  };
+  const teardown = async () => {
+    type("\x03"); await sleep(300);
+    type("\x03"); await sleep(500);
+    try { stdin.end(); } catch { /* exited */ }
+    await Promise.race([pump, sleep(2000)]);
+    server.stop(true);
+    await rm(root, { recursive: true, force: true });
+  };
+
+  await sleep(2800); // let the renderer + composer fully activate
+  return { type, sleep, typeSlow, submit, waitFor, waitForRecord, calls: () => calls, readRecords, plain, teardown };
+}
+
+const hasActivation = (records: SessionRecord[]) => records.some((record) => record.metadata?.kind === "skill-activation");
+
+async function main(): Promise<void> {
+  const failures: string[] = [];
+  const check = (scenario: string, condition: boolean, message: string) => {
+    if (!condition) failures.push(`${scenario}: ${message}`);
+  };
+  const target = await prepareTarget();
+  console.log(`\n## PTY skill-first-input smoke @ ${WIDTH}x${HEIGHT} — ${target.label}`);
+
+  // --- invoke: /skill vesicle-docs -----------------------------------------
+  {
+    const name = "invoke: /skill vesicle-docs";
+    const s = await startSession(target);
+    try {
+      s.type("/"); await s.sleep(150);
+      await s.typeSlow("skill"); await s.sleep(200);
+      s.type("\t"); await s.sleep(200);
+      await s.typeSlow("vesicle-docs"); await s.sleep(200);
+      s.type("\r");
+      await s.waitFor("reply 1");
+      const records = await s.readRecords();
+      const header = records[0];
+      const activationIndex = records.findIndex((r) => r.metadata?.kind === "skill-activation");
+      console.log(`\n===== ${name} =====\ncalls=${s.calls()} identityError=${s.plain().includes(IDENTITY_ERROR)} header.role=${header?.role} harness=${header?.metadata?.harness ? "present" : "MISSING"} activationIndex=${activationIndex} mode=${String(records[activationIndex]?.metadata?.mode ?? "MISSING")}`);
+      check(name, !s.plain().includes(IDENTITY_ERROR), "Harness identity guard fired");
+      check(name, s.plain().includes("reply 1"), "provider reply never rendered");
+      check(name, s.calls() === 1, `expected exactly 1 provider request, got ${s.calls()}`);
+      check(name, header?.role === "system", "first durable record is not the system header");
+      check(name, Boolean(header?.metadata?.harness), "session header missing the Harness identity");
+      check(name, activationIndex > 0, "activation record missing or precedes the header");
+      check(name, records[activationIndex]?.metadata?.mode === "invoke", "activation mode is not invoke");
+    } finally {
+      await s.teardown();
+    }
+  }
+
+  // --- context-only and picker: provider deferred until a normal prompt ----
+  const deferred: Array<{ name: string; drive: (s: PtySession) => Promise<void> }> = [
+    {
+      name: "context-only: /skill vesicle-docs --context-only",
+      drive: async (s) => {
+        s.type("/"); await s.sleep(150);
+        await s.typeSlow("skill"); await s.sleep(200);
+        s.type("\t"); await s.sleep(200);
+        await s.typeSlow("vesicle-docs --context-only"); await s.sleep(200);
+        s.type("\r");
+      },
+    },
+    {
+      name: "picker: bare /skill then select vesicle-docs",
+      drive: async (s) => {
+        s.type("/"); await s.sleep(150);
+        await s.typeSlow("skill"); await s.sleep(300);
+        s.type("\r"); await s.sleep(1500); // submit /skill -> open the picker
+        s.type("\r"); // select the highlighted (only) skill
+      },
+    },
+  ];
+
+  for (const scenario of deferred) {
+    const s = await startSession(target);
+    try {
+      await scenario.drive(s);
+      // Wait for the durable activation so we know the command finished, then
+      // give any (buggy) early provider call time to land before asserting zero.
+      const activated = await s.waitForRecord(hasActivation);
+      await s.sleep(1000);
+      const callsBefore = s.calls();
+      await s.submit(FOLLOW_UP_PROMPT);
+      await s.waitFor("reply 1");
+      const records = await s.readRecords();
+      const header = records[0];
+      const activationIndex = records.findIndex((r) => r.metadata?.kind === "skill-activation");
+      const followUpUser = records.find((r) => r.role === "user" && r.metadata?.kind !== "skill-activation" && (r.content ?? "").includes(FOLLOW_UP_PROMPT));
+      const assistant = records.find((r) => r.role === "assistant" && (r.content ?? "").includes("reply 1"));
+      console.log(`\n===== ${scenario.name} =====\nactivated=${activated} callsBefore=${callsBefore} callsAfter=${s.calls()} identityError=${s.plain().includes(IDENTITY_ERROR)} header.role=${header?.role} harness=${header?.metadata?.harness ? "present" : "MISSING"} activationIndex=${activationIndex} mode=${String(records[activationIndex]?.metadata?.mode ?? "MISSING")} followUpUser=${Boolean(followUpUser)} assistant=${Boolean(assistant)}`);
+      check(scenario.name, activated, "activation record never persisted");
+      check(scenario.name, !s.plain().includes(IDENTITY_ERROR), "Harness identity guard fired");
+      check(scenario.name, callsBefore === 0, `context-only made ${callsBefore} provider request(s) before any prompt`);
+      check(scenario.name, s.calls() === 1, `expected exactly 1 provider request after the follow-up, got ${s.calls()}`);
+      check(scenario.name, s.plain().includes("reply 1"), "follow-up reply never rendered");
+      check(scenario.name, header?.role === "system", "first durable record is not the system header");
+      check(scenario.name, Boolean(header?.metadata?.harness), "session header missing the Harness identity");
+      check(scenario.name, activationIndex > 0, "activation record missing or precedes the header");
+      check(scenario.name, records[activationIndex]?.metadata?.mode === "context-only", "activation mode is not context-only");
+      check(scenario.name, Boolean(followUpUser), "follow-up user record not persisted");
+      check(scenario.name, Boolean(assistant), "follow-up assistant record not persisted");
+    } finally {
+      await s.teardown();
+    }
+  }
+
+  await target.cleanup();
+
+  if (failures.length > 0) {
+    for (const failure of failures) console.log(`FAIL: ${failure}`);
+    process.exitCode = 1;
+  } else {
+    console.log(`\nPTY skill-first-input smoke passed at ${WIDTH}x${HEIGHT} (${target.label}).`);
+  }
+}
+
+await main();

--- a/src/core/agent-loop/session-init.ts
+++ b/src/core/agent-loop/session-init.ts
@@ -1,0 +1,173 @@
+/**
+ * Session identity initialization shared by the turn bootstrap and host-side
+ * entry points (e.g. `/skill` as the first input of a fresh session).
+ *
+ * Lives in `core/agent-loop` — not `session/store` — because composing the
+ * header requires config, prompt composition, assets, tool surface, and the
+ * frozen Skill catalog: the same dependency set as `bootstrapTurn`. Callers
+ * that must persist a complete session identity before any dependent record
+ * use `initializeSessionIdentity`; `bootstrapTurn` reuses
+ * `buildSessionHeaderRecord` so the two header shapes never drift.
+ */
+
+import { loadConfigForSelection } from "../../config/providers";
+import type { VesicleConfig } from "../../config/env";
+import type { VesicleRequest } from "../../providers/shared/types";
+import type { EffectiveInstructionSelection } from "../instructions";
+import { composeSystemPromptWithInstructions, selectionToRecord } from "../instructions";
+import { defaultPermissionRuntime, type PermissionRuntimeOptions } from "../permissions";
+import { loadEngineAssetRuntime } from "../runtime/engine-assets";
+import type { AssetFingerprint } from "../runtime/assets";
+import { createSessionStore, type SessionRecord } from "../session/store";
+import { requireProjectHarnessRuntime, resolveProjectHarnessRuntime } from "../harness/activation";
+import type { HarnessRuntimeIdentity } from "../harness/driver";
+import type { EngineId, EngineProfile } from "../engine/profile";
+import type { ToolDefinition } from "../tools";
+import {
+  catalogNames,
+  composeSkillCatalogBlock,
+  isMeaningfulSkillCatalogSnapshot,
+  resolveEngineEligibleCatalog,
+  resolveSessionSkillCatalog,
+  snapshotSkillCatalog,
+  type SkillCatalogSnapshot,
+} from "../skills";
+import { generationMetadata, mergeGeneration } from "./generation";
+import { resolveToolSurface } from "./tool-surface";
+import type { RunPromptOptions } from "./types";
+
+export type InitializeSessionIdentityOptions = Pick<
+  RunPromptOptions,
+  "engine" | "rootDir" | "providerSelection" | "generation" | "permission" | "harness" | "assets"
+>;
+
+export type SessionIdentity = {
+  sessionId: string;
+  sessionPath: string;
+};
+
+export type SessionHeaderParts = {
+  systemPrompt: string;
+  engine: EngineId;
+  config: VesicleConfig;
+  permission: PermissionRuntimeOptions;
+  generation: VesicleRequest["generation"] | undefined;
+  profile: EngineProfile;
+  toolSurface: { definitions: ToolDefinition[]; mcp: { definitions: ToolDefinition[] } };
+  assets: AssetFingerprint;
+  instructionalSelection: EffectiveInstructionSelection;
+  harnessIdentity: HarnessRuntimeIdentity | undefined;
+  skillCatalogSnapshot: SkillCatalogSnapshot | undefined;
+};
+
+export function buildSessionHeaderRecord(
+  parts: SessionHeaderParts,
+): Omit<SessionRecord, "uuid" | "parentUuid" | "ts" | "sessionId"> {
+  const { toolSurface } = parts;
+  return {
+    role: "system",
+    content: parts.systemPrompt,
+    metadata: {
+      engine: parts.engine,
+      provider: parts.config.provider,
+      providerId: parts.config.providerId,
+      model: parts.config.model,
+      permissionMode: parts.permission.mode,
+      ...(parts.permission.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}),
+      ...generationMetadata(parts.generation),
+      profile: {
+        displayName: parts.profile.displayName,
+        protocolVersion: parts.profile.protocolVersion,
+        tools: parts.profile.defaultTools,
+        effectiveModelTools: toolSurface.definitions.map((tool) => tool.function.name),
+        ...(toolSurface.mcp.definitions.length > 0 ? { mcpTools: toolSurface.mcp.definitions.map((tool) => tool.function.name) } : {}),
+        validators: parts.profile.validators,
+        stopGates: parts.profile.stopGates,
+      },
+      assets: parts.assets,
+      instructions: selectionToRecord(parts.instructionalSelection),
+      ...(parts.harnessIdentity ? { harness: parts.harnessIdentity } : {}),
+      // Bounded frozen-catalog identity (hash + name/scope/bodySha256 only);
+      // omitted entirely when the session has no Skills and no diagnostics.
+      ...(parts.skillCatalogSnapshot && isMeaningfulSkillCatalogSnapshot(parts.skillCatalogSnapshot)
+        ? { skills: parts.skillCatalogSnapshot }
+        : {}),
+    },
+  };
+}
+
+/**
+ * Persist a complete session identity — the system header carrying engine,
+ * provider/model, permission, generation, assets, instructions, Harness
+ * identity, and the frozen Skill catalog — as the first durable record of a
+ * brand-new session. Returns the new session's id and path.
+ *
+ * The header is the branch authority for everything persisted afterward, so
+ * host-side callers must await this before appending any dependent record
+ * (e.g. a `skill-activation`). Turn-only concerns (instruction diagnostics,
+ * logical turn ids, checkpoints, instruction freezing) remain in
+ * `bootstrapTurn`, which runs on the next provider turn.
+ */
+export async function initializeSessionIdentity(
+  options: InitializeSessionIdentityOptions,
+): Promise<SessionIdentity> {
+  const engine = options.engine ?? "etl";
+  const rootDir = options.rootDir ?? process.cwd();
+  if (engine === "stage") {
+    throw new Error("Stage sessions must start with /stage <character-card-path> <scenario-card-path> so bootstrap context is persisted before the first player action.");
+  }
+  const config = await loadConfigForSelection(options.providerSelection);
+  const generation = mergeGeneration(config.generation, options.generation);
+  const permission = options.permission ?? defaultPermissionRuntime;
+  const projectHarness = !options.assets && !options.harness
+    ? requireProjectHarnessRuntime(await resolveProjectHarnessRuntime(rootDir))
+    : undefined;
+  const assets = options.assets ?? projectHarness?.assets;
+  const harness = options.harness ?? projectHarness?.harness;
+  const engineAssets = await loadEngineAssetRuntime(engine, rootDir, assets ? { resolver: assets } : {});
+  const { profile } = engineAssets;
+  const instructional = await composeSystemPromptWithInstructions(engine, engineAssets.systemPrompt, rootDir);
+  let systemPrompt = instructional.systemPrompt;
+
+  const session = await createSessionStore(rootDir);
+
+  const frozenSkillCatalog = await resolveSessionSkillCatalog(
+    rootDir,
+    process.env,
+    profile,
+    session.sessionId,
+    undefined,
+    config.limits?.contextWindow,
+  );
+  const skillCatalog = resolveEngineEligibleCatalog(frozenSkillCatalog, profile);
+  const skillCatalogSnapshot = snapshotSkillCatalog(frozenSkillCatalog);
+  const skillCatalogBlock = composeSkillCatalogBlock(skillCatalog.catalog);
+  if (skillCatalogBlock) systemPrompt = `${systemPrompt}\n\n${skillCatalogBlock}`;
+
+  const toolSurface = await resolveToolSurface(
+    profile,
+    config.capabilities?.vision === true,
+    permission.shellExecEnabled === true || permission.dangerouslySkipPermissions === true,
+    permission.shellInterpreter,
+    {},
+    { catalogNames: catalogNames(skillCatalog) },
+  );
+
+  await session.append(
+    buildSessionHeaderRecord({
+      systemPrompt,
+      engine,
+      config,
+      permission,
+      generation,
+      profile,
+      toolSurface,
+      assets: engineAssets.assets,
+      instructionalSelection: instructional.selection,
+      harnessIdentity: harness?.identity,
+      skillCatalogSnapshot,
+    }),
+  );
+
+  return { sessionId: session.sessionId, sessionPath: session.sessionPath };
+}

--- a/src/core/agent-loop/turn-bootstrap.ts
+++ b/src/core/agent-loop/turn-bootstrap.ts
@@ -6,7 +6,7 @@ import type { ProviderSelection } from "../../config/providers";
 import type { VesicleMessage, VesicleRequest } from "../../providers/shared/types";
 import { persistedImageAttachments } from "../attachments/store";
 import { FileCheckpointManager } from "../checkpoints/file-history";
-import { composeSystemPromptWithInstructions, selectionToRecord } from "../instructions";
+import { composeSystemPromptWithInstructions } from "../instructions";
 import { composeInstructionBlocks } from "../instructions";
 import { freezeInstructionBlocks } from "../instructions/instruction-context";
 import { defaultPermissionRuntime } from "../permissions";
@@ -19,6 +19,7 @@ import { createTurnAgentManager } from "./agent-manager";
 import { emitAssetDriftIfNeeded } from "./continuation-context";
 import { generationMetadata, mergeGeneration } from "./generation";
 import { resolveToolSurface } from "./tool-surface";
+import { buildSessionHeaderRecord } from "./session-init";
 import type { RunLoopArgs } from "./turn-loop";
 import type { AgentLoopEvent, RunPromptOptions } from "./types";
 import {
@@ -158,34 +159,21 @@ export async function bootstrapTurn(options: RunPromptOptions): Promise<RunLoopA
   const providerRoundId = newProviderRoundId();
 
   if (isNewSession) {
-    await session.append({
-      role: "system",
-      content: systemPrompt,
-      metadata: {
+    await session.append(
+      buildSessionHeaderRecord({
+        systemPrompt,
         engine,
-        provider: config.provider,
-        providerId: config.providerId,
-        model: config.model,
-        permissionMode: permission.mode,
-        ...(permission.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true } : {}),
-        ...generationMetadata(generation),
-        profile: {
-          displayName: profile.displayName,
-          protocolVersion: profile.protocolVersion,
-          tools: profile.defaultTools,
-          effectiveModelTools: toolSurface.definitions.map((tool) => tool.function.name),
-          ...(toolSurface.mcp.definitions.length > 0 ? { mcpTools: toolSurface.mcp.definitions.map((tool) => tool.function.name) } : {}),
-          validators: profile.validators,
-          stopGates: profile.stopGates,
-        },
+        config,
+        permission,
+        generation,
+        profile,
+        toolSurface,
         assets: engineAssets.assets,
-        instructions: selectionToRecord(instructional.selection),
-        ...(harness?.identity ? { harness: harness.identity } : {}),
-        // Bounded frozen-catalog identity (hash + name/scope/bodySha256 only);
-        // omitted entirely when the session has no Skills and no diagnostics.
-        ...(isMeaningfulSkillCatalogSnapshot(skillCatalogSnapshot) ? { skills: skillCatalogSnapshot } : {}),
-      },
-    });
+        instructionalSelection: instructional.selection,
+        harnessIdentity: harness?.identity,
+        skillCatalogSnapshot,
+      }),
+    );
   } else if (snapshot && !snapshot.skillCatalogSnapshot && isMeaningfulSkillCatalogSnapshot(skillCatalogSnapshot)) {
     // A resumed legacy session without a persisted snapshot: make the fresh
     // freeze durable so the next resume re-resolves by name+hash instead of

--- a/src/core/session/append-store.ts
+++ b/src/core/session/append-store.ts
@@ -90,8 +90,27 @@ const LOCK_RETRY_MS = 10;
 const LOCK_TIMEOUT_MS = 5_000;
 
 /** Serialize the head-read + append transaction across Vesicle processes. */
-async function withSessionFileLock<T>(sessionPath: string, operation: () => Promise<T>): Promise<T> {
-  const lockPath = `${sessionPath}.lock`;
+function withSessionFileLock<T>(sessionPath: string, operation: () => Promise<T>): Promise<T> {
+  return withFileLock(`${sessionPath}.lock`, operation);
+}
+
+/**
+ * Run a read-check-append transaction under a per-session lockfile that is
+ * distinct from the append lock, so host-side callers (e.g. Skill activation
+ * dedup) can make the whole transaction atomic across processes without
+ * deadlocking against the inner append's own lock.
+ */
+export async function withSessionActivationLock<T>(
+  rootDir: string,
+  sessionId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const sessionDir = join(rootDir, ".vesicle", "sessions");
+  await mkdir(sessionDir, { recursive: true });
+  return withFileLock(join(sessionDir, `${sessionId}.skill-activation.lock`), operation);
+}
+
+async function withFileLock<T>(lockPath: string, operation: () => Promise<T>): Promise<T> {
   const deadline = Date.now() + LOCK_TIMEOUT_MS;
   let handle: Awaited<ReturnType<typeof open>>;
   while (true) {
@@ -100,7 +119,7 @@ async function withSessionFileLock<T>(sessionPath: string, operation: () => Prom
       break;
     } catch (error) {
       if (!isFileError(error, "EEXIST")) throw error;
-      if (Date.now() >= deadline) throw new Error(`Timed out waiting for the session append lock: ${sessionPath}`);
+      if (Date.now() >= deadline) throw new Error(`Timed out waiting for the file lock: ${lockPath}`);
       await new Promise((resolve) => setTimeout(resolve, LOCK_RETRY_MS));
     }
   }

--- a/src/core/session/store.ts
+++ b/src/core/session/store.ts
@@ -31,7 +31,7 @@ import { recoverSessionInteractions, type PendingDelegationRetry } from "./inter
 
 export { buildActiveSessionBranch } from "./record-model";
 export type { SessionRecord, SessionRole } from "./record-model";
-export { createSessionStore } from "./append-store";
+export { createSessionStore, withSessionActivationLock } from "./append-store";
 export type { SessionStore } from "./append-store";
 export type { PendingDelegationRetry } from "./interaction-recovery";
 export { FAILED_TURN_KIND } from "./history-projector";

--- a/src/core/skills/host-activation.ts
+++ b/src/core/skills/host-activation.ts
@@ -12,7 +12,7 @@
  */
 
 import type { EngineProfile } from "../engine/profile";
-import { createSessionStore, loadSessionSnapshot } from "../session/store";
+import { createSessionStore, loadSessionSnapshot, withSessionActivationLock } from "../session/store";
 import type { SkillDiagnostic, SkillResource, SkillScope } from "../../skills/types";
 import { deriveSessionActivations } from "./activation-derivation";
 import { hydrateSessionActivations, isDuplicateActivation, pruneSessionActivations, recordActivation } from "./activation-state";
@@ -46,7 +46,41 @@ export type HostSkillActivation = {
   /** Skill-relative paths of bundled scripts (for the activation card). */
   scripts: string[];
   diagnostics: SkillDiagnostic[];
+  /** UUID of the appended activation record; absent when alreadyActive. */
+  recordUuid?: string;
 };
+
+async function loadSnapshotOrUndefined(
+  rootDir: string,
+  sessionId: string,
+): Promise<Awaited<ReturnType<typeof loadSessionSnapshot>> | undefined> {
+  try {
+    return await loadSessionSnapshot(rootDir, sessionId, { synthesizeDanglingToolResults: false });
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    return undefined;
+  }
+}
+
+const activationTails = new Map<string, Promise<unknown>>();
+
+/**
+ * Serialize the hydrate/dedup/append/registry-update critical section per
+ * session (mirrors append-store's per-path tail). Without this, two concurrent
+ * identical activations both pass the hash dedup check before either records
+ * itself, appending the activation twice. A rejection does not poison the
+ * chain, and the tail entry is dropped once it is no longer the active tail.
+ */
+function serializeActivation<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+  const previous = activationTails.get(sessionId) ?? Promise.resolve();
+  const result = previous.catch(() => undefined).then(operation);
+  const tail = result.then(() => undefined, () => undefined);
+  activationTails.set(sessionId, tail);
+  void tail.finally(() => {
+    if (activationTails.get(sessionId) === tail) activationTails.delete(sessionId);
+  });
+  return result;
+}
 
 export async function activateSkillForSession(
   rootDir: string,
@@ -55,12 +89,7 @@ export async function activateSkillForSession(
   name: string,
   options: ActivateSkillForSessionOptions,
 ): Promise<HostSkillActivation> {
-  let snapshot: Awaited<ReturnType<typeof loadSessionSnapshot>> | undefined;
-  try {
-    snapshot = await loadSessionSnapshot(rootDir, sessionId, { synthesizeDanglingToolResults: false });
-  } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-  }
+  const snapshot = await loadSnapshotOrUndefined(rootDir, sessionId);
   const frozen = await resolveSessionSkillCatalog(
     rootDir,
     env,
@@ -77,12 +106,6 @@ export async function activateSkillForSession(
     throw new Error(`Unknown skill "${name}". Available skills: ${available}.`);
   }
 
-  // Re-derive the registry from durable history before dedup so a host
-  // activation that precedes any bootstrap in this process still honors
-  // activations recorded by earlier turns or processes.
-  hydrateSessionActivations(sessionId, deriveSessionActivations(snapshot?.records ?? []));
-  pruneSessionActivations(sessionId, new Set(eligible.byName.keys()));
-
   const valid = skill as ValidSkill;
   const base = {
     name: valid.name,
@@ -92,27 +115,42 @@ export async function activateSkillForSession(
     scripts: valid.parsed.resources.filter((resource) => resource.kind === "script").map((resource) => resource.path),
     diagnostics: valid.parsed.diagnostics,
   };
-  if (isDuplicateActivation(sessionId, valid.name, valid.parsed.bodySha256)) {
-    return { ...base, alreadyActive: true };
-  }
 
-  recordActivation(sessionId, valid.name, valid.parsed.bodySha256);
-  const session = await createSessionStore(
-    rootDir,
-    sessionId,
-    options.parentUuid !== undefined ? { parentUuid: options.parentUuid } : {},
+  return serializeActivation(sessionId, () =>
+    withSessionActivationLock(rootDir, sessionId, async () => {
+      // Re-read durable state under the per-session lock so an activation
+      // appended by a just-completed concurrent call — in this process or
+      // another — is visible to dedup; re-derive the registry from it so a host
+      // activation that precedes any bootstrap still honors activations recorded
+      // by earlier turns or processes.
+      const fresh = await loadSnapshotOrUndefined(rootDir, sessionId);
+      hydrateSessionActivations(sessionId, deriveSessionActivations(fresh?.records ?? []));
+      pruneSessionActivations(sessionId, new Set(eligible.byName.keys()));
+      if (isDuplicateActivation(sessionId, valid.name, valid.parsed.bodySha256)) {
+        return { ...base, alreadyActive: true };
+      }
+
+      const session = await createSessionStore(
+        rootDir,
+        sessionId,
+        options.parentUuid !== undefined ? { parentUuid: options.parentUuid } : {},
+      );
+      const appended = await session.append({
+        role: "user",
+        content: formatSkillActivationBlock(valid, "activated"),
+        metadata: {
+          kind: SKILL_ACTIVATION_KIND,
+          name: valid.name,
+          scope: valid.scope,
+          contentHash: valid.parsed.bodySha256,
+          mode: options.mode ?? "invoke",
+          scripts: base.scripts,
+        },
+      });
+      // Mark the registry only after the durable append succeeds so a failed
+      // append leaves no entry that would misclassify a retry as a duplicate.
+      recordActivation(sessionId, valid.name, valid.parsed.bodySha256);
+      return { ...base, alreadyActive: false, recordUuid: appended.uuid };
+    }),
   );
-  await session.append({
-    role: "user",
-    content: formatSkillActivationBlock(valid, "activated"),
-    metadata: {
-      kind: SKILL_ACTIVATION_KIND,
-      name: valid.name,
-      scope: valid.scope,
-      contentHash: valid.parsed.bodySha256,
-      mode: options.mode ?? "invoke",
-      scripts: base.scripts,
-    },
-  });
-  return { ...base, alreadyActive: false };
 }

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -70,7 +70,7 @@ import { createQueuedWorkController } from "./queued-work-controller";
 import { createStageSessionController } from "./stage-session-controller";
 import { createStartupController } from "./startup-controller";
 import { activateSkillForSession } from "../core/skills";
-import { initializeSessionIdentity } from "../core/agent-loop/session-init";
+import { initializeSessionIdentity, type SessionIdentity } from "../core/agent-loop/session-init";
 import { SideQuestionOverlay } from "./views/SideQuestionOverlay";
 import { WorkspacePage } from "./views/WorkspacePage";
 import { copyTextToClipboard } from "./clipboard";
@@ -922,6 +922,10 @@ export function App(props: AppProps = {}) {
    *   /new              abandon the current session and start fresh
    *   /help             show available commands
    */
+  // Serializes fresh-session identity initialization: command dispatch is
+  // fire-and-forget, so two rapid /skill commands could otherwise both pass the
+  // !sessionId() check, each mint a session, and orphan the first file.
+  let pendingSessionIdentity: Promise<SessionIdentity> | null = null;
   async function activateSkillCommand(
     name: string,
     options: { mode: "invoke" | "context-only"; taskText?: string },
@@ -929,32 +933,43 @@ export function App(props: AppProps = {}) {
     const rootDir = process.cwd();
     let sid = sessionId();
     if (!sid) {
-      // Mirror turn-controller's ensureRuntimeReady: the identity header needs a
-      // resolved provider selection and effective permission settings, and the
-      // active provider/model signals start as "loading" before config resolves.
-      if (!providerConfigReady()) {
-        setStatus("loading provider config");
-        await loadProviderConfigOnce();
+      if (!pendingSessionIdentity) {
+        pendingSessionIdentity = (async () => {
+          // Mirror turn-controller's ensureRuntimeReady: the identity header needs a
+          // resolved provider selection and effective permission settings, and the
+          // active provider/model signals start as "loading" before config resolves.
+          if (!providerConfigReady()) {
+            setStatus("loading provider config");
+            await loadProviderConfigOnce();
+          }
+          if (!permissionSettingsReady()) {
+            setStatus("loading permission settings");
+            await loadPermissionSettingsOnce();
+          }
+          return initializeSessionIdentity({
+            engine: activeEngine(),
+            rootDir,
+            providerSelection: activeProviderSelection(),
+            generation: activeGeneration(),
+            permission: {
+              mode: permissionMode(),
+              ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true as const } : {}),
+              shellExecEnabled: shellExecEnabled(),
+              shellInterpreter: shellInterpreter(),
+            },
+          });
+        })();
       }
-      if (!permissionSettingsReady()) {
-        setStatus("loading permission settings");
-        await loadPermissionSettingsOnce();
+      const initPromise = pendingSessionIdentity;
+      try {
+        const identity = await initPromise;
+        sid = identity.sessionId;
+        setSessionId(sid);
+        setSessionPath(identity.sessionPath);
+      } catch (error) {
+        if (pendingSessionIdentity === initPromise) pendingSessionIdentity = null;
+        throw error;
       }
-      const identity = await initializeSessionIdentity({
-        engine: activeEngine(),
-        rootDir,
-        providerSelection: activeProviderSelection(),
-        generation: activeGeneration(),
-        permission: {
-          mode: permissionMode(),
-          ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true as const } : {}),
-          shellExecEnabled: shellExecEnabled(),
-          shellInterpreter: shellInterpreter(),
-        },
-      });
-      sid = identity.sessionId;
-      setSessionId(sid);
-      setSessionPath(identity.sessionPath);
     }
     const branchParent = nextSessionParent();
     const activation = await activateSkillForSession(rootDir, process.env, sid, name, {

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1,5 +1,4 @@
 import { createEffect, createMemo, createSignal, Show, onCleanup, onMount } from "solid-js";
-import { join } from "node:path";
 import { useRenderer, useTerminalDimensions } from "@opentui/solid";
 import type { EngineId } from "../core/engine/profile";
 import type { VesicleMessage } from "../providers/shared/types";
@@ -71,6 +70,7 @@ import { createQueuedWorkController } from "./queued-work-controller";
 import { createStageSessionController } from "./stage-session-controller";
 import { createStartupController } from "./startup-controller";
 import { activateSkillForSession } from "../core/skills";
+import { initializeSessionIdentity } from "../core/agent-loop/session-init";
 import { SideQuestionOverlay } from "./views/SideQuestionOverlay";
 import { WorkspacePage } from "./views/WorkspacePage";
 import { copyTextToClipboard } from "./clipboard";
@@ -929,9 +929,32 @@ export function App(props: AppProps = {}) {
     const rootDir = process.cwd();
     let sid = sessionId();
     if (!sid) {
-      sid = crypto.randomUUID();
+      // Mirror turn-controller's ensureRuntimeReady: the identity header needs a
+      // resolved provider selection and effective permission settings, and the
+      // active provider/model signals start as "loading" before config resolves.
+      if (!providerConfigReady()) {
+        setStatus("loading provider config");
+        await loadProviderConfigOnce();
+      }
+      if (!permissionSettingsReady()) {
+        setStatus("loading permission settings");
+        await loadPermissionSettingsOnce();
+      }
+      const identity = await initializeSessionIdentity({
+        engine: activeEngine(),
+        rootDir,
+        providerSelection: activeProviderSelection(),
+        generation: activeGeneration(),
+        permission: {
+          mode: permissionMode(),
+          ...(props.dangerouslySkipPermissions ? { dangerouslySkipPermissions: true as const } : {}),
+          shellExecEnabled: shellExecEnabled(),
+          shellInterpreter: shellInterpreter(),
+        },
+      });
+      sid = identity.sessionId;
       setSessionId(sid);
-      setSessionPath(join(rootDir, ".vesicle", "sessions", `${sid}.jsonl`));
+      setSessionPath(identity.sessionPath);
     }
     const branchParent = nextSessionParent();
     const activation = await activateSkillForSession(rootDir, process.env, sid, name, {
@@ -940,6 +963,7 @@ export function App(props: AppProps = {}) {
       ...(branchParent ? { parentUuid: branchParent.uuid } : {}),
       contextWindow: activeModelLimits()?.contextWindow,
     });
+    if (branchParent && activation.recordUuid) setNextSessionParent({ uuid: activation.recordUuid });
     const scriptInfo = activation.scripts.length > 0
       ? ` · ${activation.scripts.length} script${activation.scripts.length > 1 ? "s" : ""}`
       : "";

--- a/tests/integration/agent-loop/session-init.test.ts
+++ b/tests/integration/agent-loop/session-init.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { runPrompt } from "../../../src/core/agent-loop/run";
+import { bootstrapTurn } from "../../../src/core/agent-loop/turn-bootstrap";
+import { initializeSessionIdentity } from "../../../src/core/agent-loop/session-init";
+import { createSessionStore, loadSessionRecords, loadSessionSnapshot } from "../../../src/core/session/store";
+import { activateSkillForSession, clearSessionActivations, clearSessionSkillCatalog } from "../../../src/core/skills";
+import { harnessRuntime } from "../harness/fixtures/harness";
+import { createPromptRoot, configureTestProviderEnv, restoreAgentLoopTestState } from "./fixtures/agent-loop";
+
+beforeEach(configureTestProviderEnv);
+afterEach(restoreAgentLoopTestState);
+
+function userConfigDir(): string {
+  return dirname(process.env.VESICLE_PROVIDERS_FILE!);
+}
+
+async function writeUserSkill(name: string): Promise<void> {
+  const root = join(userConfigDir(), "skills", name);
+  await mkdir(root, { recursive: true });
+  await Bun.write(
+    join(root, "SKILL.md"),
+    `---\nname: ${name}\ndescription: ${name} routing description\n---\n\n# ${name}\n\nBody for ${name}.\n`,
+  );
+}
+
+/** The host path the TUI now runs: full identity first, then the activation record. */
+async function initThenActivate(
+  rootDir: string,
+  name: string,
+  mode: "invoke" | "context-only" = "invoke",
+): Promise<{ sessionId: string; recordUuid: string | undefined }> {
+  const identity = await initializeSessionIdentity({ rootDir, permission: { mode: "MOMENTUM" } });
+  const activation = await activateSkillForSession(rootDir, process.env, identity.sessionId, name, {
+    profile: { id: "etl" },
+    mode,
+  });
+  return { sessionId: identity.sessionId, recordUuid: activation.recordUuid };
+}
+
+function mockProviderFetch(): void {
+  globalThis.fetch = (async () => {
+    return Response.json({ id: "round-1", choices: [{ message: { content: "done" } }] });
+  }) as unknown as typeof fetch;
+}
+
+describe("initializeSessionIdentity (issue #131)", () => {
+  test("fresh session: the identity header precedes the activation record", async () => {
+    await writeUserSkill("alpha");
+    const rootDir = await createPromptRoot({ skillTools: true });
+
+    const { sessionId } = await initThenActivate(rootDir, "alpha");
+
+    const records = await loadSessionRecords(rootDir, sessionId);
+    // First durable record is the system header, not the activation.
+    expect(records[0]?.role).toBe("system");
+    const harness = records[0]?.metadata?.harness as Record<string, unknown> | undefined;
+    expect(harness).toBeDefined();
+    for (const key of ["packId", "packVersion", "sourceCommit", "manifestSha256", "adapterId", "adapterVersion", "adapterHash"]) {
+      expect(typeof harness?.[key]).toBe("string");
+    }
+    const skills = records[0]?.metadata?.skills as { entries?: Array<{ name: string }> } | undefined;
+    expect(skills?.entries?.map((entry) => entry.name).sort()).toEqual(["alpha", "vesicle-docs"]);
+
+    // The activation is the second record and chains directly off the header.
+    expect(records[1]?.metadata?.kind).toBe("skill-activation");
+    expect(records[1]?.metadata?.name).toBe("alpha");
+    expect(records[1]?.parentUuid).toBe(records[0]?.uuid);
+
+    // The snapshot loads with a recorded Harness identity (the value the guard checks).
+    const snapshot = await loadSessionSnapshot(rootDir, sessionId);
+    expect(snapshot.harness).toBeDefined();
+    expect(snapshot.skillCatalogSnapshot).toBeDefined();
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  });
+
+  test("bootstrapTurn accepts a session whose identity was initialized before activation", async () => {
+    const rootDir = await createPromptRoot({ skillTools: true });
+    const { sessionId } = await initThenActivate(rootDir, "vesicle-docs");
+
+    // Before the fix this exact call threw "Session Harness identity does not match...".
+    await expect(
+      bootstrapTurn({ input: "hello", rootDir, sessionId, permission: { mode: "MOMENTUM" } }),
+    ).resolves.toBeDefined();
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  });
+
+  test("records the exact Harness identity passed to initialization", async () => {
+    const rootDir = await createPromptRoot({ skillTools: true });
+    const harness = harnessRuntime();
+
+    const identity = await initializeSessionIdentity({ rootDir, permission: { mode: "MOMENTUM" }, harness });
+    await activateSkillForSession(rootDir, process.env, identity.sessionId, "vesicle-docs", { profile: { id: "etl" } });
+
+    const records = await loadSessionRecords(rootDir, identity.sessionId);
+    expect(records[0]?.metadata?.harness).toEqual(harness.identity);
+
+    // The same identity satisfies the guard on the next turn.
+    await expect(
+      bootstrapTurn({ input: "hello", rootDir, sessionId: identity.sessionId, permission: { mode: "MOMENTUM" }, harness }),
+    ).resolves.toBeDefined();
+    clearSessionActivations(identity.sessionId);
+    clearSessionSkillCatalog(identity.sessionId);
+  });
+
+  test("a full turn completes after /skill-style initialization", async () => {
+    const rootDir = await createPromptRoot({ skillTools: true });
+    mockProviderFetch();
+    const { sessionId } = await initThenActivate(rootDir, "vesicle-docs");
+
+    const result = await runPrompt({ input: "hello", rootDir, sessionId, permission: { mode: "MOMENTUM" } });
+    expect(result.kind).toBe("complete");
+
+    const records = await loadSessionRecords(rootDir, sessionId);
+    const roles = records.map((record) => `${record.role}:${record.metadata?.kind ?? ""}`);
+    expect(roles[0]).toBe("system:");
+    expect(roles[1]).toBe("user:skill-activation");
+    expect(roles[2]).toBe("user:");
+    expect(records.some((record) => record.role === "assistant")).toBe(true);
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  });
+
+  test("--context-only: a later normal turn chains after the activation", async () => {
+    const rootDir = await createPromptRoot({ skillTools: true });
+    mockProviderFetch();
+    const { sessionId, recordUuid } = await initThenActivate(rootDir, "vesicle-docs", "context-only");
+    expect(recordUuid).toBeDefined();
+
+    const result = await runPrompt({ input: "hello", rootDir, sessionId, permission: { mode: "MOMENTUM" } });
+    expect(result.kind).toBe("complete");
+
+    const records = await loadSessionRecords(rootDir, sessionId);
+    const activation = records.find((record) => record.metadata?.kind === "skill-activation");
+    const userPrompt = records.find((record) => record.role === "user" && record.metadata?.kind !== "skill-activation");
+    expect(activation?.uuid).toBe(recordUuid);
+    expect(userPrompt?.parentUuid).toBe(recordUuid);
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  });
+
+  test("fail-closed: a headerless session is still rejected", async () => {
+    const rootDir = await createPromptRoot({ skillTools: true });
+    const sessionId = randomUUID();
+    const store = await createSessionStore(rootDir, sessionId);
+    await store.append({ role: "user", content: "orphan first record" });
+
+    await expect(
+      bootstrapTurn({ input: "hello", rootDir, sessionId, permission: { mode: "MOMENTUM" } }),
+    ).rejects.toThrow("Session Harness identity does not match");
+  });
+
+  test("fail-closed: activation-first ordering (the old bug) is still rejected", async () => {
+    const rootDir = await createPromptRoot({ skillTools: true });
+    const sessionId = randomUUID();
+    // Old TUI ordering: activation appended as the first record, no identity header.
+    await activateSkillForSession(rootDir, process.env, sessionId, "vesicle-docs", { profile: { id: "etl" } });
+
+    await expect(
+      bootstrapTurn({ input: "hello", rootDir, sessionId, permission: { mode: "MOMENTUM" } }),
+    ).rejects.toThrow("Session Harness identity does not match");
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  });
+});

--- a/tests/unit/skills-runtime/host-activation.test.ts
+++ b/tests/unit/skills-runtime/host-activation.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdir, rm } from "node:fs/promises";
+import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
@@ -135,6 +136,129 @@ describe("activateSkillForSession", () => {
     // so host activation fails instead of injecting different content.
     await expect(activateSkillForSession(scratch, env(), sessionId, "alpha", { profile: { id: "etl" }, filesystemOptions: noHost() }))
       .rejects.toThrow('Unknown skill "alpha". Available skills: (none).');
+    clearSessionSkillCatalog(sessionId);
+  });
+
+  test("returns the appended record uuid and chains an explicit branch parent", async () => {
+    await writeUserSkill("alpha");
+    const sessionId = randomUUID();
+    await createSession(sessionId);
+    const headerUuid = (await loadSessionRecords(scratch, sessionId))[0]!.uuid;
+
+    const activation = await activateSkillForSession(scratch, env(), sessionId, "alpha", {
+      profile: { id: "etl" },
+      filesystemOptions: noHost(),
+      parentUuid: headerUuid,
+    });
+    expect(activation.alreadyActive).toBe(false);
+    expect(activation.recordUuid).toBeDefined();
+
+    const stored = (await loadSessionRecords(scratch, sessionId)).find((record) => record.uuid === activation.recordUuid);
+    expect(stored?.metadata?.kind).toBe("skill-activation");
+    expect(stored?.parentUuid).toBe(headerUuid);
+
+    // A duplicate activation appends nothing and reports no record uuid.
+    const duplicate = await activateSkillForSession(scratch, env(), sessionId, "alpha", { profile: { id: "etl" }, filesystemOptions: noHost() });
+    expect(duplicate.alreadyActive).toBe(true);
+    expect(duplicate.recordUuid).toBeUndefined();
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  });
+
+  test("concurrent identical activations are serialized so hash dedup holds", async () => {
+    await writeUserSkill("alpha");
+    const sessionId = randomUUID();
+    await createSession(sessionId);
+
+    const [first, second] = await Promise.all([
+      activateSkillForSession(scratch, env(), sessionId, "alpha", { profile: { id: "etl" }, filesystemOptions: noHost() }),
+      activateSkillForSession(scratch, env(), sessionId, "alpha", { profile: { id: "etl" }, filesystemOptions: noHost() }),
+    ]);
+    expect([first.alreadyActive, second.alreadyActive].sort()).toEqual([false, true]);
+
+    const records = await loadSessionRecords(scratch, sessionId);
+    expect(records.filter((record) => record.metadata?.kind === "skill-activation").length).toBe(1);
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  });
+
+  test("cross-process concurrent activations are atomic so hash dedup holds", async () => {
+    await writeUserSkill("alpha");
+    const sessionId = randomUUID();
+    await createSession(sessionId);
+
+    const skillsImport = join(import.meta.dir, "..", "..", "..", "src", "core", "skills", "index.ts");
+    const workerPath = join(scratch, "worker.ts");
+    await Bun.write(
+      workerPath,
+      [
+        `import { activateSkillForSession } from ${JSON.stringify(skillsImport)};`,
+        `import { writeFile } from "node:fs/promises";`,
+        `import { existsSync } from "node:fs";`,
+        `const [rootDir, sid, skillName, readyFile, goFile, noHostDir] = process.argv.slice(2);`,
+        `await writeFile(readyFile, "ready", "utf8");`,
+        `while (!existsSync(goFile)) await Bun.sleep(2);`,
+        `const result = await activateSkillForSession(rootDir, process.env, sid, skillName, { profile: { id: "etl" }, filesystemOptions: { hostAssetsDirectory: noHostDir } });`,
+        `console.log(JSON.stringify({ alreadyActive: result.alreadyActive }));`,
+      ].join("\n"),
+    );
+
+    const noHostDir = join(scratch, "no-host");
+    const goFile = join(scratch, "go");
+    const env = { ...process.env, VESICLE_CONFIG_DIR: join(scratch, "config") };
+    const spawnWorker = (index: number) =>
+      Bun.spawn([process.execPath, workerPath, scratch, sessionId, "alpha", join(scratch, `ready-${index}`), goFile, noHostDir], { env, stdout: "pipe", stderr: "pipe" });
+    const children = [spawnWorker(0), spawnWorker(1)];
+
+    // Release both workers at once so they contend inside the critical section.
+    const deadline = Date.now() + 15000;
+    while (Date.now() < deadline && !(existsSync(join(scratch, "ready-0")) && existsSync(join(scratch, "ready-1")))) {
+      await Bun.sleep(5);
+    }
+    await writeFile(goFile, "go", "utf8");
+
+    const outputs = await Promise.all(
+      children.map(async (child) => {
+        const text = await new Response(child.stdout).text();
+        await child.exited;
+        return text;
+      }),
+    );
+    const statuses = outputs
+      .map((text) => (JSON.parse(text.trim().split("\n").at(-1)!) as { alreadyActive: boolean }).alreadyActive)
+      .sort();
+    expect(statuses).toEqual([false, true]);
+
+    const records = await loadSessionRecords(scratch, sessionId);
+    expect(records.filter((record) => record.metadata?.kind === "skill-activation").length).toBe(1);
+    clearSessionActivations(sessionId);
+    clearSessionSkillCatalog(sessionId);
+  }, 30000);
+
+  test.skipIf(process.getuid?.() === 0)("the registry is marked only after a durable append, so a failed append does not poison dedup", async () => {
+    await writeUserSkill("alpha");
+    const sessionId = randomUUID();
+    await createSession(sessionId);
+    const sessionsDir = join(scratch, ".vesicle", "sessions");
+
+    await chmod(sessionsDir, 0o555);
+    try {
+      await expect(activateSkillForSession(scratch, env(), sessionId, "alpha", { profile: { id: "etl" }, filesystemOptions: noHost() }))
+        .rejects.toThrow();
+      // The failed append must not have registered the activation.
+      const skill = (await resolveSkillCatalog(scratch, env(), { id: "etl" }, undefined, noHost())).byName.get("alpha");
+      const hash = skill?.parsed.ok ? skill.parsed.bodySha256 : "";
+      expect(hash).not.toBe("");
+      expect(isDuplicateActivation(sessionId, "alpha", hash)).toBe(false);
+    } finally {
+      await chmod(sessionsDir, 0o755);
+    }
+
+    const retry = await activateSkillForSession(scratch, env(), sessionId, "alpha", { profile: { id: "etl" }, filesystemOptions: noHost() });
+    expect(retry.alreadyActive).toBe(false);
+    const after = await activateSkillForSession(scratch, env(), sessionId, "alpha", { profile: { id: "etl" }, filesystemOptions: noHost() });
+    expect(after.alreadyActive).toBe(true);
+    clearSessionActivations(sessionId);
     clearSessionSkillCatalog(sessionId);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #131 (P1 / alpha.8 blocker): leading a fresh TUI session with `/skill <name>`, `/skill <name> --context-only`, or the bare `/skill` picker no longer trips "Session Harness identity does not match the active verified project baseline". The host path previously wrote the `skill-activation` record as the session's first record, so the first provider turn saw an "existing" session with no system header and the identity guard correctly rejected it.
- New core `initializeSessionIdentity` (+ shared `buildSessionHeaderRecord`) persists the **complete** session identity — engine/profile, provider/model, permission, generation, assets, instructions, Harness identity, and the frozen Skill catalog — as the first durable record before any activation. `bootstrapTurn` now reuses the same header builder, so the two shapes cannot drift.
- `activateSkillCommand` gates on provider-config/permission readiness (the active provider/model signals start as `"loading"`), adopts the session id only after the header is durable, and advances the branch head after a branched activation so the next turn chains after it rather than becoming a sibling.
- Dedup hardening (CR Should-fixes): the activation registry is marked only after a durable append, and the hydrate/dedup/append/record transaction runs under a per-session lock that is **atomic across processes** (new `withSessionActivationLock`, a separate lockfile from the append lock) — concurrent identical activations dedup to one whether from rapid repeated submission or separate processes.
- The Harness identity guard is unchanged; headerless legacy/corrupted sessions still fail closed and nothing auto-writes a header for an existing session.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` (1526 pass, 5 Windows-only skips, 0 fail)
- [x] `bun run doctor` (Missing: none)
- [x] `bun run scripts/smoke-skill-first-input-pty.ts` — source mode, all three surfaces
- [x] `VESICLE_BIN=./prism-vesicle bun run scripts/smoke-skill-first-input-pty.ts` — compiled Linux ELF (release shape), all three surfaces

New coverage:
- Integration `tests/integration/agent-loop/session-init.test.ts`: real first-input ordering (header precedes activation), `bootstrapTurn` acceptance, deterministic identity, full turn, `--context-only` chaining, and fail-closed guardrails (headerless + activation-first).
- Unit `tests/unit/skills-runtime/host-activation.test.ts`: `recordUuid` + branch-parent chaining, registry-after-append, in-process concurrent dedup, and a barrier-synchronized two-process test for cross-process atomicity (verified to fail without the lock).
- PTY smoke asserts rendering-independently: no identity error, exact provider-request accounting (invoke=1; context-only/picker = 0 before the follow-up, 1 after), and durable ordering incl. the persisted follow-up turn.

## Notes / Follow-ups

- Session-semantics change per `docs/dev/WORKFLOW.md` → short-lived branch + PR + independent CR (two CR rounds already addressed: in-process concurrency, then cross-process atomicity + smoke false-green).
- Out of scope (pre-existing, orthogonal to #131): the in-memory `conversation` signal does not receive the durable activation record in-process, so the invoke turn's request carries conversation + prompt without the activation body; resume replays it from durable records. Candidate for a separate issue.