### PR TITLE
refactor(tui): extract workspace buffer owner (W2)

### DIFF
--- a/src/tui/workspace/buffer-io.ts
+++ b/src/tui/workspace/buffer-io.ts
@@ -96,7 +96,16 @@ export async function readEditableFile(
     return null;
   }
   if (!info.isFile()) return null;
-  const content = await readFile(abs, "utf8");
+  // A file that vanishes or becomes unreadable between lstat and read must
+  // surface as "not readable" (null), never as an unhandled rejection — the
+  // editor pool, reload, and external-edit reconciliation all treat null as
+  // the missing/unreadable outcome.
+  let content: string;
+  try {
+    content = await readFile(abs, "utf8");
+  } catch {
+    return null;
+  }
   return {
     relPath: relPath.replace(/\\/g, "/"),
     content,

--- a/src/tui/workspace/buffer-io.ts
+++ b/src/tui/workspace/buffer-io.ts
@@ -1,8 +1,8 @@
 import { lstat, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import type { Stats } from "node:fs";
 import { dirname } from "node:path";
-import { OVERSIZED_BYTES, PREVIEW_LINE_CAP, type WorkspaceFilePreview } from "./workspace/tree-data";
-import { assertProjectRelativePath } from "./workspace/paths";
+import { OVERSIZED_BYTES, PREVIEW_LINE_CAP, type WorkspaceFilePreview } from "./tree-data";
+import { assertProjectRelativePath } from "./paths";
 
 /**
  * Editor kernel for the Workspace page (Scope B / #62, milestone B3): the
@@ -37,6 +37,11 @@ export type EditableFileRead = {
 };
 
 export type FileStamp = { mtimeMs: number; ino: number };
+
+/** Whether two disk identities describe the same file version (mtime + inode). */
+export function sameFileStamp(left: FileStamp, right: FileStamp): boolean {
+  return left.mtimeMs === right.mtimeMs && left.ino === right.ino;
+}
 
 /**
  * Whether a preview is eligible for the editable textarea. Mirrors the B2

--- a/src/tui/workspace/buffer-owner.ts
+++ b/src/tui/workspace/buffer-owner.ts
@@ -211,6 +211,18 @@ export function createBufferOwner(options: BufferOwnerPorts) {
       next.delete(relPath);
       return next;
     });
+    // A closed path must leave every pool set: a stale †disk marker would keep
+    // the status line pinned to warn after the buffer is gone. The `instances`
+    // map is deliberately left to the view's unmount lifecycle
+    // (unregisterEditorInstance): the textarea stays mounted while Solid
+    // reconciles, and purging here would orphan its registration and silently
+    // disable saves after a rekey onto a still-mounted buffer.
+    setExternalChanged((set) => {
+      if (!set.has(relPath)) return set;
+      const next = new Set(set);
+      next.delete(relPath);
+      return next;
+    });
     if (activeEditorPath() === relPath) setActiveEditorPath(null);
   }
 

--- a/src/tui/workspace/buffer-owner.ts
+++ b/src/tui/workspace/buffer-owner.ts
@@ -1,0 +1,644 @@
+import { createSignal } from "solid-js";
+import type { TextareaRenderable } from "@opentui/core";
+import {
+  atomicWriteFile,
+  computeFindOffsets,
+  readEditableFile,
+  readFileStamp,
+  sameFileStamp,
+  type FileStamp,
+} from "./buffer-io";
+import { entryExists } from "../workspace-fileops";
+import { assertProjectRelativePath } from "./paths";
+import type { EditorStatusTone } from "./types";
+
+/**
+ * Workspace editor-buffer owner (Scope B / #62, milestone B3). Uniquely owns
+ * the editable-buffer pool state: LRU editor order, the active buffer path,
+ * dirty paths, externally-changed paths, per-buffer metadata (saved snapshot +
+ * disk identity), textarea instances, cursor readout, and the find / goto /
+ * save-as input bars, plus the save / save-as / reload lifecycle.
+ *
+ * Boundary: dirty/clean truth is `instance.plainText !== meta.savedSnapshot`
+ * and disk identity is mtime + inode, both judged only here (or through the
+ * shared `sameFileStamp` comparator in buffer-io). The owner never touches the
+ * tree scan cache, validation snapshots, or external processes; cross-domain
+ * side effects flow through the narrow ports below, and the facade applies
+ * them.
+ */
+
+export type BufferWritten = {
+  path: string;
+  content: string;
+  stamp: FileStamp | null;
+};
+
+export type ExternalEditOutcome = "not-resident" | "unchanged" | "modified" | "removed" | "unreadable";
+
+export type BufferOwnerPorts = {
+  rootDir: string;
+  /** Status-line write for buffer-lifecycle messages (facade owns the line). */
+  onStatus: (text: string, tone?: EditorStatusTone) => void;
+  /** A save landed: invalidate the tree cache and refresh validation. */
+  onWritten: (result: BufferWritten) => void;
+  /** A reload/replace landed: refresh validation from the new content. */
+  onReloaded: (result: BufferWritten) => void;
+  /** Save-as switched the active buffer to `target`: refresh viewer + index. */
+  onSaveAsTargetActivated: (target: string) => Promise<void>;
+  /** The active buffer changed on disk: raise the overwrite confirm. */
+  onOverwriteConfirm: (path: string) => void;
+  /** Save-as would clobber an existing file: raise the save-as overwrite confirm. */
+  onSaveAsOverwrite: (target: string) => void;
+  /** A dirty/externally-changed buffer asks to reload: raise the reload confirm. */
+  onReloadConfirm: (path: string) => void;
+  /** A save is starting: clear any leftover close-intent from a prior dialog chain. */
+  onSaveStarted: () => void;
+};
+
+function errMsg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** LRU cap for open editable buffers (spike §4.1 / plan §4.1). */
+const EDITOR_LRU_CAP = 8;
+
+type EditorBufferMeta = FileStamp & {
+  savedSnapshot: string;
+  initialContent: string;
+};
+
+/**
+ * Reset a stale horizontal scroll offset after the cursor lands on a shorter
+ * line. OpenTUI's textarea scrolls right to follow the cursor on a long line
+ * but does not pull the offset back when the cursor moves to a shorter line,
+ * so the shorter line renders with its start cut off. This only resets when
+ * the cursor already fits within the viewport from offset 0, so typing on a
+ * long line is never disturbed. Used after navigation keys (deferred, see
+ * WorkspacePage) and after imperative goto / find jumps.
+ *
+ * Dormant while the editor uses wrapMode="word" (no horizontal scroll, so
+ * offsetX stays 0); kept as the guard for any future return to "none".
+ */
+export function resetStaleHorizontalScroll(ed: TextareaRenderable): void {
+  const vp = ed.editorView.getViewport();
+  if (vp.offsetX > 0 && ed.logicalCursor.col < vp.width) {
+    ed.editorView.setViewport(0, vp.offsetY, vp.width, vp.height, false);
+  }
+}
+
+export function createBufferOwner(options: BufferOwnerPorts) {
+  const { rootDir, onStatus } = options;
+
+  // editorOrder: most-recently-used first. activeEditorPath: the editable
+  // buffer currently shown (null while a read-only file or no file is open).
+  const [editorOrder, setEditorOrder] = createSignal<string[]>([]);
+  const [activeEditorPath, setActiveEditorPath] = createSignal<string | null>(null);
+  const [dirtyPaths, setDirtyPaths] = createSignal<ReadonlySet<string>>(new Set());
+  const [externalChanged, setExternalChanged] = createSignal<ReadonlySet<string>>(new Set());
+  const bufferMeta = new Map<string, EditorBufferMeta>();
+  const instances = new Map<string, TextareaRenderable>();
+
+  // cursor position of the active buffer (status line Ln:Col), 0-indexed
+  const [cursorLn, setCursorLn] = createSignal(0);
+  const [cursorCol, setCursorCol] = createSignal(0);
+
+  // —— editor input bars ——
+  const [findActive, setFindActive] = createSignal(false);
+  const [findQuery, setFindQuery] = createSignal("");
+  const [findMatches, setFindMatches] = createSignal<number[]>([]);
+  const [findMatchIndex, setFindMatchIndex] = createSignal(-1);
+  let findPlainSnapshot = "";
+
+  const [gotoActive, setGotoActive] = createSignal(false);
+  const [gotoDraft, setGotoDraft] = createSignal("");
+
+  const [saveAsActive, setSaveAsActive] = createSignal(false);
+  const [saveAsDraft, setSaveAsDraft] = createSignal("");
+
+  // —— instance + dirty tracking ——
+
+  function registerEditorInstance(relPath: string, instance: TextareaRenderable): void {
+    instances.set(relPath, instance);
+  }
+
+  function unregisterEditorInstance(relPath: string): void {
+    instances.delete(relPath);
+  }
+
+  /**
+   * Content-change callback from the textarea. Dirty is plainText-vs-snapshot
+   * so undo-back-to-clean clears the dot and a programmatic reload (which
+   * updates the snapshot first) never reads as a user edit.
+   */
+  function markEditorContentChanged(relPath: string): void {
+    const instance = instances.get(relPath);
+    const meta = bufferMeta.get(relPath);
+    if (!instance || !meta) return;
+    const dirty = instance.plainText !== meta.savedSnapshot;
+    setDirtyPaths((set) => {
+      if (dirty === set.has(relPath)) return set;
+      const next = new Set(set);
+      if (dirty) next.add(relPath);
+      else next.delete(relPath);
+      return next;
+    });
+    // A new edit makes a lingering "saved" / "reloaded" note stale — clear it
+    // so the status line never reads "saved" while the dot shows unsaved work.
+    if (dirty) onStatus("");
+  }
+
+  function activeInstance(): TextareaRenderable | undefined {
+    const path = activeEditorPath();
+    return path ? instances.get(path) : undefined;
+  }
+
+  /** Status-line cursor readout (onCursorChange feeds this from the textarea). */
+  function reportCursor(line: number, col: number): void {
+    setCursorLn(line);
+    setCursorCol(col);
+  }
+
+  function editorInitialContent(relPath: string): string {
+    return bufferMeta.get(relPath)?.initialContent ?? "";
+  }
+
+  // —— pool lifecycle ——
+
+  /**
+   * Admit a file into the editable buffer pool (LRU, dirty-protected). On the
+   * rare "all dirty" refusal the file still opens in the read-only viewer and
+   * a status line explains why no buffer was created.
+   */
+  async function open(relPath: string): Promise<void> {
+    if (!editorOrder().includes(relPath) && editorOrder().length >= EDITOR_LRU_CAP) {
+      const victim = [...editorOrder()].reverse().find((path) => !dirtyPaths().has(path));
+      if (!victim) {
+        onStatus(`${EDITOR_LRU_CAP} buffers open and all dirty — save or close one first`, "error");
+        setActiveEditorPath(null);
+        return;
+      }
+      close(victim);
+    }
+    if (!bufferMeta.has(relPath)) {
+      const read = await readEditableFile(rootDir, relPath);
+      if (!read) {
+        setActiveEditorPath(null);
+        return;
+      }
+      bufferMeta.set(relPath, {
+        savedSnapshot: read.content,
+        mtimeMs: read.mtimeMs,
+        ino: read.ino,
+        initialContent: read.content,
+      });
+    }
+    setEditorOrder((order) => [relPath, ...order.filter((path) => path !== relPath)]);
+    setActiveEditorPath(relPath);
+    setExternalChanged((set) => {
+      if (!set.has(relPath)) return set;
+      const next = new Set(set);
+      next.delete(relPath);
+      return next;
+    });
+  }
+
+  function close(relPath: string): void {
+    setEditorOrder((order) => order.filter((path) => path !== relPath));
+    bufferMeta.delete(relPath);
+    setDirtyPaths((set) => {
+      if (!set.has(relPath)) return set;
+      const next = new Set(set);
+      next.delete(relPath);
+      return next;
+    });
+    if (activeEditorPath() === relPath) setActiveEditorPath(null);
+  }
+
+  // —— save / save-as / reload ——
+
+  async function saveActive(): Promise<boolean> {
+    // Clear any close-intent left over from a prior dirty-confirm chain so it
+    // can't leak into this unrelated save (a stale closeAfterSave could close
+    // the wrong buffer when a later plain save force-overwrites). The dirty-
+    // confirm 'y' path re-arms it in its own .then, after this returns.
+    options.onSaveStarted();
+    const path = activeEditorPath();
+    if (!path) return false;
+    const instance = instances.get(path);
+    const meta = bufferMeta.get(path);
+    if (!instance || !meta) return false;
+    const currentStamp = await readFileStamp(rootDir, path);
+    if (currentStamp !== null && !sameFileStamp(currentStamp, meta)) {
+      options.onOverwriteConfirm(path);
+      return false;
+    }
+    return Boolean(await writeBuffer(path, instance.plainText));
+  }
+
+  /** Write the active buffer's content even when the disk identity changed. */
+  async function forceSave(): Promise<boolean> {
+    const path = activeEditorPath();
+    if (!path) return false;
+    const instance = instances.get(path);
+    if (!instance) return false;
+    return Boolean(await writeBuffer(path, instance.plainText));
+  }
+
+  /**
+   * Atomic write + post-save bookkeeping. Returns null (and surfaces a status
+   * error) on a disk failure rather than throwing, so the `void saveActive()`
+   * callers don't surface unhandled rejections and the buffer stays dirty.
+   */
+  async function writeBuffer(relPath: string, content: string): Promise<BufferWritten | null> {
+    let abs: string;
+    try {
+      abs = assertProjectRelativePath(rootDir, relPath);
+      await atomicWriteFile(abs, content);
+    } catch (error) {
+      onStatus(`failed to save ${relPath}: ${errMsg(error)}`, "error");
+      return null;
+    }
+    const meta = bufferMeta.get(relPath);
+    const stamp = await readFileStamp(rootDir, relPath);
+    if (meta) {
+      meta.savedSnapshot = content;
+      if (stamp) {
+        meta.mtimeMs = stamp.mtimeMs;
+        meta.ino = stamp.ino;
+      }
+    }
+    setDirtyPaths((set) => {
+      if (!set.has(relPath)) return set;
+      const next = new Set(set);
+      next.delete(relPath);
+      return next;
+    });
+    setExternalChanged((set) => {
+      if (!set.has(relPath)) return set;
+      const next = new Set(set);
+      next.delete(relPath);
+      return next;
+    });
+    const result = { path: relPath, content, stamp };
+    onStatus(`saved ${relPath}`, "success");
+    options.onWritten(result);
+    return result;
+  }
+
+  async function commitSaveAs(target: string): Promise<void> {
+    const path = activeEditorPath();
+    if (!path) return;
+    const instance = instances.get(path);
+    if (!instance) return;
+    const trimmed = target.trim().replace(/\\/g, "/");
+    if (!trimmed) {
+      onStatus("save-as needs a path", "error");
+      return;
+    }
+    try {
+      assertProjectRelativePath(rootDir, trimmed);
+    } catch (error) {
+      onStatus(String(error instanceof Error ? error.message : error), "error");
+      return;
+    }
+    // Refuse to silently clobber a different existing file — mirror the
+    // move/copy overwrite confirm. 'o' completes the save-as via performSaveAs.
+    if (trimmed !== path && await entryExists(rootDir, trimmed)) {
+      options.onSaveAsOverwrite(trimmed);
+      return;
+    }
+    await performSaveAs(trimmed);
+  }
+
+  /** Write the active buffer's content to `target` and switch the buffer there. */
+  async function performSaveAs(target: string): Promise<void> {
+    const path = activeEditorPath();
+    const instance = path ? instances.get(path) : undefined;
+    if (!path || !instance) return;
+    const content = instance.plainText;
+    const saved = await writeBuffer(target, content);
+    if (!saved) return; // writeBuffer already surfaced the error
+    // Switch the editable buffer to the new path (close the old, open the new
+    // without re-reading — we just wrote it). The recorded mtime must be the
+    // file's real mtime: a wall-clock value never matches the on-disk stat
+    // and would raise a spurious overwrite confirm on the next Ctrl+S.
+    close(path);
+    const writtenStamp = await readFileStamp(rootDir, target);
+    bufferMeta.set(target, {
+      savedSnapshot: content,
+      mtimeMs: writtenStamp?.mtimeMs ?? Date.now(),
+      ino: writtenStamp?.ino ?? 0,
+      initialContent: content,
+    });
+    setEditorOrder((order) => [target, ...order.filter((p) => p !== target)]);
+    setActiveEditorPath(target);
+    await options.onSaveAsTargetActivated(target);
+  }
+
+  async function reloadActiveBuffer(): Promise<void> {
+    const path = activeEditorPath();
+    if (!path) return;
+    const read = await readEditableFile(rootDir, path);
+    if (!read) {
+      onStatus(`${path} is gone from disk`, "error");
+      return;
+    }
+    const instance = instances.get(path);
+    const meta = bufferMeta.get(path);
+    if (!instance || !meta) return;
+    // replaceText preserves undo history (one undo step back to the local
+    // version); setText would clear the stack.
+    instance.replaceText(read.content);
+    meta.savedSnapshot = read.content;
+    meta.mtimeMs = read.mtimeMs;
+    meta.ino = read.ino;
+    setDirtyPaths((set) => {
+      if (!set.has(path)) return set;
+      const next = new Set(set);
+      next.delete(path);
+      return next;
+    });
+    setExternalChanged((set) => {
+      if (!set.has(path)) return set;
+      const next = new Set(set);
+      next.delete(path);
+      return next;
+    });
+    // Reload is a content change: install a fresh snapshot so the status row
+    // never reads the pre-reload verdict as current (Issue #118 §3).
+    options.onReloaded({ path, content: read.content, stamp: { mtimeMs: read.mtimeMs, ino: read.ino } });
+    onStatus(`reloaded ${path}`, "success");
+  }
+
+  function requestReloadActive(): void {
+    const path = activeEditorPath();
+    if (!path) return;
+    if (dirtyPaths().has(path) || externalChanged().has(path)) {
+      options.onReloadConfirm(path);
+    } else {
+      onStatus(`${path} is already current`);
+    }
+  }
+
+  async function checkExternalModifications(): Promise<void> {
+    const changed: string[] = [];
+    for (const path of editorOrder()) {
+      const meta = bufferMeta.get(path);
+      if (!meta) continue;
+      const stamp = await readFileStamp(rootDir, path);
+      if (stamp !== null && !sameFileStamp(stamp, meta)) changed.push(path);
+    }
+    if (changed.length === 0) return;
+    setExternalChanged(new Set(changed));
+    onStatus(`${changed.length} file(s) changed on disk — Ctrl+R to reload`, "warn");
+  }
+
+  /**
+   * External-editor reconciliation for a resident buffer: compare the live
+   * disk identity, replace the buffer content when modified, close it when
+   * removed, and surface the outcome class so the facade can react to
+   * viewer/focus state. A non-resident path returns `not-resident`.
+   */
+  async function reconcileExternalChange(relPath: string): Promise<ExternalEditOutcome> {
+    const meta = bufferMeta.get(relPath);
+    if (!meta) return "not-resident";
+    const currentStamp = await readFileStamp(rootDir, relPath);
+    if (currentStamp === null) {
+      onStatus(`${relPath} was removed by the external editor`, "error");
+      close(relPath);
+      return "removed";
+    }
+    if (sameFileStamp(currentStamp, meta)) {
+      onStatus("no changes from external editor");
+      return "unchanged";
+    }
+    const read = await readEditableFile(rootDir, relPath);
+    if (!read) {
+      onStatus(`${relPath} is no longer a readable file`, "error");
+      close(relPath);
+      return "unreadable";
+    }
+    const inst = instances.get(relPath);
+    if (inst) {
+      inst.replaceText(read.content);
+      resetStaleHorizontalScroll(inst);
+    }
+    meta.savedSnapshot = read.content;
+    meta.mtimeMs = read.mtimeMs;
+    meta.ino = read.ino;
+    setExternalChanged((set) => {
+      if (!set.has(relPath)) return set;
+      const next = new Set(set);
+      next.delete(relPath);
+      return next;
+    });
+    options.onReloaded({ path: relPath, content: read.content, stamp: { mtimeMs: read.mtimeMs, ino: read.ino } });
+    onStatus(`reloaded ${relPath}`, "success");
+    return "modified";
+  }
+
+  /** Rekey a resident buffer from oldPath to newPath (rename/move). */
+  function rekey(oldPath: string, newPath: string): void {
+    if (oldPath === newPath) return;
+    const meta = bufferMeta.get(oldPath);
+    if (!meta) return;
+    // Renaming A onto an already-open B: close B first — the move is
+    // overwriting B on disk, so B's stale buffer + pool slot must go before
+    // we rekey A, otherwise editorOrder ends up with newPath twice and B's
+    // meta is silently clobbered.
+    if (bufferMeta.has(newPath)) close(newPath);
+    const inst = instances.get(oldPath);
+    const currentText = inst?.plainText ?? meta.savedSnapshot;
+    bufferMeta.delete(oldPath);
+    bufferMeta.set(newPath, { ...meta, initialContent: currentText });
+    instances.delete(oldPath);
+    setEditorOrder((order) => order.map((p) => (p === oldPath ? newPath : p)));
+    setActiveEditorPath((p) => (p === oldPath ? newPath : p));
+    setDirtyPaths((set) => rekeySet(set, oldPath, newPath));
+    setExternalChanged((set) => rekeySet(set, oldPath, newPath));
+  }
+
+  function rekeySet(set: ReadonlySet<string>, oldPath: string, newPath: string): ReadonlySet<string> {
+    if (!set.has(oldPath)) return set;
+    const next = new Set(set);
+    next.delete(oldPath);
+    next.add(newPath);
+    return next;
+  }
+
+  // —— find / goto / save-as bars ——
+
+  function openFind(): void {
+    const instance = activeInstance();
+    if (!instance) return;
+    findPlainSnapshot = instance.plainText;
+    setFindQuery("");
+    setFindMatches([]);
+    setFindMatchIndex(-1);
+    setFindActive(true);
+  }
+
+  function closeFind(): void {
+    setFindActive(false);
+    findPlainSnapshot = "";
+  }
+
+  function refreshFind(): void {
+    const offsets = computeFindOffsets(findPlainSnapshot, findQuery());
+    setFindMatches(offsets);
+    setFindMatchIndex(offsets.length > 0 ? 0 : -1);
+    if (offsets.length > 0) selectFindMatch(0);
+  }
+
+  function findBackspace(): void {
+    setFindQuery((query) => query.slice(0, -1));
+    refreshFind();
+  }
+
+  function findAppend(char: string): void {
+    setFindQuery((query) => query + char);
+    refreshFind();
+  }
+
+  /** Enter with matches: move to the next/previous match (shift inverts). */
+  function advanceFindMatch(step: 1 | -1): void {
+    const matches = findMatches();
+    if (matches.length === 0) return;
+    const next = (findMatchIndex() + step + matches.length) % matches.length;
+    setFindMatchIndex(next);
+    selectFindMatch(next);
+  }
+
+  function selectFindMatch(index: number): void {
+    const instance = activeInstance();
+    if (!instance) return;
+    const offset = findMatches()[index];
+    if (offset === undefined) return;
+    const length = findQuery().length;
+    instance.setSelection(offset, offset + length);
+    resetStaleHorizontalScroll(instance);
+  }
+
+  function openGoto(): void {
+    if (!activeInstance()) return;
+    setGotoDraft("");
+    setGotoActive(true);
+  }
+
+  function closeGotoBar(): void {
+    setGotoActive(false);
+  }
+
+  function gotoBackspace(): void {
+    setGotoDraft((draft) => draft.slice(0, -1));
+  }
+
+  function gotoAppend(char: string): void {
+    setGotoDraft((draft) => draft + char);
+  }
+
+  function gotoCommit(): void {
+    const target = parseInt(gotoDraft(), 10);
+    setGotoActive(false);
+    if (Number.isFinite(target) && target >= 1) {
+      gotoLine(target - 1);
+    }
+  }
+
+  function openSaveAs(): void {
+    if (!activeEditorPath()) return;
+    // Start empty: in a keyboard line-input, typing appends, so pre-filling
+    // the current path would force the user to clear it first. The status
+    // line shows "save as: ▌" and Enter commits the typed path.
+    setSaveAsDraft("");
+    setSaveAsActive(true);
+  }
+
+  function closeSaveAsBar(): void {
+    setSaveAsActive(false);
+  }
+
+  function saveAsBackspace(): void {
+    setSaveAsDraft((draft) => draft.slice(0, -1));
+  }
+
+  function saveAsAppend(char: string): void {
+    setSaveAsDraft((draft) => draft + char);
+  }
+
+  function saveAsCommit(): void {
+    const target = saveAsDraft();
+    setSaveAsActive(false);
+    void commitSaveAs(target);
+  }
+
+  /** Imperative cursor jump on the active buffer (goto bar / findings jump). */
+  function gotoLine(line: number): void {
+    const inst = activeInstance();
+    if (!inst) return;
+    inst.gotoLine(line);
+    resetStaleHorizontalScroll(inst);
+  }
+
+  /** Resident disk identity of an open buffer, or null when not resident. */
+  function stampOf(relPath: string): FileStamp | null {
+    const meta = bufferMeta.get(relPath);
+    return meta ? { mtimeMs: meta.mtimeMs, ino: meta.ino } : null;
+  }
+
+  return {
+    // editor pool
+    editorOrder,
+    activeEditorPath,
+    dirtyPaths,
+    externalChanged,
+    editorInitialContent,
+    registerEditorInstance,
+    unregisterEditorInstance,
+    markEditorContentChanged,
+    reportCursor,
+    cursorLn,
+    cursorCol,
+    // lifecycle
+    open,
+    close,
+    saveActive,
+    forceSave,
+    reloadActiveBuffer,
+    requestReloadActive,
+    checkExternalModifications,
+    reconcileExternalChange,
+    rekey,
+    stampOf,
+    setActiveEditorPath,
+    // find / goto / save-as
+    findActive,
+    findQuery,
+    findMatches,
+    findMatchIndex,
+    openFind,
+    closeFind,
+    findBackspace,
+    findAppend,
+    advanceFindMatch,
+    gotoActive,
+    gotoDraft,
+    openGoto,
+    closeGotoBar,
+    gotoBackspace,
+    gotoAppend,
+    gotoCommit,
+    saveAsActive,
+    saveAsDraft,
+    openSaveAs,
+    closeSaveAsBar,
+    saveAsBackspace,
+    saveAsAppend,
+    saveAsCommit,
+    commitSaveAs,
+    performSaveAs,
+    gotoLine,
+  };
+}
+
+export type BufferOwner = ReturnType<typeof createBufferOwner>;

--- a/src/tui/workspace/controller.ts
+++ b/src/tui/workspace/controller.ts
@@ -1,14 +1,12 @@
 import { createSignal } from "solid-js";
-import type { TextareaRenderable } from "@opentui/core";
 import type { TuiKeyEvent } from "../decision-interaction";
 import {
-  atomicWriteFile,
-  computeFindOffsets,
   isEditablePreview,
-  readEditableFile,
   readFileStamp,
+  sameFileStamp,
   type FileStamp,
-} from "../workspace-editor";
+} from "./buffer-io";
+import { createBufferOwner } from "./buffer-owner";
 import {
   copyEntry,
   createDirectory,
@@ -45,22 +43,14 @@ import type { ShellPage, WorkspaceFocusRegion, ViewerScrollEdge, EditorStatusTon
  * (editor → tree → composer), and printable keys only reach the composer
  * while it is focused, so tree/viewer shortcuts never collide with drafting.
  *
- * Editor (B3): one OpenTUI textarea instance per open file preserves per-file
- * undo history (spike finding: `setText` clears the stack, so the buffer must
- * live inside the component, not be swapped as plain text). The controller
- * owns the buffer pool (LRU, dirty-protected), dirty tracking
- * (plainText-vs-snapshot), save / save-as with a project-root-bounded atomic
- * write, find / goto / save-as input bars, the dirty-on-close confirm, and
- * external-modification detection by mtime + inode on save and page
- * reactivation.
- *
  * Page state lives outside the component tree so switching pages keeps the
  * tree, open file, and focus; nothing here touches session JSONL,
  * checkpoints, or rewind.
  *
- * Ownership: tree navigation + quick-open state live in `createTreeOwner`
- * (see ./tree-owner); this factory composes the owners and keeps the
- * page/focus model, viewer, editor pool, file mutations, validation, and
+ * Ownership: tree navigation + quick-open state live in `createTreeOwner`,
+ * the editable-buffer pool / save / reload / find / goto / save-as live in
+ * `createBufferOwner`; this factory composes the owners, keeps the
+ * page/focus model, viewer, dialogs, file mutations, validation, and
  * external-editor orchestration until their own waves take over.
  */
 
@@ -75,18 +65,6 @@ type EditorDialog =
 /** Tree file-management input bar (B4 §5.1): path prompts isomorphic to save-as. */
 type OpsBarKind = "create-file" | "create-dir" | "move" | "copy";
 type OpsBar = { kind: OpsBarKind; draft: string; source: string } | null;
-
-type EditorBufferMeta = FileStamp & {
-  savedSnapshot: string;
-  initialContent: string;
-};
-
-function sameFileStamp(left: FileStamp, right: FileStamp): boolean {
-  return left.mtimeMs === right.mtimeMs && left.ino === right.ino;
-}
-
-/** LRU cap for open editable buffers (spike §4.1 / plan §4.1). */
-const EDITOR_LRU_CAP = 8;
 
 const FOCUS_CYCLE: WorkspaceFocusRegion[] = ["tree", "editor", "composer"];
 
@@ -121,25 +99,6 @@ function isCtrl(key: TuiKeyEvent, letter: string): boolean {
   return Boolean(key.ctrl && key.name === letter);
 }
 
-/**
- * Reset a stale horizontal scroll offset after the cursor lands on a shorter
- * line. OpenTUI's textarea scrolls right to follow the cursor on a long line
- * but does not pull the offset back when the cursor moves to a shorter line,
- * so the shorter line renders with its start cut off. This only resets when
- * the cursor already fits within the viewport from offset 0, so typing on a
- * long line is never disturbed. Used after navigation keys (deferred, see
- * WorkspacePage) and after imperative goto / find jumps.
- *
- * Dormant while the editor uses wrapMode="word" (no horizontal scroll, so
- * offsetX stays 0); kept as the guard for any future return to "none".
- */
-export function resetStaleHorizontalScroll(ed: TextareaRenderable): void {
-  const vp = ed.editorView.getViewport();
-  if (vp.offsetX > 0 && ed.logicalCursor.col < vp.width) {
-    ed.editorView.setViewport(0, vp.offsetY, vp.width, vp.height, false);
-  }
-}
-
 function isSaveKey(key: TuiKeyEvent): boolean {
   return isCtrl(key, "s") || key.sequence === "\x13" || key.raw === "\x13";
 }
@@ -148,25 +107,6 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   const [page, setPage] = createSignal<ShellPage>("chat");
   const [focusRegion, setFocusRegion] = createSignal<WorkspaceFocusRegion>("tree");
 
-  const tree = createTreeOwner({
-    rootDir,
-    onOpenPath: (relPath) => openPath(relPath),
-    onLoadError: (message) => status(`failed to load workspace: ${message}`, "error"),
-  });
-
-  // —— viewer ——
-  const [openFile, setOpenFile] = createSignal<WorkspaceFilePreview | null>(null);
-  const [viewMode, setViewMode] = createSignal<"source" | "preview">("source");
-  let viewerScrollBy: ((delta: number) => void) | null = null;
-  let viewerScrollEdge: ((edge: ViewerScrollEdge) => void) | null = null;
-
-  // —— editor pool (B3) ——
-  // editorOrder: most-recently-used first. activeEditorPath: the editable
-  // buffer currently shown (null while a read-only file or no file is open).
-  const [editorOrder, setEditorOrder] = createSignal<string[]>([]);
-  const [activeEditorPath, setActiveEditorPath] = createSignal<string | null>(null);
-  const [dirtyPaths, setDirtyPaths] = createSignal<ReadonlySet<string>>(new Set());
-  const [externalChanged, setExternalChanged] = createSignal<ReadonlySet<string>>(new Set());
   const [editorStatusState, setEditorStatusState] = createSignal<{ text: string; tone: EditorStatusTone }>({ text: "", tone: "info" });
   /** Status text (the component reads this for the status-line body). */
   const editorStatus = () => editorStatusState().text;
@@ -176,28 +116,45 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   function status(text: string, tone: EditorStatusTone = "info"): void {
     setEditorStatusState({ text, tone });
   }
-  const bufferMeta = new Map<string, EditorBufferMeta>();
-  const instances = new Map<string, TextareaRenderable>();
   /** Tracks whether the workspace page has been entered at least once. */
   let workspaceEntered = false;
 
-  // cursor position of the active buffer (status line Ln:Col), 0-indexed
-  const [cursorLn, setCursorLn] = createSignal(0);
-  const [cursorCol, setCursorCol] = createSignal(0);
+  const tree = createTreeOwner({
+    rootDir,
+    onOpenPath: (relPath) => openPath(relPath),
+    onLoadError: (message) => status(`failed to load workspace: ${message}`, "error"),
+  });
 
-  // —— editor input bars / dialogs ——
-  const [findActive, setFindActive] = createSignal(false);
-  const [findQuery, setFindQuery] = createSignal("");
-  const [findMatches, setFindMatches] = createSignal<number[]>([]);
-  const [findMatchIndex, setFindMatchIndex] = createSignal(-1);
-  let findPlainSnapshot = "";
+  const buffer = createBufferOwner({
+    rootDir,
+    onStatus: (text, tone) => status(text, tone),
+    onWritten: ({ path, content, stamp }) => {
+      tree.invalidateCache(path);
+      setValidationFor(path, content, stamp);
+    },
+    onReloaded: ({ path, content, stamp }) => {
+      setValidationFor(path, content, stamp);
+    },
+    onSaveAsTargetActivated: async (target) => {
+      setOpenFile(await readFilePreview(rootDir, target));
+      setViewMode("source");
+      void tree.rebuildIndex();
+    },
+    onOverwriteConfirm: (path) => setDialog({ kind: "overwrite-confirm", path }),
+    onSaveAsOverwrite: (target) => setDialog({ kind: "save-as-overwrite", path: target }),
+    onReloadConfirm: (path) => setDialog({ kind: "reload-confirm", path }),
+    onSaveStarted: () => {
+      closeAfterSave = false;
+    },
+  });
 
-  const [gotoActive, setGotoActive] = createSignal(false);
-  const [gotoDraft, setGotoDraft] = createSignal("");
+  // —— viewer ——
+  const [openFile, setOpenFile] = createSignal<WorkspaceFilePreview | null>(null);
+  const [viewMode, setViewMode] = createSignal<"source" | "preview">("source");
+  let viewerScrollBy: ((delta: number) => void) | null = null;
+  let viewerScrollEdge: ((edge: ViewerScrollEdge) => void) | null = null;
 
-  const [saveAsActive, setSaveAsActive] = createSignal(false);
-  const [saveAsDraft, setSaveAsDraft] = createSignal("");
-
+  // —— editor input dialogs ——
   const [dialog, setDialog] = createSignal<EditorDialog>(null);
 
   // —— file-management ops bar (B4 §5.1) ——
@@ -222,7 +179,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
    */
   function validationState(): ValidationState {
     const snap = validationSnapshot();
-    if ((snap.state === "result" || snap.state === "no-match") && dirtyPaths().has(snap.path)) {
+    if ((snap.state === "result" || snap.state === "no-match") && buffer.dirtyPaths().has(snap.path)) {
       return { state: "stale", path: snap.path };
     }
     return snap;
@@ -262,7 +219,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     setPage(next);
     if (next === "workspace") {
       void tree.ensureLoaded();
-      if (reentering || workspaceEntered) void checkExternalModifications();
+      if (reentering || workspaceEntered) void buffer.checkExternalModifications();
       workspaceEntered = true;
     }
   }
@@ -293,9 +250,9 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
       && !dialogActionPending
       && !tree.quickOpenActive()
       && !findingsOpen()
-      && !findActive()
-      && !gotoActive()
-      && !saveAsActive()
+      && !buffer.findActive()
+      && !buffer.gotoActive()
+      && !buffer.saveAsActive()
       && !dialog()
       && !opsBar();
   }
@@ -309,7 +266,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
    */
   function canEditOpenFile(): boolean {
     const file = openFile();
-    return Boolean(file && isEditablePreview(file) && activeEditorPath() === file.relPath);
+    return Boolean(file && isEditablePreview(file) && buffer.activeEditorPath() === file.relPath);
   }
 
   async function openPath(relPath: string): Promise<boolean> {
@@ -321,61 +278,11 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     status("");
     setValidationFor(relPath, preview.lines?.join("\n") ?? "", await readFileStamp(rootDir, relPath));
     if (isEditablePreview(preview)) {
-      await openEditableBuffer(relPath);
+      await buffer.open(relPath);
     } else {
-      setActiveEditorPath(null);
+      buffer.setActiveEditorPath(null);
     }
     return true;
-  }
-
-  /**
-   * Admit a file into the editable buffer pool (LRU, dirty-protected). On the
-   * rare "all dirty" refusal the file still opens in the read-only viewer and
-   * a status line explains why no buffer was created.
-   */
-  async function openEditableBuffer(relPath: string): Promise<void> {
-    if (!editorOrder().includes(relPath) && editorOrder().length >= EDITOR_LRU_CAP) {
-      const victim = [...editorOrder()].reverse().find((path) => !dirtyPaths().has(path));
-      if (!victim) {
-        setEditorStatusState({ text: `${EDITOR_LRU_CAP} buffers open and all dirty — save or close one first`, tone: "error" });
-        setActiveEditorPath(null);
-        return;
-      }
-      closeBuffer(victim);
-    }
-    if (!bufferMeta.has(relPath)) {
-      const read = await readEditableFile(rootDir, relPath);
-      if (!read) {
-        setActiveEditorPath(null);
-        return;
-      }
-      bufferMeta.set(relPath, {
-        savedSnapshot: read.content,
-        mtimeMs: read.mtimeMs,
-        ino: read.ino,
-        initialContent: read.content,
-      });
-    }
-    setEditorOrder((order) => [relPath, ...order.filter((path) => path !== relPath)]);
-    setActiveEditorPath(relPath);
-    setExternalChanged((set) => {
-      if (!set.has(relPath)) return set;
-      const next = new Set(set);
-      next.delete(relPath);
-      return next;
-    });
-  }
-
-  function closeBuffer(relPath: string): void {
-    setEditorOrder((order) => order.filter((path) => path !== relPath));
-    bufferMeta.delete(relPath);
-    setDirtyPaths((set) => {
-      if (!set.has(relPath)) return set;
-      const next = new Set(set);
-      next.delete(relPath);
-      return next;
-    });
-    if (activeEditorPath() === relPath) setActiveEditorPath(null);
   }
 
   /** Command bridge: open the page, ensure the model is loaded, locate. */
@@ -421,231 +328,6 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     };
   }
 
-  // —— editor instance + dirty tracking ——
-
-  function registerEditorInstance(relPath: string, instance: TextareaRenderable): void {
-    instances.set(relPath, instance);
-  }
-
-  function unregisterEditorInstance(relPath: string): void {
-    instances.delete(relPath);
-  }
-
-  /**
-   * Content-change callback from the textarea. Dirty is plainText-vs-snapshot
-   * so undo-back-to-clean clears the dot and a programmatic reload (which
-   * updates the snapshot first) never reads as a user edit.
-   */
-  function markEditorContentChanged(relPath: string): void {
-    const instance = instances.get(relPath);
-    const meta = bufferMeta.get(relPath);
-    if (!instance || !meta) return;
-    const dirty = instance.plainText !== meta.savedSnapshot;
-    setDirtyPaths((set) => {
-      if (dirty === set.has(relPath)) return set;
-      const next = new Set(set);
-      if (dirty) next.add(relPath);
-      else next.delete(relPath);
-      return next;
-    });
-    // A new edit makes a lingering "saved" / "reloaded" note stale — clear it
-    // so the status line never reads "saved" while the dot shows unsaved work.
-    if (dirty && editorStatusState().text) status("");
-  }
-
-  function activeInstance(): TextareaRenderable | undefined {
-    const path = activeEditorPath();
-    return path ? instances.get(path) : undefined;
-  }
-
-  /** Status-line cursor readout (onCursorChange feeds this from the textarea). */
-  function reportCursor(line: number, col: number): void {
-    setCursorLn(line);
-    setCursorCol(col);
-  }
-
-  function editorInitialContent(relPath: string): string {
-    return bufferMeta.get(relPath)?.initialContent ?? "";
-  }
-
-  // —— save / save-as / reload ——
-
-  async function saveActive(): Promise<boolean> {
-    // Clear any close-intent left over from a prior dirty-confirm chain so it
-    // can't leak into this unrelated save (a stale closeAfterSave could close
-    // the wrong buffer when a later plain save force-overwrites). The dirty-
-    // confirm 'y' path re-arms it in its own .then, after this returns.
-    closeAfterSave = false;
-    const path = activeEditorPath();
-    if (!path) return false;
-    const instance = instances.get(path);
-    const meta = bufferMeta.get(path);
-    if (!instance || !meta) return false;
-    const currentStamp = await readFileStamp(rootDir, path);
-    if (currentStamp !== null && !sameFileStamp(currentStamp, meta)) {
-      setDialog({ kind: "overwrite-confirm", path });
-      return false;
-    }
-    return writeBuffer(path, instance.plainText);
-  }
-
-  /**
-   * Set when a dirty-confirm "save and close" diverts to the overwrite
-   * confirm: the close intent survives, so force-overwriting completes the
-   * close. saveActive() clears it at the start of every save so it can't leak
-   * across buffers; choosing save-as or cancelling clears it too.
-   */
-  let closeAfterSave = false;
-  // Dialog actions that await filesystem I/O temporarily own keyboard input.
-  // Without this guard, the dialog disappears before the save promise settles
-  // and a fast Esc can reopen it against the same in-flight buffer.
-  let dialogActionPending = false;
-
-  function runDialogAction(action: () => Promise<unknown>): void {
-    dialogActionPending = true;
-    void action().finally(() => { dialogActionPending = false; });
-  }
-
-  async function forceSaveActive(): Promise<void> {
-    const path = activeEditorPath();
-    if (!path) return;
-    const instance = instances.get(path);
-    if (!instance) return;
-    const saved = await writeBuffer(path, instance.plainText);
-    if (saved && closeAfterSave) {
-      closeAfterSave = false;
-      afterDirtyConfirm();
-    }
-  }
-
-  /**
-   * Atomic write + post-save bookkeeping. Returns false (and surfaces a status
-   * error) on a disk failure rather than throwing, so the `void saveActive()`
-   * callers don't surface unhandled rejections and the buffer stays dirty.
-   */
-  async function writeBuffer(relPath: string, content: string): Promise<boolean> {
-    let abs: string;
-    try {
-      abs = assertProjectRelativePath(rootDir, relPath);
-      await atomicWriteFile(abs, content);
-    } catch (error) {
-      status(`failed to save ${relPath}: ${errMsg(error)}`, "error");
-      return false;
-    }
-    const meta = bufferMeta.get(relPath);
-    const stamp = await readFileStamp(rootDir, relPath);
-    if (meta) {
-      meta.savedSnapshot = content;
-      if (stamp) {
-        meta.mtimeMs = stamp.mtimeMs;
-        meta.ino = stamp.ino;
-      }
-    }
-    setDirtyPaths((set) => {
-      if (!set.has(relPath)) return set;
-      const next = new Set(set);
-      next.delete(relPath);
-      return next;
-    });
-    setExternalChanged((set) => {
-      if (!set.has(relPath)) return set;
-      const next = new Set(set);
-      next.delete(relPath);
-      return next;
-    });
-    tree.invalidateCache(relPath);
-    status(`saved ${relPath}`, "success");
-    setValidationFor(relPath, content, stamp);
-    return true;
-  }
-
-  async function commitSaveAs(target: string): Promise<void> {
-    const path = activeEditorPath();
-    if (!path) return;
-    const instance = instances.get(path);
-    if (!instance) return;
-    const trimmed = target.trim().replace(/\\/g, "/");
-    if (!trimmed) {
-      status("save-as needs a path", "error");
-      return;
-    }
-    try {
-      assertProjectRelativePath(rootDir, trimmed);
-    } catch (error) {
-      status(String(error instanceof Error ? error.message : error), "error");
-      return;
-    }
-    // Refuse to silently clobber a different existing file — mirror the
-    // move/copy overwrite confirm. 'o' completes the save-as via performSaveAs.
-    if (trimmed !== path && await entryExists(rootDir, trimmed)) {
-      setDialog({ kind: "save-as-overwrite", path: trimmed });
-      return;
-    }
-    await performSaveAs(trimmed);
-  }
-
-  /** Write the active buffer's content to `target` and switch the buffer there. */
-  async function performSaveAs(target: string): Promise<void> {
-    const path = activeEditorPath();
-    const instance = path ? instances.get(path) : undefined;
-    if (!path || !instance) return;
-    const content = instance.plainText;
-    const saved = await writeBuffer(target, content);
-    if (!saved) return; // writeBuffer already surfaced the error
-    // Switch the editable buffer to the new path (close the old, open the new
-    // without re-reading — we just wrote it). The recorded mtime must be the
-    // file's real mtime: a wall-clock value never matches the on-disk stat
-    // and would raise a spurious overwrite confirm on the next Ctrl+S.
-    closeBuffer(path);
-    const writtenStamp = await readFileStamp(rootDir, target);
-    bufferMeta.set(target, {
-      savedSnapshot: content,
-      mtimeMs: writtenStamp?.mtimeMs ?? Date.now(),
-      ino: writtenStamp?.ino ?? 0,
-      initialContent: content,
-    });
-    setEditorOrder((order) => [target, ...order.filter((p) => p !== target)]);
-    setActiveEditorPath(target);
-    setOpenFile(await readFilePreview(rootDir, target));
-    setViewMode("source");
-    void tree.rebuildIndex();
-  }
-
-  async function reloadActiveBuffer(): Promise<void> {
-    const path = activeEditorPath();
-    if (!path) return;
-    const read = await readEditableFile(rootDir, path);
-    if (!read) {
-      status(`${path} is gone from disk`, "error");
-      return;
-    }
-    const instance = instances.get(path);
-    const meta = bufferMeta.get(path);
-    if (!instance || !meta) return;
-    // replaceText preserves undo history (one undo step back to the local
-    // version); setText would clear the stack.
-    instance.replaceText(read.content);
-    meta.savedSnapshot = read.content;
-    meta.mtimeMs = read.mtimeMs;
-    meta.ino = read.ino;
-    setDirtyPaths((set) => {
-      if (!set.has(path)) return set;
-      const next = new Set(set);
-      next.delete(path);
-      return next;
-    });
-    setExternalChanged((set) => {
-      if (!set.has(path)) return set;
-      const next = new Set(set);
-      next.delete(path);
-      return next;
-    });
-    // Reload is a content change: install a fresh snapshot so the status row
-    // never reads the pre-reload verdict as current (Issue #118 §3).
-    setValidationFor(path, read.content, { mtimeMs: read.mtimeMs, ino: read.ino });
-    status(`reloaded ${path}`, "success");
-  }
-
   // —— external editor handoff (B5 §6) ——
 
   /** Renderer + spawn primitives, injected by the component (see WorkspacePage). */
@@ -686,7 +368,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     if (stat?.kind === "dir") { status(`${target} is a directory`, "error"); return; }
     // dirty gate (plan §6.1): an unsaved buffer would be silently overwritten
     // by whatever the external editor writes, so refuse and point at Ctrl+S.
-    if (dirtyPaths().has(target)) {
+    if (buffer.dirtyPaths().has(target)) {
       status(`${target} has unsaved edits — press Ctrl+S before the external editor`, "error");
       return;
     }
@@ -715,77 +397,23 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   }
 
   /**
-   * React to whatever the external editor did: an open editable buffer is
-   * reloaded when its disk identity changes (and revalidated, like a save); a
-   * deleted or re-linked file is closed; a file that was only in the tree just
-   * has its directory cache + index invalidated.
+   * React to whatever the external editor did: a resident buffer is reconciled
+   * by the buffer owner (unchanged/modified/removed), and the facade only
+   * reacts to viewer/focus state; a non-resident file just has its tree cache
+   * + index invalidated and the viewer re-read if it was showing the file.
    */
   async function refreshAfterExternalEdit(relPath: string): Promise<void> {
-    const meta = bufferMeta.get(relPath);
-    if (meta) {
-      const currentStamp = await readFileStamp(rootDir, relPath);
-      if (currentStamp === null) {
-        status(`${relPath} was removed by the external editor`, "error");
-        closeBuffer(relPath);
-        if (openFile()?.relPath === relPath) { setOpenFile(null); setFocusRegion("tree"); }
-        return;
-      }
-      if (sameFileStamp(currentStamp, meta)) {
-        status("no changes from external editor");
-        return;
-      }
-      const read = await readEditableFile(rootDir, relPath);
-      if (!read) {
-        status(`${relPath} is no longer a readable file`, "error");
-        closeBuffer(relPath);
-        return;
-      }
-      const inst = instances.get(relPath);
-      if (inst) {
-        inst.replaceText(read.content);
-        resetStaleHorizontalScroll(inst);
-      }
-      meta.savedSnapshot = read.content;
-      meta.mtimeMs = read.mtimeMs;
-      meta.ino = read.ino;
-      setExternalChanged((set) => {
-        if (!set.has(relPath)) return set;
-        const next = new Set(set);
-        next.delete(relPath);
-        return next;
-      });
-      setValidationFor(relPath, read.content, { mtimeMs: read.mtimeMs, ino: read.ino });
-      status(`reloaded ${relPath}`, "success");
+    const outcome = await buffer.reconcileExternalChange(relPath);
+    if (outcome === "not-resident") {
+      tree.invalidateCache(relPath);
+      await tree.refreshRowsAndIndex();
+      if (openFile()?.relPath === relPath) await reloadViewer();
       return;
     }
-    // Not an editable buffer: refresh the tree, and re-read the viewer if it
-    // was showing this file (covers read-only / image / binary handoffs).
-    tree.invalidateCache(relPath);
-    await tree.refreshRowsAndIndex();
-    if (openFile()?.relPath === relPath) await reloadViewer();
-  }
-
-  function requestReloadActive(): void {
-    const path = activeEditorPath();
-    if (!path) return;
-    if (dirtyPaths().has(path) || externalChanged().has(path)) {
-      setDialog({ kind: "reload-confirm", path });
-    } else {
-      status(`${path} is already current`);
+    if (outcome === "removed" && openFile()?.relPath === relPath) {
+      setOpenFile(null);
+      setFocusRegion("tree");
     }
-  }
-
-  async function checkExternalModifications(): Promise<void> {
-    const changed: string[] = [];
-    for (const path of editorOrder()) {
-      const meta = bufferMeta.get(path);
-      if (!meta) continue;
-      const stamp = await readFileStamp(rootDir, path);
-      if (stamp !== null && !sameFileStamp(stamp, meta)) changed.push(path);
-    }
-    if (changed.length === 0) return;
-    setExternalChanged(new Set(changed));
-    status(`${changed.length} file(s) changed on disk — Ctrl+R to reload`, "warn");
   }
 
   /** Leave the editable source by one focus level (Esc-clean destination). */
@@ -800,53 +428,31 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     }
   }
 
-  // —— find / goto / save-as bars ——
+  // —— save / dialog orchestration ——
 
-  function openFind(): void {
-    const instance = activeInstance();
-    if (!instance) return;
-    findPlainSnapshot = instance.plainText;
-    setFindQuery("");
-    setFindMatches([]);
-    setFindMatchIndex(-1);
-    setFindActive(true);
+  /**
+   * Set when a dirty-confirm "save and close" diverts to the overwrite
+   * confirm: the close intent survives, so force-overwriting completes the
+   * close. saveActive() clears it at the start of every save so it can't leak
+   * across buffers; choosing save-as or cancelling clears it too.
+   */
+  let closeAfterSave = false;
+  // Dialog actions that await filesystem I/O temporarily own keyboard input.
+  // Without this guard, the dialog disappears before the save promise settles
+  // and a fast Esc can reopen it against the same in-flight buffer.
+  let dialogActionPending = false;
+
+  function runDialogAction(action: () => Promise<unknown>): void {
+    dialogActionPending = true;
+    void action().finally(() => { dialogActionPending = false; });
   }
 
-  function closeFind(): void {
-    setFindActive(false);
-    findPlainSnapshot = "";
-  }
-
-  function refreshFind(): void {
-    const offsets = computeFindOffsets(findPlainSnapshot, findQuery());
-    setFindMatches(offsets);
-    setFindMatchIndex(offsets.length > 0 ? 0 : -1);
-    if (offsets.length > 0) selectFindMatch(0);
-  }
-
-  function selectFindMatch(index: number): void {
-    const instance = activeInstance();
-    if (!instance) return;
-    const offset = findMatches()[index];
-    if (offset === undefined) return;
-    const length = findQuery().length;
-    instance.setSelection(offset, offset + length);
-    resetStaleHorizontalScroll(instance);
-  }
-
-  function openGoto(): void {
-    if (!activeInstance()) return;
-    setGotoDraft("");
-    setGotoActive(true);
-  }
-
-  function openSaveAs(): void {
-    if (!activeEditorPath()) return;
-    // Start empty: in a keyboard line-input, typing appends, so pre-filling
-    // the current path would force the user to clear it first. The status
-    // line shows "save as: ▌" and Enter commits the typed path.
-    setSaveAsDraft("");
-    setSaveAsActive(true);
+  async function forceSaveActive(): Promise<void> {
+    const saved = await buffer.forceSave();
+    if (saved && closeAfterSave) {
+      closeAfterSave = false;
+      afterDirtyConfirm();
+    }
   }
 
   // —— file management (B4 §5.1) ——
@@ -919,7 +525,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     try {
       if (overwrite) await removeFile(rootDir, target);
       await moveEntry(rootDir, source, target);
-      rekeyOpenBuffer(source, target);
+      rekeyAcrossOwners(source, target);
       status(`moved ${source} → ${target}`, "success");
       await afterTreeMutation2(source, target);
       tree.selectRelPath(target);
@@ -945,10 +551,10 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     try {
       // Drop any open editable buffer for this path first (the confirm already
       // noted unsaved edits); also clear the viewer if it was showing it.
-      if (bufferMeta.has(relPath)) closeBuffer(relPath);
+      if (buffer.stampOf(relPath)) buffer.close(relPath);
       if (openFile()?.relPath === relPath) {
         setOpenFile(null);
-        setActiveEditorPath(null);
+        buffer.setActiveEditorPath(null);
         setFocusRegion("tree");
       }
       // A deleted file may own the validation snapshot even when it was never
@@ -965,41 +571,18 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   }
 
   /**
-   * Rekey an open editable buffer from oldPath to newPath (rename/move).
-   * Content and dirty state survive via the captured plainText → initialValue
-   * on remount; the textarea's undo stack does NOT survive the path-keyed
-   * remount (a known B4 limitation — finish editing before renaming if undo
-   * matters). Read-only viewers just refresh via afterTreeMutation.
+   * Rekey an open editable buffer from oldPath to newPath (rename/move) across
+   * the owners: the buffer owner rekeys pool state, the facade rekeys the
+   * viewer preview and the validation snapshot. Content and dirty state
+   * survive via the captured plainText → initialValue on remount; the
+   * textarea's undo stack does NOT survive the path-keyed remount (a known B4
+   * limitation — finish editing before renaming if undo matters).
    */
-  function rekeyOpenBuffer(oldPath: string, newPath: string): void {
-    if (oldPath === newPath) return;
-    const meta = bufferMeta.get(oldPath);
-    if (!meta) return;
-    // Renaming A onto an already-open B: close B first — the move is
-    // overwriting B on disk, so B's stale buffer + pool slot must go before
-    // we rekey A, otherwise editorOrder ends up with newPath twice and B's
-    // meta is silently clobbered.
-    if (bufferMeta.has(newPath)) closeBuffer(newPath);
-    const inst = instances.get(oldPath);
-    const currentText = inst?.plainText ?? meta.savedSnapshot;
-    bufferMeta.delete(oldPath);
-    bufferMeta.set(newPath, { ...meta, initialContent: currentText });
-    instances.delete(oldPath);
-    setEditorOrder((order) => order.map((p) => (p === oldPath ? newPath : p)));
-    setActiveEditorPath((p) => (p === oldPath ? newPath : p));
-    setDirtyPaths((set) => rekeySet(set, oldPath, newPath));
-    setExternalChanged((set) => rekeySet(set, oldPath, newPath));
+  function rekeyAcrossOwners(oldPath: string, newPath: string): void {
+    buffer.rekey(oldPath, newPath);
     const file = openFile();
     if (file?.relPath === oldPath) setOpenFile({ ...file, relPath: newPath });
     rekeyValidation(oldPath, newPath);
-  }
-
-  function rekeySet(set: ReadonlySet<string>, oldPath: string, newPath: string): ReadonlySet<string> {
-    if (!set.has(oldPath)) return set;
-    const next = new Set(set);
-    next.delete(oldPath);
-    next.add(newPath);
-    return next;
   }
 
   async function afterTreeMutation(relPath: string): Promise<void> {
@@ -1028,7 +611,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
    */
   async function openFindingsForCurrent(relPath: string): Promise<boolean> {
     const snap = validationSnapshot();
-    if ((snap.state === "result" || snap.state === "no-match") && snap.path === relPath && !dirtyPaths().has(relPath)) {
+    if ((snap.state === "result" || snap.state === "no-match") && snap.path === relPath && !buffer.dirtyPaths().has(relPath)) {
       const current = await readFileStamp(rootDir, relPath);
       if (validationStamp !== null && current !== null && sameFileStamp(current, validationStamp)) {
         setFindingsIndex(0);
@@ -1052,7 +635,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
       return;
     }
     const relPath = row.node.relPath;
-    if (dirtyPaths().has(relPath)) {
+    if (buffer.dirtyPaths().has(relPath)) {
       status(`save ${relPath} before validating`, "info");
       return;
     }
@@ -1076,7 +659,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   async function viewerValidate(): Promise<void> {
     const file = openFile();
     if (!file) { status("open a file to validate", "info"); return; }
-    if (dirtyPaths().has(file.relPath)) {
+    if (buffer.dirtyPaths().has(file.relPath)) {
       status(`save ${file.relPath} before validating`, "info");
       return;
     }
@@ -1132,15 +715,11 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     const snap = validationSnapshot();
     if (!file || !canEditOpenFile() || finding.line === null) return;
     if (snap.state !== "pending" && snap.path !== file.relPath) return;
-    if (activeEditorPath() !== file.relPath) setActiveEditorPath(file.relPath);
+    if (buffer.activeEditorPath() !== file.relPath) buffer.setActiveEditorPath(file.relPath);
     setViewMode("source");
     setFocusRegion("editor");
     setFindingsOpen(false);
-    const inst = instances.get(file.relPath);
-    if (inst) {
-      inst.gotoLine(finding.line);
-      resetStaleHorizontalScroll(inst);
-    }
+    buffer.gotoLine(finding.line);
   }
 
   // —— quick open keys ——
@@ -1159,70 +738,55 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   // —— key handling ——
 
   function handleFindKey(key: TuiKeyEvent): boolean {
-    if (key.name === "escape") { closeFind(); return true; }
+    if (key.name === "escape") { buffer.closeFind(); return true; }
     if (key.name === "enter") {
       // Enter with an empty query closes the bar (matches the goto bar) instead
       // of being a silent no-op; a non-empty query with no matches stays open so
       // the user can revise it.
-      if (!findQuery()) { closeFind(); return true; }
-      const matches = findMatches();
+      if (!buffer.findQuery()) { buffer.closeFind(); return true; }
+      const matches = buffer.findMatches();
       if (matches.length === 0) return true;
-      const step = key.shift ? -1 : 1;
-      const next = (findMatchIndex() + step + matches.length) % matches.length;
-      setFindMatchIndex(next);
-      selectFindMatch(next);
+      buffer.advanceFindMatch(key.shift ? -1 : 1);
       return true;
     }
     if (key.name === "backspace") {
-      setFindQuery((query) => query.slice(0, -1));
-      refreshFind();
+      buffer.findBackspace();
       return true;
     }
     const char = printableChar(key);
     if (char) {
-      setFindQuery((query) => query + char);
-      refreshFind();
+      buffer.findAppend(char);
     }
     return true;
   }
 
   function handleGotoKey(key: TuiKeyEvent): boolean {
-    if (key.name === "escape") { setGotoActive(false); return true; }
+    if (key.name === "escape") { buffer.closeGotoBar(); return true; }
     if (key.name === "enter") {
-      const target = parseInt(gotoDraft(), 10);
-      setGotoActive(false);
-      if (Number.isFinite(target) && target >= 1) {
-        const inst = activeInstance();
-        if (inst) {
-          inst.gotoLine(target - 1);
-          resetStaleHorizontalScroll(inst);
-        }
-      }
+      buffer.gotoCommit();
       return true;
     }
     if (key.name === "backspace") {
-      setGotoDraft((draft) => draft.slice(0, -1));
+      buffer.gotoBackspace();
       return true;
     }
     const char = printableChar(key);
-    if (char && /[0-9]/.test(char)) setGotoDraft((draft) => draft + char);
+    if (char && /[0-9]/.test(char)) buffer.gotoAppend(char);
     return true;
   }
 
   function handleSaveAsKey(key: TuiKeyEvent): boolean {
-    if (key.name === "escape") { setSaveAsActive(false); return true; }
+    if (key.name === "escape") { buffer.closeSaveAsBar(); return true; }
     if (key.name === "enter") {
-      const target = saveAsDraft();
-      setSaveAsActive(false);
-      void commitSaveAs(target);
+      buffer.saveAsCommit();
       return true;
     }
     if (key.name === "backspace") {
-      setSaveAsDraft((draft) => draft.slice(0, -1));
+      buffer.saveAsBackspace();
       return true;
     }
     const char = printableChar(key);
-    if (char && /[A-Za-z0-9._\-/]/.test(char)) setSaveAsDraft((draft) => draft + char);
+    if (char && /[A-Za-z0-9._\-/]/.test(char)) buffer.saveAsAppend(char);
     return true;
   }
 
@@ -1238,7 +802,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
         // force-overwriting completes the close — the edits are never
         // discarded under the user's feet.
         runDialogAction(async () => {
-          const saved = await saveActive();
+          const saved = await buffer.saveActive();
           if (saved) afterDirtyConfirm();
           else closeAfterSave = true;
         });
@@ -1255,12 +819,12 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
       }
       // Save-as satisfies the save intent by itself; the buffer moves to the
       // new path and stays open there.
-      if (key.name === "s") { closeAfterSave = false; setDialog(null); openSaveAs(); return true; }
+      if (key.name === "s") { closeAfterSave = false; setDialog(null); buffer.openSaveAs(); return true; }
       if (key.name === "c") { closeAfterSave = false; setDialog(null); return true; }
       return true;
     }
     if (current.kind === "reload-confirm") {
-      if (key.name === "y") { setDialog(null); runDialogAction(reloadActiveBuffer); return true; }
+      if (key.name === "y") { setDialog(null); runDialogAction(buffer.reloadActiveBuffer); return true; }
       if (key.name === "n") { setDialog(null); return true; }
       return true;
     }
@@ -1290,7 +854,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
       if (key.name === "o") {
         const p = current.path;
         setDialog(null);
-        runDialogAction(() => performSaveAs(p));
+        runDialogAction(() => buffer.performSaveAs(p));
         return true;
       }
       if (key.name === "c" || key.name === "escape") { setDialog(null); return true; }
@@ -1304,8 +868,8 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
    * the file, and return focus to the tree.
    */
   function afterDirtyConfirm(): void {
-    const path = activeEditorPath();
-    if (path) closeBuffer(path);
+    const path = buffer.activeEditorPath();
+    if (path) buffer.close(path);
     setOpenFile(null);
     setFocusRegion("tree");
     clearValidation();
@@ -1365,17 +929,17 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   function handleEditableKey(key: TuiKeyEvent): boolean {
     // Ctrl+Shift+S (save-as) before Ctrl+S — isSaveKey would otherwise catch
     // the shift variant and route it to a plain save.
-    if (key.ctrl && key.shift && key.name === "s") { openSaveAs(); return true; }
-    if (isSaveKey(key)) { void saveActive(); return true; }
-    if (isCtrl(key, "f")) { openFind(); return true; }
-    if (isCtrl(key, "g")) { openGoto(); return true; }
-    if (isCtrl(key, "r")) { requestReloadActive(); return true; }
+    if (key.ctrl && key.shift && key.name === "s") { buffer.openSaveAs(); return true; }
+    if (isSaveKey(key)) { void buffer.saveActive(); return true; }
+    if (isCtrl(key, "f")) { buffer.openFind(); return true; }
+    if (isCtrl(key, "g")) { buffer.openGoto(); return true; }
+    if (isCtrl(key, "r")) { buffer.requestReloadActive(); return true; }
     // undo / redo / ctrl+_ legacy fallback: the textarea's custom keyBindings
     // own these — let the key propagate.
     if (key.ctrl && (key.name === "z" || key.name === "y" || key.name === "_")) return false;
     if (key.name === "escape") {
-      const path = activeEditorPath();
-      if (path && dirtyPaths().has(path)) {
+      const path = buffer.activeEditorPath();
+      if (path && buffer.dirtyPaths().has(path)) {
         setDialog({ kind: "dirty-confirm", path });
         return true;
       }
@@ -1394,9 +958,9 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     if (findingsOpen()) return handleFindingsKey(key);
     if (dialog()) return handleDialogKey(key);
     if (opsBar()) return handleOpsBarKey(key);
-    if (findActive()) return handleFindKey(key);
-    if (gotoActive()) return handleGotoKey(key);
-    if (saveAsActive()) return handleSaveAsKey(key);
+    if (buffer.findActive()) return handleFindKey(key);
+    if (buffer.gotoActive()) return handleGotoKey(key);
+    if (buffer.saveAsActive()) return handleSaveAsKey(key);
     if (key.ctrl && key.name === "p") { tree.openQuickOpen(); return true; }
     // Ctrl+X hands off to the external editor from every Workspace focus
     // region (B5 §6.1); caught here so it also covers the composer region and
@@ -1438,32 +1002,32 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     // external editor handoff (B5)
     registerExternalEditor,
     // editor pool
-    editorOrder,
-    activeEditorPath,
-    dirtyPaths,
-    externalChanged,
+    editorOrder: buffer.editorOrder,
+    activeEditorPath: buffer.activeEditorPath,
+    dirtyPaths: buffer.dirtyPaths,
+    externalChanged: buffer.externalChanged,
     editorStatus,
     editorStatusTone,
-    editorInitialContent,
+    editorInitialContent: buffer.editorInitialContent,
     isEditing,
     editableSourcePasteActive,
-    registerEditorInstance,
-    unregisterEditorInstance,
-    markEditorContentChanged,
-    reportCursor,
-    cursorLn,
-    cursorCol,
-    saveActive,
-    reloadActiveBuffer,
+    registerEditorInstance: buffer.registerEditorInstance,
+    unregisterEditorInstance: buffer.unregisterEditorInstance,
+    markEditorContentChanged: buffer.markEditorContentChanged,
+    reportCursor: buffer.reportCursor,
+    cursorLn: buffer.cursorLn,
+    cursorCol: buffer.cursorCol,
+    saveActive: buffer.saveActive,
+    reloadActiveBuffer: buffer.reloadActiveBuffer,
     // editor bars / dialogs
-    findActive,
-    findQuery,
-    findMatches,
-    findMatchIndex,
-    gotoActive,
-    gotoDraft,
-    saveAsActive,
-    saveAsDraft,
+    findActive: buffer.findActive,
+    findQuery: buffer.findQuery,
+    findMatches: buffer.findMatches,
+    findMatchIndex: buffer.findMatchIndex,
+    gotoActive: buffer.gotoActive,
+    gotoDraft: buffer.gotoDraft,
+    saveAsActive: buffer.saveAsActive,
+    saveAsDraft: buffer.saveAsDraft,
     dialog,
     // file management (B4)
     opsBar,

--- a/src/tui/workspace/controller.ts
+++ b/src/tui/workspace/controller.ts
@@ -114,6 +114,11 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   const editorStatusTone = () => editorStatusState().tone;
   /** Typed setter; clears to neutral info when called with no tone. */
   function status(text: string, tone: EditorStatusTone = "info"): void {
+    const current = editorStatusState();
+    // Skip identical writes: the dirty tracker clears the line on every
+    // keystroke, and an empty-line clear must not re-trigger the status
+    // render on each keypress (hot path — see markEditorContentChanged).
+    if (current.text === text && current.tone === tone) return;
     setEditorStatusState({ text, tone });
   }
   /** Tracks whether the workspace page has been entered at least once. */

--- a/src/tui/workspace/index.ts
+++ b/src/tui/workspace/index.ts
@@ -5,7 +5,8 @@
  * state. The surface is the complete set of exports external consumers may
  * use; W5 removes the root compat module after callers switch to this path.
  */
-export { createWorkspaceController, resetStaleHorizontalScroll } from "./controller";
+export { createWorkspaceController } from "./controller";
+export { resetStaleHorizontalScroll } from "./buffer-owner";
 export type { WorkspaceController } from "./controller";
 export type {
   ShellPage,

--- a/tests/unit/tui/workspace-buffer-owner.test.ts
+++ b/tests/unit/tui/workspace-buffer-owner.test.ts
@@ -1,0 +1,330 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { TextareaRenderable } from "@opentui/core";
+import { createBufferOwner, type BufferWritten } from "../../../src/tui/workspace/buffer-owner";
+import type { FileStamp } from "../../../src/tui/workspace/buffer-io";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "vesicle-ws-buffer-owner-"));
+  await mkdir(join(root, "workspace"), { recursive: true });
+  await writeFile(join(root, "workspace/a.md"), "# A\n\nbody\n");
+  await writeFile(join(root, "workspace/b.md"), "# B\n\nbody\n");
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+/**
+ * Headless stand-in for a mounted textarea (same contract the controller
+ * suites use): plainText drives dirty, replaceText/setSelection/gotoLine
+ * record imperative calls.
+ */
+function mockEditor(initial: string) {
+  let text = initial;
+  const calls = {
+    setSelection: [] as Array<[number, number]>,
+    gotoLine: [] as number[],
+    replaceText: [] as string[],
+  };
+  return {
+    get plainText() { return text; },
+    setSelection: (start: number, end: number) => { calls.setSelection.push([start, end]); },
+    gotoLine: (n: number) => { calls.gotoLine.push(n); },
+    insertText: (s: string) => { text += s; },
+    replaceText: (s: string) => { text = s; calls.replaceText.push(s); },
+    logicalCursor: { row: 0, col: 0, offset: 0 },
+    editorView: {
+      getViewport: () => ({ offsetX: 0, offsetY: 0, width: 80, height: 24 }),
+      setViewport: () => undefined,
+    },
+    calls,
+    type: (s: string) => { text = s; },
+  } as unknown as TextareaRenderable & {
+    calls: typeof calls;
+    type: (s: string) => void;
+  };
+}
+
+function makeOwner() {
+  const calls = {
+    status: [] as Array<[string, string | undefined]>,
+    written: [] as BufferWritten[],
+    reloaded: [] as BufferWritten[],
+    saveAsTargetActivated: [] as string[],
+    overwriteConfirm: [] as string[],
+    saveAsOverwrite: [] as string[],
+    reloadConfirm: [] as string[],
+    saveStarted: 0,
+  };
+  const owner = createBufferOwner({
+    rootDir: root,
+    onStatus: (text, tone) => { calls.status.push([text, tone]); },
+    onWritten: (result) => { calls.written.push(result); },
+    onReloaded: (result) => { calls.reloaded.push(result); },
+    onSaveAsTargetActivated: async (target) => { calls.saveAsTargetActivated.push(target); },
+    onOverwriteConfirm: (path) => { calls.overwriteConfirm.push(path); },
+    onSaveAsOverwrite: (target) => { calls.saveAsOverwrite.push(target); },
+    onReloadConfirm: (path) => { calls.reloadConfirm.push(path); },
+    onSaveStarted: () => { calls.saveStarted += 1; },
+  });
+  return { owner, calls };
+}
+
+async function openEditable(relPath: string, content?: string) {
+  const { owner, calls } = makeOwner();
+  await owner.open(relPath);
+  const inst = mockEditor(content ?? "# A\n\nbody\n");
+  owner.registerEditorInstance(relPath, inst);
+  return { owner, calls, inst };
+}
+
+function stampOf(written: BufferWritten): FileStamp {
+  expect(written.stamp).not.toBeNull();
+  return written.stamp!;
+}
+
+describe("workspace buffer owner: pool lifecycle", () => {
+  test("open admits a buffer, close removes it from every pool set", async () => {
+    const { owner } = makeOwner();
+    await owner.open("workspace/a.md");
+    expect(owner.editorOrder()).toEqual(["workspace/a.md"]);
+    expect(owner.activeEditorPath()).toBe("workspace/a.md");
+    const inst = mockEditor("# A\n\nbody\n");
+    owner.registerEditorInstance("workspace/a.md", inst);
+    inst.type("# A\n\nchanged\n");
+    owner.markEditorContentChanged("workspace/a.md");
+    expect(owner.dirtyPaths().has("workspace/a.md")).toBe(true);
+    owner.close("workspace/a.md");
+    expect(owner.editorOrder()).toEqual([]);
+    expect(owner.activeEditorPath()).toBeNull();
+    expect(owner.dirtyPaths().has("workspace/a.md")).toBe(false);
+    expect(owner.stampOf("workspace/a.md")).toBeNull();
+  });
+
+  test("close purges a stale external-changed entry (status warn can clear)", async () => {
+    const { owner } = makeOwner();
+    await owner.open("workspace/a.md");
+    owner.registerEditorInstance("workspace/a.md", mockEditor("# A\n\nbody\n"));
+    // Simulate a disk change observed by the page-reactivation check.
+    await new Promise((r) => setTimeout(r, 20));
+    await writeFile(join(root, "workspace/a.md"), "# A\n\nchanged on disk\n");
+    await owner.checkExternalModifications();
+    expect(owner.externalChanged().has("workspace/a.md")).toBe(true);
+    owner.close("workspace/a.md");
+    expect(owner.externalChanged().has("workspace/a.md")).toBe(false);
+  });
+
+  test("LRU eviction closes the oldest clean victim; all-dirty refusal keeps it closed", async () => {
+    const { owner, calls } = makeOwner();
+    const instances: Array<ReturnType<typeof mockEditor>> = [];
+    for (let i = 0; i < 8; i += 1) {
+      const p = `workspace/f${i}.md`;
+      await writeFile(join(root, p), `f${i}\n`);
+      await owner.open(p);
+      const inst = mockEditor(`f${i}\n`);
+      instances.push(inst);
+      owner.registerEditorInstance(p, inst);
+      inst.type(`g${i}\n`);
+      owner.markEditorContentChanged(p);
+    }
+    // Ninth open with every buffer dirty: refused, no victim.
+    await writeFile(join(root, "workspace/f8.md"), "f8\n");
+    await owner.open("workspace/f8.md");
+    expect(owner.activeEditorPath()).toBeNull();
+    expect(calls.status.at(-1)?.[0]).toContain("all dirty");
+    // Clean one buffer (f3): the oldest clean victim gets evicted for f8.
+    instances[3]!.type("f3\n");
+    owner.markEditorContentChanged("workspace/f3.md");
+    await owner.open("workspace/f8.md");
+    expect(owner.activeEditorPath()).toBe("workspace/f8.md");
+    expect(owner.editorOrder().length).toBe(8);
+    expect(owner.stampOf("workspace/f3.md")).toBeNull();
+  });
+
+  test("rekey moves pool state to the new path; rekey onto an open buffer closes it first", async () => {
+    const { owner } = makeOwner();
+    await owner.open("workspace/a.md");
+    const instA = mockEditor("# A\n\nbody\n");
+    owner.registerEditorInstance("workspace/a.md", instA);
+    instA.type("# A\n\ndirty\n");
+    owner.markEditorContentChanged("workspace/a.md");
+    await owner.open("workspace/b.md");
+    const instB = mockEditor("# B\n\nbody\n");
+    owner.registerEditorInstance("workspace/b.md", instB);
+
+    owner.rekey("workspace/a.md", "workspace/b.md");
+    // B's stale buffer closed first, A rekeyed onto it: exactly one entry.
+    // The pre-existing close-then-rekey sequence leaves the active path null
+    // when B was the active buffer (the view falls back to the read-only
+    // preview); preserved verbatim, W3's applyMutation owns any change.
+    expect(owner.editorOrder().filter((p) => p === "workspace/b.md").length).toBe(1);
+    expect(owner.activeEditorPath()).toBeNull();
+    expect(owner.dirtyPaths().has("workspace/b.md")).toBe(true);
+    expect(owner.stampOf("workspace/a.md")).toBeNull();
+    expect(owner.stampOf("workspace/b.md")).not.toBeNull();
+  });
+});
+
+describe("workspace buffer owner: save and save-as", () => {
+  test("saveActive writes, clears dirty, and reports the written outcome", async () => {
+    const { owner, calls, inst } = await openEditable("workspace/a.md");
+    inst.type("# A\n\nedited\n");
+    owner.markEditorContentChanged("workspace/a.md");
+    const saved = await owner.saveActive();
+    expect(saved).toBe(true);
+    expect(calls.saveStarted).toBe(1);
+    expect(calls.written.length).toBe(1);
+    expect(calls.written[0]!.path).toBe("workspace/a.md");
+    expect(calls.written[0]!.content).toBe("# A\n\nedited\n");
+    expect(owner.dirtyPaths().has("workspace/a.md")).toBe(false);
+    expect(calls.status.some(([t]) => t.startsWith("saved"))).toBe(true);
+  });
+
+  test("saveActive diverts to the overwrite confirm when the disk identity changed", async () => {
+    const { owner, calls } = await openEditable("workspace/a.md");
+    await new Promise((r) => setTimeout(r, 20));
+    await writeFile(join(root, "workspace/a.md"), "# A\n\noutside\n");
+    const saved = await owner.saveActive();
+    expect(saved).toBe(false);
+    expect(calls.overwriteConfirm).toEqual(["workspace/a.md"]);
+    expect(calls.written.length).toBe(0);
+  });
+
+  test("forceSave writes even after an external disk change", async () => {
+    const { owner, calls } = await openEditable("workspace/a.md");
+    await new Promise((r) => setTimeout(r, 20));
+    await writeFile(join(root, "workspace/a.md"), "# A\n\noutside\n");
+    const saved = await owner.forceSave();
+    expect(saved).toBe(true);
+    expect(calls.written.length).toBe(1);
+    expect(owner.dirtyPaths().has("workspace/a.md")).toBe(false);
+  });
+
+  test("save-as to a free target switches the buffer and activates the target", async () => {
+    const { owner, calls, inst } = await openEditable("workspace/a.md");
+    inst.type("# A\n\nsave-as\n");
+    owner.markEditorContentChanged("workspace/a.md");
+    await owner.commitSaveAs("workspace/new.md");
+    expect(calls.written.some((w) => w.path === "workspace/new.md")).toBe(true);
+    expect(calls.saveAsTargetActivated).toEqual(["workspace/new.md"]);
+    expect(owner.activeEditorPath()).toBe("workspace/new.md");
+    expect(owner.editorOrder()).toEqual(["workspace/new.md"]);
+    expect(owner.dirtyPaths().has("workspace/new.md")).toBe(false);
+  });
+
+  test("save-as to an existing different file raises the overwrite confirm", async () => {
+    const { owner, calls } = await openEditable("workspace/a.md");
+    await owner.commitSaveAs("workspace/b.md");
+    expect(calls.saveAsOverwrite).toEqual(["workspace/b.md"]);
+    expect(owner.activeEditorPath()).toBe("workspace/a.md");
+    expect(calls.saveAsTargetActivated.length).toBe(0);
+  });
+
+  test("save-as records the real written stamp so the next save is not a false overwrite", async () => {
+    const { owner, calls } = await openEditable("workspace/a.md");
+    await owner.commitSaveAs("workspace/new.md");
+    const stamp = stampOf(calls.written.find((w) => w.path === "workspace/new.md")!);
+    expect(owner.stampOf("workspace/new.md")).toEqual(stamp);
+  });
+});
+
+describe("workspace buffer owner: reload and external reconciliation", () => {
+  test("requestReloadActive raises the confirm when dirty, notes current otherwise", async () => {
+    const { owner, calls, inst } = await openEditable("workspace/a.md");
+    inst.type("# A\n\ndirty\n");
+    owner.markEditorContentChanged("workspace/a.md");
+    owner.requestReloadActive();
+    expect(calls.reloadConfirm).toEqual(["workspace/a.md"]);
+    // Undo back to clean: the reload request now reports "already current".
+    inst.type("# A\n\nbody\n");
+    owner.markEditorContentChanged("workspace/a.md");
+    owner.requestReloadActive();
+    expect(calls.status.some(([t]) => t.includes("already current"))).toBe(true);
+  });
+
+  test("reloadActiveBuffer replaces text, clears dirty, and reports the reloaded content", async () => {
+    const { owner, calls, inst } = await openEditable("workspace/a.md");
+    inst.type("# A\n\nlocal\n");
+    owner.markEditorContentChanged("workspace/a.md");
+    await writeFile(join(root, "workspace/a.md"), "# A\n\nfresh\n");
+    await owner.reloadActiveBuffer();
+    expect(inst.calls.replaceText).toEqual(["# A\n\nfresh\n"]);
+    expect(owner.dirtyPaths().has("workspace/a.md")).toBe(false);
+    expect(calls.reloaded.length).toBe(1);
+    expect(calls.reloaded[0]!.content).toBe("# A\n\nfresh\n");
+    expect(owner.stampOf("workspace/a.md")).toEqual(stampOf(calls.reloaded[0]!));
+  });
+
+  test("checkExternalModifications flags stamp-mismatched open buffers", async () => {
+    const { owner, calls } = await openEditable("workspace/a.md");
+    await new Promise((r) => setTimeout(r, 20));
+    await writeFile(join(root, "workspace/a.md"), "# A\n\nchanged\n");
+    await owner.checkExternalModifications();
+    expect(owner.externalChanged().has("workspace/a.md")).toBe(true);
+    expect(calls.status.some(([t]) => t.includes("changed on disk"))).toBe(true);
+  });
+
+  test("reconcileExternalChange classifies unchanged, modified, removed, and non-resident", async () => {
+    const { owner, calls, inst } = await openEditable("workspace/a.md");
+    // unchanged: same disk identity.
+    expect(await owner.reconcileExternalChange("workspace/a.md")).toBe("unchanged");
+    expect(calls.status.some(([t]) => t.includes("no changes"))).toBe(true);
+    // modified: new mtime + new content → replaceText + reloaded.
+    await new Promise((r) => setTimeout(r, 20));
+    await writeFile(join(root, "workspace/a.md"), "# A\n\nedited outside\n");
+    expect(await owner.reconcileExternalChange("workspace/a.md")).toBe("modified");
+    expect(inst.calls.replaceText).toEqual(["# A\n\nedited outside\n"]);
+    expect(calls.reloaded.at(-1)?.content).toBe("# A\n\nedited outside\n");
+    // removed: gone from disk → buffer closed.
+    await rm(join(root, "workspace/a.md"));
+    expect(await owner.reconcileExternalChange("workspace/a.md")).toBe("removed");
+    expect(owner.stampOf("workspace/a.md")).toBeNull();
+    expect(owner.dirtyPaths().has("workspace/a.md")).toBe(false);
+    // not-resident: a path with no buffer just reports the class.
+    expect(await owner.reconcileExternalChange("workspace/b.md")).toBe("not-resident");
+  });
+
+  test.skipIf(process.platform === "win32" || (typeof process.getuid === "function" && process.getuid() === 0))(
+    "reconcileExternalChange classifies an unreadable file as unreadable and closes the buffer",
+    async () => {
+      const { owner, calls } = await openEditable("workspace/a.md");
+      await new Promise((r) => setTimeout(r, 20));
+      await writeFile(join(root, "workspace/a.md"), "# A\n\nlocked\n");
+      await chmod(join(root, "workspace/a.md"), 0o000);
+      try {
+        expect(await owner.reconcileExternalChange("workspace/a.md")).toBe("unreadable");
+        expect(owner.stampOf("workspace/a.md")).toBeNull();
+        expect(calls.status.some(([t]) => t.includes("no longer a readable file"))).toBe(true);
+      } finally {
+        await chmod(join(root, "workspace/a.md"), 0o644);
+      }
+    },
+  );
+});
+
+describe("workspace buffer owner: find / goto / save-as bars", () => {
+  test("find bar matches, advances, and jumps via setSelection", async () => {
+    const { owner, inst } = await openEditable("workspace/a.md", "aa bb aa cc\n");
+    owner.openFind();
+    owner.findAppend("aa");
+    expect(owner.findMatches()).toEqual([0, 6]);
+    owner.advanceFindMatch(1);
+    expect(inst.calls.setSelection).toEqual([[0, 2], [6, 8]]);
+    owner.closeFind();
+    expect(owner.findActive()).toBe(false);
+  });
+
+  test("goto bar commits a 1-based line jump", async () => {
+    const { owner, inst } = await openEditable("workspace/a.md", "l1\nl2\nl3\n");
+    owner.openGoto();
+    owner.gotoAppend("2");
+    owner.gotoCommit();
+    expect(inst.calls.gotoLine).toEqual([1]);
+    expect(owner.gotoActive()).toBe(false);
+  });
+});

--- a/tests/unit/tui/workspace-editor.test.ts
+++ b/tests/unit/tui/workspace-editor.test.ts
@@ -8,7 +8,7 @@ import {
   isEditablePreview,
   readEditableFile,
   readFileStamp,
-} from "../../../src/tui/workspace-editor";
+} from "../../../src/tui/workspace/buffer-io";
 import { assertProjectRelativePath } from "../../../src/tui/workspace/paths";
 import { readFilePreview } from "../../../src/tui/workspace/tree-data";
 


### PR DESCRIPTION
## Summary

Code Smell Round 3, Wave W2 (Buffer owner), per `dev/docs/working/CODE_SMELL_REMEDIATION_IMPLEMENTATION_PLAN.md` §6.

- `workspace-editor.ts` moves equivalently to `workspace/buffer-io.ts` (pure/bounded I/O + `sameFileStamp` as the single mtime+inode comparator authority); old file removed, no pass-through.
- New `buffer-owner.ts` uniquely owns the editor pool (LRU order, active path, dirty/external-changed sets, per-buffer metadata, textarea instances, cursor, find/goto/save-as bars) and the save / save-as / reload / external-reconciliation lifecycle, communicating with the facade only through eight narrow named ports.
- `controller.ts` keeps page/focus, viewer, dialog serialization, ops bar, validation, external editor, and key routing until their waves; public `WorkspaceController` surface unchanged (59 members).
- Behavior preserved function-for-function (independent CR compared every moved body against the pre-W2 controller).

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` (1811 pass, 6 skip, 0 fail)
- [x] `bun run doctor` (Missing: none)
- [x] `git diff --check`
- Focused: workspace-editor (buffer-io) suite + workspace-editor-controller suite (39 pass) + workspace-controller + workspace-page component (33 pass)

## Notes / Follow-ups

- Independent CR (subagent, exact HEAD): Blocking none; Should-fix (execution record) resolved; nits addressed (identical-status write skip restores the keystroke hot-path guard).
- W3 (file-operation + validation owners) next, same plan section.