### PR TITLE
refactor(tui): extract file-operation and validation owners (W3)

### DIFF
--- a/src/tui/views/WorkspacePage.tsx
+++ b/src/tui/views/WorkspacePage.tsx
@@ -6,8 +6,8 @@ import { MarkdownContent } from "../widgets/MarkdownContent";
 import type { WorkspaceController, EditorStatusTone } from "../workspace-controller";
 import { resetStaleHorizontalScroll } from "../workspace-controller";
 import type { WorkspaceFileKind } from "../workspace";
-import { pendingValidation, validationSeverity, validationSummary } from "../workspace-validate";
-import type { ValidationState } from "../workspace-validate";
+import { pendingValidation, validationSeverity, validationSummary } from "../workspace/validation";
+import type { ValidationState } from "../workspace/validation";
 import { displayWidth, truncateMiddle } from "../format";
 import {
   dialogStatus,
@@ -642,7 +642,7 @@ function quickOpenWidth(pageWidth: number): number {
   return Math.max(30, Math.min(72, Math.floor(pageWidth * 0.6)));
 }
 
-function findingsList(state: import("../workspace-validate").ValidationState): import("../workspace-validate").LocatedFinding[] {
+function findingsList(state: import("../workspace/validation").ValidationState): import("../workspace/validation").LocatedFinding[] {
   return state.state === "result" ? state.findings : [];
 }
 
@@ -654,7 +654,7 @@ function findingsList(state: import("../workspace-validate").ValidationState): i
  * the `findings: `/` — ` chrome and the summary, so a long or CJK path can
  * never clip the verdict (Issue #118 §8).
  */
-function FindingsHeader(props: { state: import("../workspace-validate").ValidationState; width: number }) {
+function FindingsHeader(props: { state: import("../workspace/validation").ValidationState; width: number }) {
   const content = () => {
     const s = props.state;
     const summary = validationSummary(s) || "—";

--- a/src/tui/workspace/buffer-owner.ts
+++ b/src/tui/workspace/buffer-owner.ts
@@ -8,9 +8,9 @@ import {
   sameFileStamp,
   type FileStamp,
 } from "./buffer-io";
-import { entryExists } from "../workspace-fileops";
+import { entryExists } from "./file-operations";
 import { assertProjectRelativePath } from "./paths";
-import type { EditorStatusTone } from "./types";
+import type { EditorStatusTone, WorkspaceMutation } from "./types";
 
 /**
  * Workspace editor-buffer owner (Scope B / #62, milestone B3). Uniquely owns
@@ -478,6 +478,17 @@ export function createBufferOwner(options: BufferOwnerPorts) {
     return next;
   }
 
+  /** Apply a frozen file-operation mutation to pool state. */
+  function applyMutation(mutation: WorkspaceMutation): void {
+    if (mutation.kind === "moved") {
+      rekey(mutation.source, mutation.target);
+      return;
+    }
+    if (mutation.kind === "deleted" && stampOf(mutation.path)) {
+      close(mutation.path);
+    }
+  }
+
   // —— find / goto / save-as bars ——
 
   function openFind(): void {
@@ -621,6 +632,7 @@ export function createBufferOwner(options: BufferOwnerPorts) {
     checkExternalModifications,
     reconcileExternalChange,
     rekey,
+    applyMutation,
     stampOf,
     setActiveEditorPath,
     // find / goto / save-as

--- a/src/tui/workspace/controller.ts
+++ b/src/tui/workspace/controller.ts
@@ -1,27 +1,8 @@
 import { createSignal } from "solid-js";
 import type { TuiKeyEvent } from "../decision-interaction";
-import {
-  isEditablePreview,
-  readFileStamp,
-  sameFileStamp,
-  type FileStamp,
-} from "./buffer-io";
+import { isEditablePreview, readFileStamp } from "./buffer-io";
 import { createBufferOwner } from "./buffer-owner";
-import {
-  copyEntry,
-  createDirectory,
-  createFile,
-  entryExists,
-  moveEntry,
-  removeFile,
-  trashEntry,
-} from "../workspace-fileops";
-import {
-  pendingValidation,
-  runValidation,
-  type LocatedFinding,
-  type ValidationState,
-} from "../workspace-validate";
+import { createFileOperationOwner } from "./file-operation-owner";
 import {
   resolveEditorCommand,
   runExternalEditor,
@@ -31,7 +12,8 @@ import { loadSettings, type Settings } from "../../config/settings";
 import { assertProjectRelativePath } from "./paths";
 import { readFilePreview, statEntry, type WorkspaceFilePreview } from "./tree-data";
 import { createTreeOwner } from "./tree-owner";
-import type { ShellPage, WorkspaceFocusRegion, ViewerScrollEdge, EditorStatusTone } from "./types";
+import { createValidationOwner } from "./validation-owner";
+import type { ShellPage, WorkspaceFocusRegion, ViewerScrollEdge, EditorStatusTone, WorkspaceMutation } from "./types";
 
 /**
  * Shell page state for the two-page model (Scope B / #62). B1 shipped the
@@ -49,22 +31,13 @@ import type { ShellPage, WorkspaceFocusRegion, ViewerScrollEdge, EditorStatusTon
  *
  * Ownership: tree navigation + quick-open state live in `createTreeOwner`,
  * the editable-buffer pool / save / reload / find / goto / save-as live in
- * `createBufferOwner`; this factory composes the owners, keeps the
- * page/focus model, viewer, dialogs, file mutations, validation, and
- * external-editor orchestration until their own waves take over.
+ * `createBufferOwner`, file mutations + ops bar + confirm dialogs live in
+ * `createFileOperationOwner`, and validation state + findings navigation live
+ * in `createValidationOwner`. This factory composes the owners, keeps the
+ * page/focus model and viewer state, applies frozen mutations in the fixed
+ * tree → buffer → validation order, and routes keys until the input-router
+ * wave takes over.
  */
-
-type B3DialogKind = "dirty-confirm" | "overwrite-confirm" | "reload-confirm";
-type EditorDialog =
-  | { kind: B3DialogKind; path: string }
-  | { kind: "delete-confirm"; path: string }
-  | { kind: "ops-overwrite"; path: string; op: "move" | "copy"; source: string }
-  | { kind: "save-as-overwrite"; path: string }
-  | null;
-
-/** Tree file-management input bar (B4 §5.1): path prompts isomorphic to save-as. */
-type OpsBarKind = "create-file" | "create-dir" | "move" | "copy";
-type OpsBar = { kind: OpsBarKind; draft: string; source: string } | null;
 
 const FOCUS_CYCLE: WorkspaceFocusRegion[] = ["tree", "editor", "composer"];
 
@@ -124,6 +97,12 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   /** Tracks whether the workspace page has been entered at least once. */
   let workspaceEntered = false;
 
+  // —— viewer ——
+  const [openFile, setOpenFile] = createSignal<WorkspaceFilePreview | null>(null);
+  const [viewMode, setViewMode] = createSignal<"source" | "preview">("source");
+  let viewerScrollBy: ((delta: number) => void) | null = null;
+  let viewerScrollEdge: ((edge: ViewerScrollEdge) => void) | null = null;
+
   const tree = createTreeOwner({
     rootDir,
     onOpenPath: (relPath) => openPath(relPath),
@@ -135,89 +114,46 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     onStatus: (text, tone) => status(text, tone),
     onWritten: ({ path, content, stamp }) => {
       tree.invalidateCache(path);
-      setValidationFor(path, content, stamp);
+      validation.setFor(path, content, stamp);
     },
     onReloaded: ({ path, content, stamp }) => {
-      setValidationFor(path, content, stamp);
+      validation.setFor(path, content, stamp);
     },
     onSaveAsTargetActivated: async (target) => {
       setOpenFile(await readFilePreview(rootDir, target));
       setViewMode("source");
       void tree.rebuildIndex();
     },
-    onOverwriteConfirm: (path) => setDialog({ kind: "overwrite-confirm", path }),
-    onSaveAsOverwrite: (target) => setDialog({ kind: "save-as-overwrite", path: target }),
-    onReloadConfirm: (path) => setDialog({ kind: "reload-confirm", path }),
+    onOverwriteConfirm: (path) => fileOps.raiseDialog({ kind: "overwrite-confirm", path }),
+    onSaveAsOverwrite: (target) => fileOps.raiseDialog({ kind: "save-as-overwrite", path: target }),
+    onReloadConfirm: (path) => fileOps.raiseDialog({ kind: "reload-confirm", path }),
     onSaveStarted: () => {
-      closeAfterSave = false;
+      fileOps.clearCloseAfterSave();
     },
   });
 
-  // —— viewer ——
-  const [openFile, setOpenFile] = createSignal<WorkspaceFilePreview | null>(null);
-  const [viewMode, setViewMode] = createSignal<"source" | "preview">("source");
-  let viewerScrollBy: ((delta: number) => void) | null = null;
-  let viewerScrollEdge: ((edge: ViewerScrollEdge) => void) | null = null;
+  const fileOps = createFileOperationOwner({
+    rootDir,
+    onStatus: (text, tone) => status(text, tone),
+  });
 
-  // —— editor input dialogs ——
-  const [dialog, setDialog] = createSignal<EditorDialog>(null);
-
-  // —— file-management ops bar (B4 §5.1) ——
-  const [opsBar, setOpsBar] = createSignal<OpsBar>(null);
-
-  // —— in-page validation (B4 §5.2) ——
-  // The snapshot is the retained last result plus the path it describes. The
-  // projected `validationState()` folds in the dirty-buffer staleness rule so
-  // the view never has to: a result whose owning buffer is dirty reads as the
-  // neutral `validation stale` state, and clearing the dirty flag (undo to
-  // clean, save, reload) restores it without re-running the validators.
-  const [validationSnapshot, setValidationSnapshot] = createSignal<ValidationState>(pendingValidation);
-  const [findingsOpen, setFindingsOpen] = createSignal(false);
-  const [findingsIndex, setFindingsIndex] = createSignal(0);
-
-  /**
-   * Displayed validation state. Reads the snapshot plus dirty-buffer truth: a
-   * result/no-match whose path is currently dirty projects to `stale` so the
-   * old verdict never reads as current over edited content. Plain function (not
-   * a memo) so callers — including tests outside a reactive root — always read
-   * the latest projection.
-   */
-  function validationState(): ValidationState {
-    const snap = validationSnapshot();
-    if ((snap.state === "result" || snap.state === "no-match") && buffer.dirtyPaths().has(snap.path)) {
-      return { state: "stale", path: snap.path };
-    }
-    return snap;
-  }
-
-  /**
-   * Disk identity (mtime+ino) of the file the snapshot was computed from. The
-   * findings panel compares this against the live file before reusing a
-   * snapshot, so a deleted-then-recreated or externally rewritten file at the
-   * same path cannot inherit the previous file's findings (Issue #118 review
-   * round 2).
-   */
-  let validationStamp: FileStamp | null = null;
-
-  /** Install a fresh snapshot for `relPath` from its content, with its disk identity. */
-  function setValidationFor(relPath: string, content: string, stamp: FileStamp | null = null): void {
-    setValidationSnapshot(runValidation(relPath, content));
-    validationStamp = stamp;
-  }
-
-  /** Clear the snapshot back to pending (close/delete of the validated file). */
-  function clearValidation(): void {
-    setValidationSnapshot(pendingValidation);
-    validationStamp = null;
-  }
-
-  /** Rekey the snapshot path after a rename/move; the underlying result is unchanged. */
-  function rekeyValidation(oldPath: string, newPath: string): void {
-    const snap = validationSnapshot();
-    if (snap.state !== "pending" && snap.path === oldPath) {
-      setValidationSnapshot({ ...snap, path: newPath } as ValidationState);
-    }
-  }
+  const validation = createValidationOwner({
+    rootDir,
+    onStatus: (text, tone) => status(text, tone),
+    isDirty: (path) => buffer.dirtyPaths().has(path),
+    selectedFilePath: () => {
+      const row = tree.rows()[tree.selectedIndex()];
+      return row && row.node.kind === "file" ? row.node.relPath : null;
+    },
+    openFile: () => openFile(),
+    canEditOpenFile: () => canEditOpenFile(),
+    onJumpTo: (relPath, line) => {
+      if (buffer.activeEditorPath() !== relPath) buffer.setActiveEditorPath(relPath);
+      setViewMode("source");
+      setFocusRegion("editor");
+      buffer.gotoLine(line);
+    },
+  });
 
   function activatePage(next: ShellPage): void {
     const reentering = next === "workspace" && page() === "workspace";
@@ -252,14 +188,14 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     return page() === "workspace"
       && focusRegion() === "editor"
       && isEditing()
-      && !dialogActionPending
+      && !fileOps.dialogActionPending()
       && !tree.quickOpenActive()
-      && !findingsOpen()
+      && !validation.findingsOpen()
       && !buffer.findActive()
       && !buffer.gotoActive()
       && !buffer.saveAsActive()
-      && !dialog()
-      && !opsBar();
+      && !fileOps.dialog()
+      && !fileOps.opsBar();
   }
 
   /**
@@ -281,7 +217,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     setViewMode(preview.kind === "markdown" ? "preview" : "source");
     setFocusRegion("editor");
     status("");
-    setValidationFor(relPath, preview.lines?.join("\n") ?? "", await readFileStamp(rootDir, relPath));
+    validation.setFor(relPath, preview.lines?.join("\n") ?? "", await readFileStamp(rootDir, relPath));
     if (isEditablePreview(preview)) {
       await buffer.open(relPath);
     } else {
@@ -316,7 +252,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     const preview = await readFilePreview(rootDir, file.relPath);
     if (preview) {
       setOpenFile(preview);
-      setValidationFor(file.relPath, preview.lines?.join("\n") ?? "", await readFileStamp(rootDir, file.relPath));
+      validation.setFor(file.relPath, preview.lines?.join("\n") ?? "", await readFileStamp(rootDir, file.relPath));
       status(`reloaded ${file.relPath}`, "success");
     }
   }
@@ -331,6 +267,33 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
       viewerScrollBy = null;
       viewerScrollEdge = null;
     };
+  }
+
+  // —— mutation application (fixed tree → buffer → validation order) ——
+
+  /**
+   * Apply a frozen file-operation mutation across the owners. The viewer and
+   * tree-selection reactions are the facade's own state; buffer rekey/close
+   * and validation rekey/clear are each owner's `applyMutation`.
+   */
+  async function applyMutation(mutation: WorkspaceMutation): Promise<void> {
+    await tree.applyMutation(mutation);
+    buffer.applyMutation(mutation);
+    validation.applyMutation(mutation);
+    if (mutation.kind === "created" && mutation.entryType === "directory") {
+      tree.selectRelPath(mutation.path);
+    }
+    if (mutation.kind === "copied" || mutation.kind === "moved") {
+      tree.selectRelPath(mutation.target);
+    }
+    if (mutation.kind === "moved" && openFile()?.relPath === mutation.source) {
+      const file = openFile();
+      if (file) setOpenFile({ ...file, relPath: mutation.target });
+    }
+    if (mutation.kind === "deleted" && openFile()?.relPath === mutation.path) {
+      setOpenFile(null);
+      setFocusRegion("tree");
+    }
   }
 
   // —— external editor handoff (B5 §6) ——
@@ -435,299 +398,31 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
 
   // —— save / dialog orchestration ——
 
-  /**
-   * Set when a dirty-confirm "save and close" diverts to the overwrite
-   * confirm: the close intent survives, so force-overwriting completes the
-   * close. saveActive() clears it at the start of every save so it can't leak
-   * across buffers; choosing save-as or cancelling clears it too.
-   */
-  let closeAfterSave = false;
-  // Dialog actions that await filesystem I/O temporarily own keyboard input.
-  // Without this guard, the dialog disappears before the save promise settles
-  // and a fast Esc can reopen it against the same in-flight buffer.
-  let dialogActionPending = false;
-
-  function runDialogAction(action: () => Promise<unknown>): void {
-    dialogActionPending = true;
-    void action().finally(() => { dialogActionPending = false; });
-  }
-
   async function forceSaveActive(): Promise<void> {
     const saved = await buffer.forceSave();
-    if (saved && closeAfterSave) {
-      closeAfterSave = false;
+    if (saved && fileOps.closeAfterSavePending()) {
+      fileOps.clearCloseAfterSave();
       afterDirtyConfirm();
     }
   }
 
-  // —— file management (B4 §5.1) ——
-
-  function openOpsBar(kind: OpsBarKind): void {
-    const row = tree.rows()[tree.selectedIndex()];
-    if (!row) return;
-    const source = row.node.relPath;
-    // create-* and move/copy both prefill the directory part so the user types
-    // the new name in place (B3 save-as taught us a pre-filled full path just
-    // has to be cleared first).
-    setOpsBar({ kind, draft: tree.selectionDirPrefix(), source });
-  }
-
-  function handleOpsBarKey(key: TuiKeyEvent): boolean {
-    const bar = opsBar();
-    if (!bar) return false;
-    if (key.name === "escape") { setOpsBar(null); return true; }
-    if (key.name === "enter") {
-      const draft = bar.draft.trim().replace(/\\/g, "/");
-      setOpsBar(null);
-      if (!draft) { status(`${bar.kind} needs a path`, "error"); return true; }
-      try {
-        assertProjectRelativePath(rootDir, draft);
-      } catch (error) {
-        status(String(error instanceof Error ? error.message : error), "error");
-        return true;
-      }
-      if (bar.kind === "create-file") void execCreateFile(draft);
-      else if (bar.kind === "create-dir") void execCreateDir(draft);
-      else if (bar.kind === "move") void execMove(bar.source, draft, false);
-      else void execCopy(bar.source, draft, false);
-      return true;
-    }
-    if (key.name === "backspace") {
-      setOpsBar((b) => (b ? { ...b, draft: b.draft.slice(0, -1) } : b));
-      return true;
-    }
-    const ch = printableChar(key);
-    if (ch && /[A-Za-z0-9._\-/]/.test(ch)) {
-      setOpsBar((b) => (b ? { ...b, draft: b.draft + ch } : b));
-    }
-    return true;
-  }
-
-  async function execCreateFile(relPath: string): Promise<void> {
-    try {
-      await createFile(rootDir, relPath);
-      status(`created ${relPath}`, "success");
-      await afterTreeMutation(relPath);
-      await openPath(relPath);
-    } catch (error) { status(errMsg(error), "error"); }
-  }
-
-  async function execCreateDir(relPath: string): Promise<void> {
-    try {
-      await createDirectory(rootDir, relPath);
-      status(`created directory ${relPath}`, "success");
-      await afterTreeMutation(relPath);
-      tree.selectRelPath(relPath);
-    } catch (error) { status(errMsg(error), "error"); }
-  }
-
-  async function execMove(source: string, target: string, overwrite: boolean): Promise<void> {
-    if (target === source) { status("move target equals source", "error"); return; }
-    if (!overwrite && await entryExists(rootDir, target)) {
-      setDialog({ kind: "ops-overwrite", path: target, op: "move", source });
-      return;
-    }
-    try {
-      if (overwrite) await removeFile(rootDir, target);
-      await moveEntry(rootDir, source, target);
-      rekeyAcrossOwners(source, target);
-      status(`moved ${source} → ${target}`, "success");
-      await afterTreeMutation2(source, target);
-      tree.selectRelPath(target);
-    } catch (error) { status(errMsg(error), "error"); }
-  }
-
-  async function execCopy(source: string, target: string, overwrite: boolean): Promise<void> {
-    if (target === source) { status("copy target equals source", "error"); return; }
-    if (!overwrite && await entryExists(rootDir, target)) {
-      setDialog({ kind: "ops-overwrite", path: target, op: "copy", source });
-      return;
-    }
-    try {
-      if (overwrite) await removeFile(rootDir, target);
-      await copyEntry(rootDir, source, target);
-      status(`copied ${source} → ${target}`, "success");
-      await afterTreeMutation2(source, target);
-      tree.selectRelPath(target);
-    } catch (error) { status(errMsg(error), "error"); }
-  }
-
-  async function execDelete(relPath: string): Promise<void> {
-    try {
-      // Drop any open editable buffer for this path first (the confirm already
-      // noted unsaved edits); also clear the viewer if it was showing it.
-      if (buffer.stampOf(relPath)) buffer.close(relPath);
-      if (openFile()?.relPath === relPath) {
-        setOpenFile(null);
-        buffer.setActiveEditorPath(null);
-        setFocusRegion("tree");
-      }
-      // A deleted file may own the validation snapshot even when it was never
-      // opened (tree `v` validates the selection without opening it). Clear it
-      // whenever the snapshot describes the deleted path, so a recreated file
-      // at the same path — or an external rewrite — cannot inherit stale
-      // findings (Issue #118 review round 2).
-      const deletedSnap = validationSnapshot();
-      if (deletedSnap.state !== "pending" && deletedSnap.path === relPath) clearValidation();
-      const trashPath = await trashEntry(rootDir, relPath);
-      status(`moved ${relPath} → ${trashPath} (trash)`, "success");
-      await afterTreeMutation(relPath);
-    } catch (error) { status(errMsg(error), "error"); }
-  }
-
   /**
-   * Rekey an open editable buffer from oldPath to newPath (rename/move) across
-   * the owners: the buffer owner rekeys pool state, the facade rekeys the
-   * viewer preview and the validation snapshot. Content and dirty state
-   * survive via the captured plainText → initialValue on remount; the
-   * textarea's undo stack does NOT survive the path-keyed remount (a known B4
-   * limitation — finish editing before renaming if undo matters).
+   * After a dirty-confirm save/discard: drop the buffer's local state, close
+   * the file, and return focus to the tree.
    */
-  function rekeyAcrossOwners(oldPath: string, newPath: string): void {
-    buffer.rekey(oldPath, newPath);
-    const file = openFile();
-    if (file?.relPath === oldPath) setOpenFile({ ...file, relPath: newPath });
-    rekeyValidation(oldPath, newPath);
-  }
-
-  async function afterTreeMutation(relPath: string): Promise<void> {
-    tree.invalidateCache(relPath);
-    await tree.refreshRowsAndIndex();
-  }
-
-  async function afterTreeMutation2(source: string, target: string): Promise<void> {
-    tree.invalidateCache(source);
-    tree.invalidateCache(target);
-    await tree.refreshRowsAndIndex();
+  function afterDirtyConfirm(): void {
+    const path = buffer.activeEditorPath();
+    if (path) buffer.close(path);
+    setOpenFile(null);
+    setFocusRegion("tree");
+    validation.clear();
   }
 
   function errMsg(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
   }
 
-  // —— in-page validation (B4 §5.2) ——
-
-  /**
-   * Open the findings panel for a snapshot already current for `relPath`
-   * (consume, no re-run). Returns false when the caller should bail. Reuse is
-   * gated on the live file's disk identity still matching the snapshot's, so a
-   * recreated or externally rewritten file at the same path does not inherit
-   * stale findings (Issue #118 review round 2).
-   */
-  async function openFindingsForCurrent(relPath: string): Promise<boolean> {
-    const snap = validationSnapshot();
-    if ((snap.state === "result" || snap.state === "no-match") && snap.path === relPath && !buffer.dirtyPaths().has(relPath)) {
-      const current = await readFileStamp(rootDir, relPath);
-      if (validationStamp !== null && current !== null && sameFileStamp(current, validationStamp)) {
-        setFindingsIndex(0);
-        setFindingsOpen(true);
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Tree-focus `v` targets the selected row, never an unrelated open file
-   * (Issue #118 §3). A directory or empty selection stays closed with a hint;
-   * a dirty buffer is not silently validated against its older disk image; a
-   * snapshot already current for the selection is consumed rather than re-run.
-   */
-  async function treeValidate(): Promise<void> {
-    const row = tree.rows()[tree.selectedIndex()];
-    if (!row || row.node.kind !== "file") {
-      status("select a file to validate", "info");
-      return;
-    }
-    const relPath = row.node.relPath;
-    if (buffer.dirtyPaths().has(relPath)) {
-      status(`save ${relPath} before validating`, "info");
-      return;
-    }
-    if (await openFindingsForCurrent(relPath)) return;
-    const preview = await readFilePreview(rootDir, relPath);
-    if (!preview) {
-      status(`${relPath} is not readable`, "error");
-      return;
-    }
-    const stamp = await readFileStamp(rootDir, relPath);
-    setValidationFor(relPath, preview.lines?.join("\n") ?? "", stamp);
-    setFindingsIndex(0);
-    setFindingsOpen(true);
-  }
-
-  /**
-   * Viewer-focus `v` targets the open file. Same dirty-buffer and consume
-   * rules as the tree path; re-validates only when the snapshot is stale or
-   * for a different file.
-   */
-  async function viewerValidate(): Promise<void> {
-    const file = openFile();
-    if (!file) { status("open a file to validate", "info"); return; }
-    if (buffer.dirtyPaths().has(file.relPath)) {
-      status(`save ${file.relPath} before validating`, "info");
-      return;
-    }
-    if (await openFindingsForCurrent(file.relPath)) return;
-    const stamp = await readFileStamp(rootDir, file.relPath);
-    setValidationFor(file.relPath, file.lines?.join("\n") ?? "", stamp);
-    setFindingsIndex(0);
-    setFindingsOpen(true);
-  }
-
-  /**
-   * Whether `Enter` in the findings panel would really jump. Requires an
-   * admitted editable buffer for the open file and a selected finding with a
-   * resolvable line (Issue #118 §4 — read-only / oversized / refused-buffer
-   * targets must neither advertise nor execute a jump).
-   */
-  function canJumpToSelectedFinding(): boolean {
-    const file = openFile();
-    if (!file || !canEditOpenFile()) return false;
-    const snap = validationSnapshot();
-    if (snap.state !== "result") return false;
-    // The findings panel can describe a different file than the one open (tree
-    // `v` validates the selection without opening it). A jump must target the
-    // open buffer, so refuse — and do not advertise Enter — when the snapshot
-    // belongs to another file (Issue #118 review: cross-file jump).
-    if (snap.path !== file.relPath) return false;
-    const finding = snap.findings[findingsIndex()];
-    return Boolean(finding && finding.line !== null);
-  }
-
-  function handleFindingsKey(key: TuiKeyEvent): boolean {
-    const state = validationSnapshot();
-    const findings = state.state === "result" ? state.findings : [];
-    if (key.name === "escape") { setFindingsOpen(false); return true; }
-    if (findings.length === 0) return true;
-    if (key.name === "up") { setFindingsIndex((i) => Math.max(0, i - 1)); return true; }
-    if (key.name === "down") { setFindingsIndex((i) => Math.min(findings.length - 1, i + 1)); return true; }
-    if (key.name === "enter") {
-      if (canJumpToSelectedFinding()) {
-        const finding = findings[findingsIndex()];
-        if (finding) jumpToFinding(finding);
-      }
-      return true;
-    }
-    return true;
-  }
-
-  /** Land the active editable buffer at a finding's line and close the panel. */
-  function jumpToFinding(finding: LocatedFinding): void {
-    const file = openFile();
-    // Defence-in-depth alongside canJumpToSelectedFinding: never jump a finding
-    // from another file's snapshot into the open buffer.
-    const snap = validationSnapshot();
-    if (!file || !canEditOpenFile() || finding.line === null) return;
-    if (snap.state !== "pending" && snap.path !== file.relPath) return;
-    if (buffer.activeEditorPath() !== file.relPath) buffer.setActiveEditorPath(file.relPath);
-    setViewMode("source");
-    setFocusRegion("editor");
-    setFindingsOpen(false);
-    buffer.gotoLine(finding.line);
-  }
-
-  // —— quick open keys ——
+  // —— key handling ——
 
   function handleQuickOpenKey(key: TuiKeyEvent): boolean {
     if (key.name === "escape") { tree.closeQuickOpen(); return true; }
@@ -739,8 +434,6 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     if (char) tree.quickOpenAppend(char);
     return true; // the panel owns all input while open
   }
-
-  // —— key handling ——
 
   function handleFindKey(key: TuiKeyEvent): boolean {
     if (key.name === "escape") { buffer.closeFind(); return true; }
@@ -795,89 +488,109 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     return true;
   }
 
+  function handleOpsBarKey(key: TuiKeyEvent): boolean {
+    const bar = fileOps.opsBar();
+    if (!bar) return false;
+    if (key.name === "escape") { fileOps.closeOpsBar(); return true; }
+    if (key.name === "enter") {
+      void fileOps.opsBarCommit().then(async (mutation) => {
+        if (!mutation) return;
+        await applyMutation(mutation);
+        if (mutation.kind === "created" && mutation.entryType === "file") {
+          await openPath(mutation.path);
+        }
+      });
+      return true;
+    }
+    if (key.name === "backspace") {
+      fileOps.opsBarBackspace();
+      return true;
+    }
+    const ch = printableChar(key);
+    if (ch && /[A-Za-z0-9._\-/]/.test(ch)) {
+      fileOps.opsBarAppend(ch);
+    }
+    return true;
+  }
+
   function handleDialogKey(key: TuiKeyEvent): boolean {
-    const current = dialog();
+    const current = fileOps.dialog();
     if (!current) return false;
-    if (key.name === "escape") { closeAfterSave = false; setDialog(null); return true; }
+    if (key.name === "escape") { fileOps.clearCloseAfterSave(); fileOps.closeDialog(); return true; }
     if (current.kind === "dirty-confirm") {
       if (key.name === "y") {
-        setDialog(null);
+        fileOps.closeDialog();
         // Close only when the save actually landed. A save diverted to the
         // overwrite confirm keeps the buffer open and arms closeAfterSave so
         // force-overwriting completes the close — the edits are never
         // discarded under the user's feet.
-        runDialogAction(async () => {
+        fileOps.runDialogAction(async () => {
           const saved = await buffer.saveActive();
           if (saved) afterDirtyConfirm();
-          else closeAfterSave = true;
+          else fileOps.armCloseAfterSave();
         });
         return true;
       }
-      if (key.name === "n") { setDialog(null); afterDirtyConfirm(); return true; }
+      if (key.name === "n") { fileOps.closeDialog(); afterDirtyConfirm(); return true; }
       return true;
     }
     if (current.kind === "overwrite-confirm") {
       if (key.name === "o") {
-        setDialog(null);
-        runDialogAction(forceSaveActive);
+        fileOps.closeDialog();
+        fileOps.runDialogAction(forceSaveActive);
         return true;
       }
       // Save-as satisfies the save intent by itself; the buffer moves to the
       // new path and stays open there.
-      if (key.name === "s") { closeAfterSave = false; setDialog(null); buffer.openSaveAs(); return true; }
-      if (key.name === "c") { closeAfterSave = false; setDialog(null); return true; }
+      if (key.name === "s") { fileOps.clearCloseAfterSave(); fileOps.closeDialog(); buffer.openSaveAs(); return true; }
+      if (key.name === "c") { fileOps.clearCloseAfterSave(); fileOps.closeDialog(); return true; }
       return true;
     }
     if (current.kind === "reload-confirm") {
-      if (key.name === "y") { setDialog(null); runDialogAction(buffer.reloadActiveBuffer); return true; }
-      if (key.name === "n") { setDialog(null); return true; }
+      if (key.name === "y") { fileOps.closeDialog(); fileOps.runDialogAction(buffer.reloadActiveBuffer); return true; }
+      if (key.name === "n") { fileOps.closeDialog(); return true; }
       return true;
     }
     if (current.kind === "delete-confirm") {
       // Plan §5.1: "y deletes / anything else cancels".
       if (key.name === "y") {
         const p = current.path;
-        setDialog(null);
-        runDialogAction(() => execDelete(p));
+        fileOps.closeDialog();
+        fileOps.runDialogAction(async () => {
+          const mutation = await fileOps.execDelete(p);
+          if (mutation) await applyMutation(mutation);
+        });
         return true;
       }
-      setDialog(null);
+      fileOps.closeDialog();
       return true;
     }
     if (current.kind === "ops-overwrite") {
       if (key.name === "o") {
         const { op, source, path: target } = current;
-        setDialog(null);
-        if (op === "move") runDialogAction(() => execMove(source, target, true));
-        else runDialogAction(() => execCopy(source, target, true));
+        fileOps.closeDialog();
+        fileOps.runDialogAction(async () => {
+          const mutation = op === "move"
+            ? await fileOps.execMove(source, target, true)
+            : await fileOps.execCopy(source, target, true);
+          if (mutation) await applyMutation(mutation);
+        });
         return true;
       }
-      if (key.name === "c") { setDialog(null); return true; }
+      if (key.name === "c") { fileOps.closeDialog(); return true; }
       return true;
     }
     if (current.kind === "save-as-overwrite") {
       if (key.name === "o") {
         const p = current.path;
-        setDialog(null);
-        runDialogAction(() => buffer.performSaveAs(p));
+        fileOps.closeDialog();
+        fileOps.runDialogAction(() => buffer.performSaveAs(p));
         return true;
       }
-      if (key.name === "c" || key.name === "escape") { setDialog(null); return true; }
+      if (key.name === "c" || key.name === "escape") { fileOps.closeDialog(); return true; }
       return true;
     }
     return true;
-  }
-
-  /**
-   * After a dirty-confirm save/discard: drop the buffer's local state, close
-   * the file, and return focus to the tree.
-   */
-  function afterDirtyConfirm(): void {
-    const path = buffer.activeEditorPath();
-    if (path) buffer.close(path);
-    setOpenFile(null);
-    setFocusRegion("tree");
-    clearValidation();
   }
 
   function handleTreeKey(key: TuiKeyEvent): boolean {
@@ -890,16 +603,28 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
       case "r": void tree.refresh(); return true;
       case ".": void tree.toggleHidden(); return true;
       case "/": tree.openQuickOpen(); return true;
-      case "a": openOpsBar(key.shift ? "create-dir" : "create-file"); return true;
-      case "m":
-      case "f2": openOpsBar("move"); return true;
-      case "c": openOpsBar("copy"); return true;
-      case "d": {
+      case "a": {
         const row = tree.rows()[tree.selectedIndex()];
-        if (row) setDialog({ kind: "delete-confirm", path: row.node.relPath });
+        if (row) fileOps.openOpsBar(key.shift ? "create-dir" : "create-file", row.node.relPath, tree.selectionDirPrefix());
         return true;
       }
-      case "v": void treeValidate(); return true;
+      case "m":
+      case "f2": {
+        const row = tree.rows()[tree.selectedIndex()];
+        if (row) fileOps.openOpsBar("move", row.node.relPath, tree.selectionDirPrefix());
+        return true;
+      }
+      case "c": {
+        const row = tree.rows()[tree.selectedIndex()];
+        if (row) fileOps.openOpsBar("copy", row.node.relPath, tree.selectionDirPrefix());
+        return true;
+      }
+      case "d": {
+        const row = tree.rows()[tree.selectedIndex()];
+        if (row) fileOps.raiseDialog({ kind: "delete-confirm", path: row.node.relPath });
+        return true;
+      }
+      case "v": void validation.treeValidate(); return true;
       case "q": setFocusRegion("composer"); return true;
       case "escape": setFocusRegion("composer"); return true;
       default: return true; // focused region owns (and swallows) the rest
@@ -912,7 +637,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
       case "q": setFocusRegion("tree"); return true;
       case "r": void reloadViewer(); return true;
       case "m": toggleViewMode(); return true;
-      case "v": void viewerValidate(); return true;
+      case "v": void validation.viewerValidate(); return true;
       case "up": viewerScrollBy?.(-1); return true;
       case "down": viewerScrollBy?.(1); return true;
       case "pageup": viewerScrollBy?.(-10); return true;
@@ -945,7 +670,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     if (key.name === "escape") {
       const path = buffer.activeEditorPath();
       if (path && buffer.dirtyPaths().has(path)) {
-        setDialog({ kind: "dirty-confirm", path });
+        fileOps.raiseDialog({ kind: "dirty-confirm", path });
         return true;
       }
       leaveEditorSource();
@@ -958,11 +683,11 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
   /** Returns true when the key was consumed by the Workspace page. */
   function handleKey(key: TuiKeyEvent): boolean {
     if (page() !== "workspace") return false;
-    if (dialogActionPending) return true;
+    if (fileOps.dialogActionPending()) return true;
     if (tree.quickOpenActive()) return handleQuickOpenKey(key);
-    if (findingsOpen()) return handleFindingsKey(key);
-    if (dialog()) return handleDialogKey(key);
-    if (opsBar()) return handleOpsBarKey(key);
+    if (validation.findingsOpen()) return validation.handleFindingsKey(key);
+    if (fileOps.dialog()) return handleDialogKey(key);
+    if (fileOps.opsBar()) return handleOpsBarKey(key);
     if (buffer.findActive()) return handleFindKey(key);
     if (buffer.gotoActive()) return handleGotoKey(key);
     if (buffer.saveAsActive()) return handleSaveAsKey(key);
@@ -1033,16 +758,16 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     gotoDraft: buffer.gotoDraft,
     saveAsActive: buffer.saveAsActive,
     saveAsDraft: buffer.saveAsDraft,
-    dialog,
+    dialog: fileOps.dialog,
     // file management (B4)
-    opsBar,
+    opsBar: fileOps.opsBar,
     // in-page validation (B4)
-    validationState,
-    validationSnapshot,
-    findingsOpen,
-    findingsIndex,
+    validationState: validation.validationState,
+    validationSnapshot: validation.validationSnapshot,
+    findingsOpen: validation.findingsOpen,
+    findingsIndex: validation.findingsIndex,
     canEditOpenFile,
-    canJumpToSelectedFinding,
+    canJumpToSelectedFinding: validation.canJumpToSelectedFinding,
     // quick open
     quickOpenActive: tree.quickOpenActive,
     quickQuery: tree.quickQuery,

--- a/src/tui/workspace/file-operation-owner.ts
+++ b/src/tui/workspace/file-operation-owner.ts
@@ -1,0 +1,218 @@
+import { createSignal } from "solid-js";
+import {
+  copyEntry,
+  createDirectory,
+  createFile,
+  entryExists,
+  moveEntry,
+  removeFile,
+  trashEntry,
+} from "./file-operations";
+import { assertProjectRelativePath } from "./paths";
+import type { EditorStatusTone, WorkspaceMutation } from "./types";
+
+/**
+ * Workspace file-operation owner (Scope B / #62, milestone B4). Uniquely owns
+ * the tree file-management state: the ops bar (create/move/copy path prompts),
+ * the overwrite/delete confirm dialog surface and its action serialization,
+ * and the guarded mutation execution (create / move / copy / delete).
+ *
+ * Boundary: every successful mutation is returned as a frozen
+ * `WorkspaceMutation`; the facade applies it to the owners in the fixed
+ * tree → buffer → validation order. This owner never reads editor instances
+ * or validation snapshots, and it never rekeys another owner's state.
+ */
+
+export type OpsBarKind = "create-file" | "create-dir" | "move" | "copy";
+export type OpsBar = { kind: OpsBarKind; draft: string; source: string } | null;
+
+export type FileOpOwnerPorts = {
+  rootDir: string;
+  /** Status-line write for mutation results and refusals (facade owns the line). */
+  onStatus: (text: string, tone?: EditorStatusTone) => void;
+};
+
+function errMsg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createFileOperationOwner(options: FileOpOwnerPorts) {
+  const { rootDir, onStatus } = options;
+
+  // —— tree file-management ops bar (B4 §5.1) ——
+  const [opsBar, setOpsBar] = createSignal<OpsBar>(null);
+
+  // —— confirm dialogs + action serialization ——
+  // The dialog signal is the page's single modal surface; B3 buffer dialogs
+  // (dirty/overwrite/reload/save-as overwrite) are raised through the facade
+  // into this owner, which serializes every async dialog action behind
+  // `dialogActionPending` so a fast Esc cannot reopen a dialog against an
+  // in-flight save.
+  const [dialog, setDialog] = createSignal<EditorDialog>(null);
+  let dialogActionPending = false;
+
+  /**
+   * Set when a dirty-confirm "save and close" diverts to the overwrite
+   * confirm: the close intent survives, so force-overwriting completes the
+   * close. saveActive() clears it at the start of every save (via the facade's
+   * onSaveStarted wiring) so it can't leak across buffers; choosing save-as or
+   * cancelling clears it too.
+   */
+  let closeAfterSave = false;
+
+  function raiseDialog(next: EditorDialog): void {
+    setDialog(next);
+  }
+
+  function closeDialog(): void {
+    setDialog(null);
+  }
+
+  function runDialogAction(action: () => Promise<unknown>): void {
+    dialogActionPending = true;
+    void action().finally(() => { dialogActionPending = false; });
+  }
+
+  function armCloseAfterSave(): void {
+    closeAfterSave = true;
+  }
+
+  function clearCloseAfterSave(): void {
+    closeAfterSave = false;
+  }
+
+  // —— ops bar ——
+
+  /**
+   * Open an ops bar with the tree selection's directory prefix pre-filled.
+   * The facade supplies the selected row and its directory prefix (tree
+   * state); this owner only shapes the bar.
+   */
+  function openOpsBar(kind: OpsBarKind, source: string, dirPrefix: string): void {
+    // create-* and move/copy both prefill the directory part so the user types
+    // the new name in place (B3 save-as taught us a pre-filled full path just
+    // has to be cleared first).
+    setOpsBar({ kind, draft: dirPrefix, source });
+  }
+
+  function closeOpsBar(): void {
+    setOpsBar(null);
+  }
+
+  function opsBarBackspace(): void {
+    setOpsBar((b) => (b ? { ...b, draft: b.draft.slice(0, -1) } : b));
+  }
+
+  function opsBarAppend(char: string): void {
+    setOpsBar((b) => (b ? { ...b, draft: b.draft + char } : b));
+  }
+
+  /** Enter on the ops bar: commit the draft as a guarded mutation. */
+  async function opsBarCommit(): Promise<WorkspaceMutation | null> {
+    const bar = opsBar();
+    if (!bar) return null;
+    const draft = bar.draft.trim().replace(/\\/g, "/");
+    setOpsBar(null);
+    if (!draft) { onStatus(`${bar.kind} needs a path`, "error"); return null; }
+    try {
+      assertProjectRelativePath(rootDir, draft);
+    } catch (error) {
+      onStatus(String(error instanceof Error ? error.message : error), "error");
+      return null;
+    }
+    if (bar.kind === "create-file") return execCreateFile(draft);
+    if (bar.kind === "create-dir") return execCreateDir(draft);
+    if (bar.kind === "move") return execMove(bar.source, draft, false);
+    return execCopy(bar.source, draft, false);
+  }
+
+  // —— guarded mutations ——
+
+  async function execCreateFile(relPath: string): Promise<WorkspaceMutation | null> {
+    try {
+      await createFile(rootDir, relPath);
+      onStatus(`created ${relPath}`, "success");
+      return { kind: "created", path: relPath, entryType: "file" };
+    } catch (error) { onStatus(errMsg(error), "error"); return null; }
+  }
+
+  async function execCreateDir(relPath: string): Promise<WorkspaceMutation | null> {
+    try {
+      await createDirectory(rootDir, relPath);
+      onStatus(`created directory ${relPath}`, "success");
+      return { kind: "created", path: relPath, entryType: "directory" };
+    } catch (error) { onStatus(errMsg(error), "error"); return null; }
+  }
+
+  async function execMove(source: string, target: string, overwrite: boolean): Promise<WorkspaceMutation | null> {
+    if (target === source) { onStatus("move target equals source", "error"); return null; }
+    if (!overwrite && await entryExists(rootDir, target)) {
+      raiseDialog({ kind: "ops-overwrite", path: target, op: "move", source });
+      return null;
+    }
+    try {
+      if (overwrite) await removeFile(rootDir, target);
+      await moveEntry(rootDir, source, target);
+      onStatus(`moved ${source} → ${target}`, "success");
+      return { kind: "moved", source, target };
+    } catch (error) { onStatus(errMsg(error), "error"); return null; }
+  }
+
+  async function execCopy(source: string, target: string, overwrite: boolean): Promise<WorkspaceMutation | null> {
+    if (target === source) { onStatus("copy target equals source", "error"); return null; }
+    if (!overwrite && await entryExists(rootDir, target)) {
+      raiseDialog({ kind: "ops-overwrite", path: target, op: "copy", source });
+      return null;
+    }
+    try {
+      if (overwrite) await removeFile(rootDir, target);
+      await copyEntry(rootDir, source, target);
+      onStatus(`copied ${source} → ${target}`, "success");
+      return { kind: "copied", source, target };
+    } catch (error) { onStatus(errMsg(error), "error"); return null; }
+  }
+
+  async function execDelete(relPath: string): Promise<WorkspaceMutation | null> {
+    try {
+      const trashPath = await trashEntry(rootDir, relPath);
+      onStatus(`moved ${relPath} → ${trashPath} (trash)`, "success");
+      return { kind: "deleted", path: relPath };
+    } catch (error) { onStatus(errMsg(error), "error"); return null; }
+  }
+
+  return {
+    // ops bar
+    opsBar,
+    openOpsBar,
+    closeOpsBar,
+    opsBarBackspace,
+    opsBarAppend,
+    opsBarCommit,
+    // dialogs + serialization
+    dialog,
+    raiseDialog,
+    closeDialog,
+    runDialogAction,
+    dialogActionPending: () => dialogActionPending,
+    armCloseAfterSave,
+    clearCloseAfterSave,
+    closeAfterSavePending: () => closeAfterSave,
+    // mutations
+    execCreateFile,
+    execCreateDir,
+    execMove,
+    execCopy,
+    execDelete,
+  };
+}
+
+export type FileOperationOwner = ReturnType<typeof createFileOperationOwner>;
+
+export type EditorDialog =
+  | { kind: "dirty-confirm"; path: string }
+  | { kind: "overwrite-confirm"; path: string }
+  | { kind: "reload-confirm"; path: string }
+  | { kind: "delete-confirm"; path: string }
+  | { kind: "ops-overwrite"; path: string; op: "move" | "copy"; source: string }
+  | { kind: "save-as-overwrite"; path: string }
+  | null;

--- a/src/tui/workspace/file-operation-owner.ts
+++ b/src/tui/workspace/file-operation-owner.ts
@@ -43,11 +43,12 @@ export function createFileOperationOwner(options: FileOpOwnerPorts) {
   const [opsBar, setOpsBar] = createSignal<OpsBar>(null);
 
   // —— confirm dialogs + action serialization ——
-  // The dialog signal is the page's single modal surface; B3 buffer dialogs
-  // (dirty/overwrite/reload/save-as overwrite) are raised through the facade
-  // into this owner, which serializes every async dialog action behind
-  // `dialogActionPending` so a fast Esc cannot reopen a dialog against an
-  // in-flight save.
+  // The dialog signal is the page's single modal surface: buffer-owned B3
+  // dialogs (dirty/overwrite/reload/save-as overwrite) are raised through the
+  // facade into this owner alongside the B4 delete/ops-overwrite dialogs. The
+  // controller keeps interpreting dialog actions (key routing, W4) and only
+  // delegates the serialization gate here, so no dialog is interpreted in two
+  // places.
   const [dialog, setDialog] = createSignal<EditorDialog>(null);
   let dialogActionPending = false;
 
@@ -132,7 +133,7 @@ export function createFileOperationOwner(options: FileOpOwnerPorts) {
     try {
       await createFile(rootDir, relPath);
       onStatus(`created ${relPath}`, "success");
-      return { kind: "created", path: relPath, entryType: "file" };
+      return Object.freeze({ kind: "created", path: relPath, entryType: "file" });
     } catch (error) { onStatus(errMsg(error), "error"); return null; }
   }
 
@@ -140,7 +141,7 @@ export function createFileOperationOwner(options: FileOpOwnerPorts) {
     try {
       await createDirectory(rootDir, relPath);
       onStatus(`created directory ${relPath}`, "success");
-      return { kind: "created", path: relPath, entryType: "directory" };
+      return Object.freeze({ kind: "created", path: relPath, entryType: "directory" });
     } catch (error) { onStatus(errMsg(error), "error"); return null; }
   }
 
@@ -154,7 +155,7 @@ export function createFileOperationOwner(options: FileOpOwnerPorts) {
       if (overwrite) await removeFile(rootDir, target);
       await moveEntry(rootDir, source, target);
       onStatus(`moved ${source} → ${target}`, "success");
-      return { kind: "moved", source, target };
+      return Object.freeze({ kind: "moved", source, target });
     } catch (error) { onStatus(errMsg(error), "error"); return null; }
   }
 
@@ -168,7 +169,7 @@ export function createFileOperationOwner(options: FileOpOwnerPorts) {
       if (overwrite) await removeFile(rootDir, target);
       await copyEntry(rootDir, source, target);
       onStatus(`copied ${source} → ${target}`, "success");
-      return { kind: "copied", source, target };
+      return Object.freeze({ kind: "copied", source, target });
     } catch (error) { onStatus(errMsg(error), "error"); return null; }
   }
 
@@ -176,7 +177,7 @@ export function createFileOperationOwner(options: FileOpOwnerPorts) {
     try {
       const trashPath = await trashEntry(rootDir, relPath);
       onStatus(`moved ${relPath} → ${trashPath} (trash)`, "success");
-      return { kind: "deleted", path: relPath };
+      return Object.freeze({ kind: "deleted", path: relPath });
     } catch (error) { onStatus(errMsg(error), "error"); return null; }
   }
 

--- a/src/tui/workspace/file-operations.ts
+++ b/src/tui/workspace/file-operations.ts
@@ -1,6 +1,6 @@
 import { copyFile, lstat, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
-import { assertProjectRelativePath } from "./workspace/paths";
+import { assertProjectRelativePath } from "./paths";
 
 /**
  * File-management primitives for the Workspace page tree (Scope B / #62,

--- a/src/tui/workspace/tree-owner.ts
+++ b/src/tui/workspace/tree-owner.ts
@@ -7,6 +7,7 @@ import {
   type WorkspaceTreeNode,
   type WorkspaceVisibleRow,
 } from "./tree-data";
+import type { WorkspaceMutation } from "./types";
 
 /**
  * Workspace file-tree owner (Scope B / #62). Owns the tree navigation state —
@@ -213,6 +214,20 @@ export function createTreeOwner(options: TreeOwnerOptions) {
     await Promise.all([recomputeRows(), rebuildIndex()]);
   }
 
+  /**
+   * Apply a frozen file-operation mutation: invalidate the affected caches and
+   * refresh rows + index. Selection follow-ups are the facade's reaction.
+   */
+  function applyMutation(mutation: WorkspaceMutation): Promise<void> {
+    if (mutation.kind === "created" || mutation.kind === "deleted") {
+      invalidateCache(mutation.path);
+    } else {
+      invalidateCache(mutation.source);
+      invalidateCache(mutation.target);
+    }
+    return refreshRowsAndIndex();
+  }
+
   // —— quick open ——
 
   function openQuickOpen(): void {
@@ -268,6 +283,7 @@ export function createTreeOwner(options: TreeOwnerOptions) {
     invalidateCache,
     refreshRowsAndIndex,
     rebuildIndex,
+    applyMutation,
     // quick open
     quickOpenActive,
     quickQuery,

--- a/src/tui/workspace/types.ts
+++ b/src/tui/workspace/types.ts
@@ -19,3 +19,15 @@ export type ViewerScrollEdge = "home" | "end";
  * for save/reload confirmations.
  */
 export type EditorStatusTone = "info" | "success" | "warn" | "error";
+
+/**
+ * A frozen file-operation result. The file-operation owner returns one of
+ * these for every successful mutation; the facade applies it to the owners in
+ * the fixed tree → buffer → validation order, so no owner interprets a
+ * mutation by reaching into another owner's state.
+ */
+export type WorkspaceMutation =
+  | { kind: "created"; path: string; entryType: "file" | "directory" }
+  | { kind: "copied"; source: string; target: string }
+  | { kind: "moved"; source: string; target: string }
+  | { kind: "deleted"; path: string };

--- a/src/tui/workspace/validation-owner.ts
+++ b/src/tui/workspace/validation-owner.ts
@@ -1,0 +1,251 @@
+import { createSignal } from "solid-js";
+import type { TuiKeyEvent } from "../decision-interaction";
+import { readFileStamp, sameFileStamp, type FileStamp } from "./buffer-io";
+import { readFilePreview, type WorkspaceFilePreview } from "./tree-data";
+import {
+  pendingValidation,
+  runValidation,
+  type LocatedFinding,
+  type ValidationState,
+} from "./validation";
+import type { WorkspaceMutation } from "./types";
+
+/**
+ * Workspace in-page validation owner (Scope B / #62, milestone B4 §5.2).
+ * Uniquely owns the path-owned validation snapshot, its disk-identity stamp,
+ * the dirty-to-stale projection, and the findings panel state (open / index /
+ * jump), plus the validation triggering rules for tree and viewer focus.
+ *
+ * Boundary: the owner never mutates the filesystem and never reads editor
+ * instance state. Dirty-buffer truth, tree selection, and the open file /
+ * editable admission arrive through narrow accessor ports wired by the
+ * facade; content reads go through the same pure modules the other owners
+ * use (tree-data previews, buffer-io stamps).
+ */
+
+export type ValidationOwnerPorts = {
+  rootDir: string;
+  /** Status-line write for validation messages (facade owns the line). */
+  onStatus: (text: string, tone?: "info" | "success" | "warn" | "error") => void;
+  /** Dirty-buffer truth from the buffer owner (drives the stale projection). */
+  isDirty: (path: string) => boolean;
+  /** The tree selection's file path, or null when not a file row. */
+  selectedFilePath: () => string | null;
+  /** The open preview (viewer state), or null when nothing is open. */
+  openFile: () => WorkspaceFilePreview | null;
+  /** Whether an editable buffer is admitted for the open file. */
+  canEditOpenFile: () => boolean;
+  /** Land the open editable buffer at a finding's line (buffer/viewer/focus). */
+  onJumpTo: (relPath: string, line: number) => void;
+};
+
+export function createValidationOwner(options: ValidationOwnerPorts) {
+  const { rootDir, onStatus } = options;
+
+  // The snapshot is the retained last result plus the path it describes. The
+  // projected `validationState()` folds in the dirty-buffer staleness rule so
+  // the view never has to: a result whose owning buffer is dirty reads as the
+  // neutral `validation stale` state, and clearing the dirty flag (undo to
+  // clean, save, reload) restores it without re-running the validators.
+  const [validationSnapshot, setValidationSnapshot] = createSignal<ValidationState>(pendingValidation);
+  const [findingsOpen, setFindingsOpen] = createSignal(false);
+  const [findingsIndex, setFindingsIndex] = createSignal(0);
+
+  /**
+   * Disk identity (mtime+ino) of the file the snapshot was computed from. The
+   * findings panel compares this against the live file before reusing a
+   * snapshot, so a deleted-then-recreated or externally rewritten file at the
+   * same path cannot inherit the previous file's findings (Issue #118 review
+   * round 2).
+   */
+  let validationStamp: FileStamp | null = null;
+
+  /**
+   * Displayed validation state. Reads the snapshot plus dirty-buffer truth: a
+   * result/no-match whose path is currently dirty projects to `stale` so the
+   * old verdict never reads as current over edited content. Plain function (not
+   * a memo) so callers — including tests outside a reactive root — always read
+   * the latest projection.
+   */
+  function validationState(): ValidationState {
+    const snap = validationSnapshot();
+    if ((snap.state === "result" || snap.state === "no-match") && options.isDirty(snap.path)) {
+      return { state: "stale", path: snap.path };
+    }
+    return snap;
+  }
+
+  /** Install a fresh snapshot for `relPath` from its content, with its disk identity. */
+  function setFor(relPath: string, content: string, stamp: FileStamp | null = null): void {
+    setValidationSnapshot(runValidation(relPath, content));
+    validationStamp = stamp;
+  }
+
+  /** Clear the snapshot back to pending (close/delete of the validated file). */
+  function clear(): void {
+    setValidationSnapshot(pendingValidation);
+    validationStamp = null;
+  }
+
+  /** Rekey the snapshot path after a rename/move; the underlying result is unchanged. */
+  function rekey(oldPath: string, newPath: string): void {
+    const snap = validationSnapshot();
+    if (snap.state !== "pending" && snap.path === oldPath) {
+      setValidationSnapshot({ ...snap, path: newPath } as ValidationState);
+    }
+  }
+
+  /** Apply a frozen file-operation mutation to this owner's state. */
+  function applyMutation(mutation: WorkspaceMutation): void {
+    if (mutation.kind === "moved") {
+      rekey(mutation.source, mutation.target);
+      return;
+    }
+    if (mutation.kind === "deleted") {
+      // A deleted file may own the validation snapshot even when it was never
+      // opened (tree `v` validates the selection without opening it). Clear it
+      // whenever the snapshot describes the deleted path, so a recreated file
+      // at the same path — or an external rewrite — cannot inherit stale
+      // findings (Issue #118 review round 2).
+      const snap = validationSnapshot();
+      if (snap.state !== "pending" && snap.path === mutation.path) clear();
+    }
+  }
+
+  /**
+   * Open the findings panel for a snapshot already current for `relPath`
+   * (consume, no re-run). Returns false when the caller should bail. Reuse is
+   * gated on the live file's disk identity still matching the snapshot's, so a
+   * recreated or externally rewritten file at the same path does not inherit
+   * stale findings (Issue #118 review round 2).
+   */
+  async function openFindingsForCurrent(relPath: string): Promise<boolean> {
+    const snap = validationSnapshot();
+    if ((snap.state === "result" || snap.state === "no-match") && snap.path === relPath && !options.isDirty(relPath)) {
+      const current = await readFileStamp(rootDir, relPath);
+      if (validationStamp !== null && current !== null && sameFileStamp(current, validationStamp)) {
+        setFindingsIndex(0);
+        setFindingsOpen(true);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Tree-focus `v` targets the selected row, never an unrelated open file
+   * (Issue #118 §3). A directory or empty selection stays closed with a hint;
+   * a dirty buffer is not silently validated against its older disk image; a
+   * snapshot already current for the selection is consumed rather than re-run.
+   */
+  async function treeValidate(): Promise<void> {
+    const relPath = options.selectedFilePath();
+    if (!relPath) {
+      onStatus("select a file to validate", "info");
+      return;
+    }
+    if (options.isDirty(relPath)) {
+      onStatus(`save ${relPath} before validating`, "info");
+      return;
+    }
+    if (await openFindingsForCurrent(relPath)) return;
+    const preview = await readFilePreview(rootDir, relPath);
+    if (!preview) {
+      onStatus(`${relPath} is not readable`, "error");
+      return;
+    }
+    const stamp = await readFileStamp(rootDir, relPath);
+    setFor(relPath, preview.lines?.join("\n") ?? "", stamp);
+    setFindingsIndex(0);
+    setFindingsOpen(true);
+  }
+
+  /**
+   * Viewer-focus `v` targets the open file. Same dirty-buffer and consume
+   * rules as the tree path; re-validates only when the snapshot is stale or
+   * for a different file.
+   */
+  async function viewerValidate(): Promise<void> {
+    const file = options.openFile();
+    if (!file) { onStatus("open a file to validate", "info"); return; }
+    if (options.isDirty(file.relPath)) {
+      onStatus(`save ${file.relPath} before validating`, "info");
+      return;
+    }
+    if (await openFindingsForCurrent(file.relPath)) return;
+    const stamp = await readFileStamp(rootDir, file.relPath);
+    setFor(file.relPath, file.lines?.join("\n") ?? "", stamp);
+    setFindingsIndex(0);
+    setFindingsOpen(true);
+  }
+
+  /**
+   * Whether `Enter` in the findings panel would really jump. Requires an
+   * admitted editable buffer for the open file and a selected finding with a
+   * resolvable line (Issue #118 §4 — read-only / oversized / refused-buffer
+   * targets must neither advertise nor execute a jump).
+   */
+  function canJumpToSelectedFinding(): boolean {
+    const file = options.openFile();
+    if (!file || !options.canEditOpenFile()) return false;
+    const snap = validationSnapshot();
+    if (snap.state !== "result") return false;
+    // The findings panel can describe a different file than the one open (tree
+    // `v` validates the selection without opening it). A jump must target the
+    // open buffer, so refuse — and do not advertise Enter — when the snapshot
+    // belongs to another file (Issue #118 review: cross-file jump).
+    if (snap.path !== file.relPath) return false;
+    const finding = snap.findings[findingsIndex()];
+    return Boolean(finding && finding.line !== null);
+  }
+
+  function handleFindingsKey(key: TuiKeyEvent): boolean {
+    const state = validationSnapshot();
+    const findings = state.state === "result" ? state.findings : [];
+    if (key.name === "escape") { setFindingsOpen(false); return true; }
+    if (findings.length === 0) return true;
+    if (key.name === "up") { setFindingsIndex((i) => Math.max(0, i - 1)); return true; }
+    if (key.name === "down") { setFindingsIndex((i) => Math.min(findings.length - 1, i + 1)); return true; }
+    if (key.name === "enter") {
+      if (canJumpToSelectedFinding()) {
+        const finding = findings[findingsIndex()];
+        if (finding) jumpToFinding(finding);
+      }
+      return true;
+    }
+    return true;
+  }
+
+  /** Land the active editable buffer at a finding's line and close the panel. */
+  function jumpToFinding(finding: LocatedFinding): void {
+    const file = options.openFile();
+    // Defence-in-depth alongside canJumpToSelectedFinding: never jump a finding
+    // from another file's snapshot into the open buffer.
+    const snap = validationSnapshot();
+    if (!file || !options.canEditOpenFile() || finding.line === null) return;
+    if (snap.state !== "pending" && snap.path !== file.relPath) return;
+    setFindingsOpen(false);
+    options.onJumpTo(file.relPath, finding.line);
+  }
+
+  return {
+    // snapshot + findings state
+    validationSnapshot,
+    validationState,
+    findingsOpen,
+    findingsIndex,
+    // installers
+    setFor,
+    clear,
+    rekey,
+    applyMutation,
+    // triggering + navigation
+    openFindingsForCurrent,
+    treeValidate,
+    viewerValidate,
+    canJumpToSelectedFinding,
+    handleFindingsKey,
+  };
+}
+
+export type ValidationOwner = ReturnType<typeof createValidationOwner>;

--- a/src/tui/workspace/validation.ts
+++ b/src/tui/workspace/validation.ts
@@ -1,5 +1,5 @@
-import { ARTIFACT_VALIDATOR_NAMES } from "../core/artifacts/workbench";
-import { validateContent } from "../core/validators/registry";
+import { ARTIFACT_VALIDATOR_NAMES } from "../../core/artifacts/workbench";
+import { validateContent } from "../../core/validators/registry";
 
 /**
  * In-page validation orchestration for the Workspace page (Scope B / #62,

--- a/tests/unit/tui/workspace-file-operation-owner.test.ts
+++ b/tests/unit/tui/workspace-file-operation-owner.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { lstat, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createFileOperationOwner } from "../../../src/tui/workspace/file-operation-owner";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "vesicle-ws-fileops-owner-"));
+  await mkdir(join(root, "workspace"), { recursive: true });
+  await writeFile(join(root, "workspace/a.md"), "# A\n");
+  await writeFile(join(root, "workspace/b.md"), "# B\n");
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function makeOwner() {
+  const calls = {
+    status: [] as Array<[string, string | undefined]>,
+  };
+  const owner = createFileOperationOwner({
+    rootDir: root,
+    onStatus: (text, tone) => { calls.status.push([text, tone]); },
+  });
+  return { owner, calls };
+}
+
+describe("workspace file-operation owner: ops bar", () => {
+  test("openOpsBar prefills the draft with the directory prefix", () => {
+    const { owner } = makeOwner();
+    owner.openOpsBar("create-file", "workspace/a.md", "workspace/");
+    expect(owner.opsBar()).toEqual({ kind: "create-file", draft: "workspace/", source: "workspace/a.md" });
+    owner.opsBarAppend("new.md");
+    expect(owner.opsBar()?.draft).toBe("workspace/new.md");
+    owner.opsBarBackspace();
+    expect(owner.opsBar()?.draft).toBe("workspace/new.m");
+    owner.closeOpsBar();
+    expect(owner.opsBar()).toBeNull();
+  });
+
+  test("opsBarCommit rejects an escaping draft without running a mutation", async () => {
+    const { owner, calls } = makeOwner();
+    owner.openOpsBar("create-file", "workspace/a.md", "");
+    for (const ch of "../../escape.md") owner.opsBarAppend(ch);
+    const mutation = await owner.opsBarCommit();
+    expect(mutation).toBeNull();
+    expect(owner.opsBar()).toBeNull();
+    expect(calls.status.at(-1)?.[0]).toContain("escapes");
+    await expect(lstat(join(root, "escape.md"))).rejects.toThrow();
+  });
+});
+
+describe("workspace file-operation owner: guarded mutations", () => {
+  test("create-file returns a created mutation and writes the file", async () => {
+    const { owner } = makeOwner();
+    const mutation = await owner.execCreateFile("workspace/new.md");
+    expect(mutation).toEqual({ kind: "created", path: "workspace/new.md", entryType: "file" });
+    const info = await lstat(join(root, "workspace/new.md"));
+    expect(info.isFile()).toBe(true);
+  });
+
+  test("create over an existing file fails without a mutation", async () => {
+    const { owner, calls } = makeOwner();
+    const mutation = await owner.execCreateFile("workspace/a.md");
+    expect(mutation).toBeNull();
+    expect(calls.status.at(-1)?.[0]).toContain("already exists");
+  });
+
+  test("create-dir returns a created directory mutation", async () => {
+    const { owner } = makeOwner();
+    const mutation = await owner.execCreateDir("workspace/sub");
+    expect(mutation).toEqual({ kind: "created", path: "workspace/sub", entryType: "directory" });
+    const info = await lstat(join(root, "workspace/sub"));
+    expect(info.isDirectory()).toBe(true);
+  });
+
+  test("move to a free target returns a moved mutation; move onto an existing target raises the overwrite dialog", async () => {
+    const { owner } = makeOwner();
+    await writeFile(join(root, "workspace/c.md"), "# C\n");
+    const moved = await owner.execMove("workspace/a.md", "workspace/d.md", false);
+    expect(moved).toEqual({ kind: "moved", source: "workspace/a.md", target: "workspace/d.md" });
+    await expect(lstat(join(root, "workspace/a.md"))).rejects.toThrow();
+
+    const gated = await owner.execMove("workspace/b.md", "workspace/c.md", false);
+    expect(gated).toBeNull();
+    expect(owner.dialog()).toEqual({ kind: "ops-overwrite", path: "workspace/c.md", op: "move", source: "workspace/b.md" });
+
+    const forced = await owner.execMove("workspace/b.md", "workspace/c.md", true);
+    expect(forced).toEqual({ kind: "moved", source: "workspace/b.md", target: "workspace/c.md" });
+  });
+
+  test("move target equals source is refused", async () => {
+    const { owner, calls } = makeOwner();
+    const mutation = await owner.execMove("workspace/a.md", "workspace/a.md", true);
+    expect(mutation).toBeNull();
+    expect(calls.status.at(-1)?.[0]).toContain("target equals source");
+  });
+
+  test("copy returns a copied mutation and leaves the source intact", async () => {
+    const { owner } = makeOwner();
+    const mutation = await owner.execCopy("workspace/a.md", "workspace/copy.md", false);
+    expect(mutation).toEqual({ kind: "copied", source: "workspace/a.md", target: "workspace/copy.md" });
+    await expect(lstat(join(root, "workspace/a.md"))).resolves.toBeDefined();
+    await expect(lstat(join(root, "workspace/copy.md"))).resolves.toBeDefined();
+  });
+
+  test("delete trashes the entry and returns a deleted mutation", async () => {
+    const { owner } = makeOwner();
+    const mutation = await owner.execDelete("workspace/a.md");
+    expect(mutation).toEqual({ kind: "deleted", path: "workspace/a.md" });
+    await expect(lstat(join(root, "workspace/a.md"))).rejects.toThrow();
+    const trash = await import("node:fs/promises").then((m) => m.readdir(join(root, ".vesicle", "trash")));
+    expect(trash.some((name) => name.endsWith("a.md"))).toBe(true);
+  });
+
+  test("deleting a missing entry reports an error without a mutation", async () => {
+    const { owner, calls } = makeOwner();
+    const mutation = await owner.execDelete("workspace/missing.md");
+    expect(mutation).toBeNull();
+    expect(calls.status.at(-1)?.[0]).toContain("does not exist");
+  });
+});
+
+describe("workspace file-operation owner: dialog serialization", () => {
+  test("runDialogAction gates key input while the action is in flight", async () => {
+    const { owner } = makeOwner();
+    let release: () => void = () => undefined;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    owner.runDialogAction(async () => { await gate; });
+    expect(owner.dialogActionPending()).toBe(true);
+    release();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(owner.dialogActionPending()).toBe(false);
+  });
+
+  test("close-after-save intent survives until cleared", () => {
+    const { owner } = makeOwner();
+    expect(owner.closeAfterSavePending()).toBe(false);
+    owner.armCloseAfterSave();
+    expect(owner.closeAfterSavePending()).toBe(true);
+    owner.clearCloseAfterSave();
+    expect(owner.closeAfterSavePending()).toBe(false);
+  });
+});

--- a/tests/unit/tui/workspace-fileops.test.ts
+++ b/tests/unit/tui/workspace-fileops.test.ts
@@ -10,7 +10,7 @@ import {
   moveEntry,
   removeFile,
   trashEntry,
-} from "../../../src/tui/workspace-fileops";
+} from "../../../src/tui/workspace/file-operations";
 
 let root: string;
 

--- a/tests/unit/tui/workspace-validate.test.ts
+++ b/tests/unit/tui/workspace-validate.test.ts
@@ -5,7 +5,7 @@ import {
   runValidation,
   validationSeverity,
   validationSummary,
-} from "../../../src/tui/workspace-validate";
+} from "../../../src/tui/workspace/validation";
 
 describe("validate anchor extraction", () => {
   test("pulls ## section headers and quoted frontmatter keys from a finding", () => {
@@ -127,7 +127,7 @@ describe("validate run + summary + severity", () => {
   });
 
   test("the summary is pure state and never carries an action token (Issue #118 §1)", () => {
-    type VState = import("../../../src/tui/workspace-validate").ValidationState;
+    type VState = import("../../../src/tui/workspace/validation").ValidationState;
     // Each outcome maps to an exact summary, and none carries an action token.
     const cases: Array<{ state: VState; want: string }> = [
       { state: { state: "pending" }, want: "" },

--- a/tests/unit/tui/workspace-validation-owner.test.ts
+++ b/tests/unit/tui/workspace-validation-owner.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { WorkspaceFilePreview } from "../../../src/tui/workspace/tree-data";
+import { createValidationOwner } from "../../../src/tui/workspace/validation-owner";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "vesicle-ws-validation-owner-"));
+  await mkdir(join(root, "workspace"), { recursive: true });
+  await writeFile(join(root, "workspace/a.md"), "# A\n\nbody\n");
+  await writeFile(join(root, "workspace/b.md"), "# B\n\nbody\n");
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+function makeOwner(overrides: Partial<{
+  dirty: (path: string) => boolean;
+  selectedFilePath: () => string | null;
+  openFile: () => WorkspaceFilePreview | null;
+  canEditOpenFile: () => boolean;
+}> = {}) {
+  const calls = {
+    status: [] as Array<[string, string | undefined]>,
+    jumps: [] as Array<[string, number]>,
+  };
+  const owner = createValidationOwner({
+    rootDir: root,
+    onStatus: (text, tone) => { calls.status.push([text, tone]); },
+    isDirty: overrides.dirty ?? (() => false),
+    selectedFilePath: overrides.selectedFilePath ?? (() => null),
+    openFile: overrides.openFile ?? (() => null),
+    canEditOpenFile: overrides.canEditOpenFile ?? (() => false),
+    onJumpTo: (relPath, line) => { calls.jumps.push([relPath, line]); },
+  });
+  return { owner, calls };
+}
+
+const YAML_RESULT = "---\narchetype: x\n---\nbody\n";
+
+describe("workspace validation owner: snapshot lifecycle", () => {
+  test("setFor installs a result snapshot; clear resets to pending", () => {
+    const { owner } = makeOwner();
+    expect(owner.validationState()).toEqual({ state: "pending" });
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    const snap = owner.validationSnapshot();
+    expect(snap.state).toBe("result");
+    if (snap.state === "result") {
+      expect(snap.path).toBe("workspace/a.md");
+      expect(owner.canJumpToSelectedFinding()).toBe(false);
+    }
+    owner.clear();
+    expect(owner.validationState()).toEqual({ state: "pending" });
+  });
+
+  test("dirty buffer projects the snapshot to stale without losing the result", () => {
+    const dirtyPaths = new Set<string>();
+    const { owner } = makeOwner({ dirty: (p) => dirtyPaths.has(p) });
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    dirtyPaths.add("workspace/a.md");
+    expect(owner.validationState()).toEqual({ state: "stale", path: "workspace/a.md" });
+    dirtyPaths.delete("workspace/a.md");
+    expect(owner.validationState().state).toBe("result");
+  });
+
+  test("rekey moves the snapshot path and keeps the verdict", () => {
+    const { owner } = makeOwner();
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    owner.rekey("workspace/a.md", "workspace/renamed.md");
+    expect(owner.validationSnapshot()).toMatchObject({ state: "result", path: "workspace/renamed.md" });
+  });
+});
+
+describe("workspace validation owner: typed mutations", () => {
+  test("applyMutation(moved) rekeys the snapshot path", () => {
+    const { owner } = makeOwner();
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    owner.applyMutation({ kind: "moved", source: "workspace/a.md", target: "workspace/renamed.md" });
+    expect(owner.validationSnapshot()).toMatchObject({ state: "result", path: "workspace/renamed.md" });
+  });
+
+  test("applyMutation(deleted) clears a snapshot that owns the deleted path", () => {
+    const { owner } = makeOwner();
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    owner.applyMutation({ kind: "deleted", path: "workspace/a.md" });
+    expect(owner.validationState()).toEqual({ state: "pending" });
+  });
+
+  test("applyMutation(deleted) leaves a snapshot for another path untouched", () => {
+    const { owner } = makeOwner();
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    owner.applyMutation({ kind: "deleted", path: "workspace/b.md" });
+    expect(owner.validationSnapshot()).toMatchObject({ state: "result", path: "workspace/a.md" });
+  });
+});
+
+describe("workspace validation owner: triggering and navigation", () => {
+  test("treeValidate validates the selected file and opens findings", async () => {
+    const { owner } = makeOwner({
+      selectedFilePath: () => "workspace/a.md",
+      openFile: () => null,
+      canEditOpenFile: () => false,
+    });
+    // The fixture must be a validator-matching artifact (Module A/B shape).
+    await writeFile(join(root, "workspace/a.md"), YAML_RESULT);
+    await owner.treeValidate();
+    expect(owner.findingsOpen()).toBe(true);
+    expect(owner.validationSnapshot().state).toBe("result");
+  });
+
+  test("treeValidate refuses a dirty buffer with a status hint", async () => {
+    const { owner, calls } = makeOwner({
+      selectedFilePath: () => "workspace/a.md",
+      dirty: (p) => p === "workspace/a.md",
+    });
+    await owner.treeValidate();
+    expect(owner.findingsOpen()).toBe(false);
+    expect(calls.status.at(-1)?.[0]).toContain("save");
+  });
+
+  test("findings navigation moves the index and jumps through the port", () => {
+    const { owner, calls } = makeOwner({
+      openFile: () => ({ kind: "text", relPath: "workspace/a.md", size: 1, readonly: false, symlink: false, oversized: false }) as WorkspaceFilePreview,
+      canEditOpenFile: () => true,
+    });
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    expect(owner.canJumpToSelectedFinding()).toBe(true);
+    owner.handleFindingsKey({ name: "enter" } as never);
+    expect(owner.findingsOpen()).toBe(false);
+    expect(calls.jumps.length).toBe(1);
+  });
+
+  test("findings navigation refuses a cross-file jump", () => {
+    const { owner, calls } = makeOwner({
+      openFile: () => ({ kind: "text", relPath: "workspace/b.md", size: 1, readonly: false, symlink: false, oversized: false }) as WorkspaceFilePreview,
+      canEditOpenFile: () => true,
+    });
+    // The snapshot belongs to a.md while b.md is open: Enter must not jump.
+    owner.setFor("workspace/a.md", YAML_RESULT);
+    expect(owner.canJumpToSelectedFinding()).toBe(false);
+    owner.handleFindingsKey({ name: "enter" } as never);
+    expect(calls.jumps.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Code Smell Round 3, Wave W3 (File-operation + validation owners), per `dev/docs/working/CODE_SMELL_REMEDIATION_IMPLEMENTATION_PLAN.md` §6.

- `workspace-fileops.ts` → `workspace/file-operations.ts` and `workspace-validate.ts` → `workspace/validation.ts` are equivalent moves (no pass-through).
- New `file-operation-owner.ts` uniquely owns the ops bar, the confirm-dialog surface and its action serialization, and the guarded mutations — every success returns a frozen `WorkspaceMutation`.
- New `validation-owner.ts` uniquely owns the path-owned snapshot, disk stamp, dirty-to-stale projection, and findings navigation, consuming buffer/tree/viewer truth through narrow named ports.
- The facade applies each mutation exactly once per owner in the fixed tree → buffer → validation order (`applyMutation`); the old `rekeyOpenBuffer`/`rekeyValidation`/`afterTreeMutation*` cross-state functions are gone. Controller shrinks 1053 → ~700 lines.
- New direct owner suites (file-operation 12 tests, validation 10 tests) protect the mutation protocol.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` (1850 pass, 6 skip, 0 fail)
- [x] `bun run doctor` (Missing: none)
- [x] `git diff --check`
- Focused: fileops + validate + status suites (64 pass), editor-controller + controller + buffer-owner + workspace-page component (80 pass), new owner suites (22 pass)

## Notes / Follow-ups

- Independent CR (subagent, exact HEAD): Blocking none; Should-fix resolved — delete-failure-path ordering deviation is recorded in the execution plan as a deliberate protocol consequence (pre-W3 cleared buffer/viewer/validation before the trash attempt; the mutation protocol applies state only after a successful mutation; no test or contract covered the failure path); execution record appended.
- W4 (external-editor owner + input router) next, same plan section.