### PR TITLE
refactor(tui): extract external-editor owner and workspace input router (W4)

### DIFF
--- a/src/tui/workspace/controller.ts
+++ b/src/tui/workspace/controller.ts
@@ -2,15 +2,10 @@ import { createSignal } from "solid-js";
 import type { TuiKeyEvent } from "../decision-interaction";
 import { isEditablePreview, readFileStamp } from "./buffer-io";
 import { createBufferOwner } from "./buffer-owner";
+import { createExternalEditorOwner } from "./external-editor-owner";
 import { createFileOperationOwner } from "./file-operation-owner";
-import {
-  resolveEditorCommand,
-  runExternalEditor,
-  type EditorRuntime,
-} from "../workspace-external-editor";
-import { loadSettings, type Settings } from "../../config/settings";
-import { assertProjectRelativePath } from "./paths";
-import { readFilePreview, statEntry, type WorkspaceFilePreview } from "./tree-data";
+import { routeWorkspaceKey, type InputSurface } from "./input-router";
+import { readFilePreview, type WorkspaceFilePreview } from "./tree-data";
 import { createTreeOwner } from "./tree-owner";
 import { createValidationOwner } from "./validation-owner";
 import type { ShellPage, WorkspaceFocusRegion, ViewerScrollEdge, EditorStatusTone, WorkspaceMutation } from "./types";
@@ -296,14 +291,30 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     }
   }
 
-  // —— external editor handoff (B5 §6) ——
-
-  /** Renderer + spawn primitives, injected by the component (see WorkspacePage). */
-  let externalEditorRuntime: EditorRuntime | null = null;
-  function registerExternalEditor(runtime: EditorRuntime): () => void {
-    externalEditorRuntime = runtime;
-    return () => { externalEditorRuntime = null; };
-  }
+  const externalEditor = createExternalEditorOwner({
+    rootDir,
+    onStatus: (text, tone) => status(text, tone),
+    resolveHandoffTarget: () => resolveHandoffTarget(),
+    buffer: {
+      isDirty: (path) => buffer.dirtyPaths().has(path),
+      reconcile: (path) => buffer.reconcileExternalChange(path),
+    },
+    tree: {
+      invalidateCache: (path) => tree.invalidateCache(path),
+      refreshRowsAndIndex: () => tree.refreshRowsAndIndex(),
+    },
+    viewer: {
+      reloadIfShowing: async (relPath) => {
+        if (openFile()?.relPath === relPath) await reloadViewer();
+      },
+      closeIfShowing: (relPath) => {
+        if (openFile()?.relPath === relPath) {
+          setOpenFile(null);
+          setFocusRegion("tree");
+        }
+      },
+    },
+  });
 
   /** Which file Ctrl+X hands off, by focus region (plan §6.1). */
   function resolveHandoffTarget(): string | null {
@@ -320,68 +331,6 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     if (file) return file.relPath;
     status("open or select a file to edit externally", "info");
     return null;
-  }
-
-  async function handoffToExternal(): Promise<void> {
-    const target = resolveHandoffTarget();
-    if (!target) return;
-    let abs: string;
-    try {
-      abs = assertProjectRelativePath(rootDir, target);
-    } catch (error) {
-      status(errMsg(error), "error");
-      return;
-    }
-    const stat = await statEntry(rootDir, target);
-    if (stat?.kind === "dir") { status(`${target} is a directory`, "error"); return; }
-    // dirty gate (plan §6.1): an unsaved buffer would be silently overwritten
-    // by whatever the external editor writes, so refuse and point at Ctrl+S.
-    if (buffer.dirtyPaths().has(target)) {
-      status(`${target} has unsaved edits — press Ctrl+S before the external editor`, "error");
-      return;
-    }
-    const runtime = externalEditorRuntime;
-    if (!runtime) { status("external editor is unavailable in this build", "error"); return; }
-
-    let settings: Settings;
-    try {
-      settings = await loadSettings();
-    } catch (error) {
-      status(`settings.yaml is malformed — ${errMsg(error)} (fix or remove it)`, "error");
-      return;
-    }
-    const editor = resolveEditorCommand({ env: process.env, settings });
-    status(`opening ${target} in ${editor.command}…`, "info");
-    let exitCode = 0;
-    try {
-      const result = await runExternalEditor({ absPath: abs, editor, runtime });
-      exitCode = result.exitCode;
-    } catch (error) {
-      status(`editor "${editor.command}" failed to start — ${errMsg(error)}`, "error");
-      return;
-    }
-    if (exitCode !== 0) status(`editor exited with code ${exitCode}`, "warn");
-    await refreshAfterExternalEdit(target);
-  }
-
-  /**
-   * React to whatever the external editor did: a resident buffer is reconciled
-   * by the buffer owner (unchanged/modified/removed), and the facade only
-   * reacts to viewer/focus state; a non-resident file just has its tree cache
-   * + index invalidated and the viewer re-read if it was showing the file.
-   */
-  async function refreshAfterExternalEdit(relPath: string): Promise<void> {
-    const outcome = await buffer.reconcileExternalChange(relPath);
-    if (outcome === "not-resident") {
-      tree.invalidateCache(relPath);
-      await tree.refreshRowsAndIndex();
-      if (openFile()?.relPath === relPath) await reloadViewer();
-      return;
-    }
-    if (outcome === "removed" && openFile()?.relPath === relPath) {
-      setOpenFile(null);
-      setFocusRegion("tree");
-    }
   }
 
   /** Leave the editable source by one focus level (Esc-clean destination). */
@@ -416,10 +365,6 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     setOpenFile(null);
     setFocusRegion("tree");
     validation.clear();
-  }
-
-  function errMsg(error: unknown): string {
-    return error instanceof Error ? error.message : String(error);
   }
 
   // —— key handling ——
@@ -682,21 +627,22 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
 
   /** Returns true when the key was consumed by the Workspace page. */
   function handleKey(key: TuiKeyEvent): boolean {
-    if (page() !== "workspace") return false;
-    if (fileOps.dialogActionPending()) return true;
-    if (tree.quickOpenActive()) return handleQuickOpenKey(key);
-    if (validation.findingsOpen()) return validation.handleFindingsKey(key);
-    if (fileOps.dialog()) return handleDialogKey(key);
-    if (fileOps.opsBar()) return handleOpsBarKey(key);
-    if (buffer.findActive()) return handleFindKey(key);
-    if (buffer.gotoActive()) return handleGotoKey(key);
-    if (buffer.saveAsActive()) return handleSaveAsKey(key);
+    return routeWorkspaceKey(key, routerPorts);
+  }
+
+  /** Global Workspace keys (Ctrl+P / Ctrl+X / F6) — routed before the region. */
+  function handleGlobalKeys(key: TuiKeyEvent): boolean {
     if (key.ctrl && key.name === "p") { tree.openQuickOpen(); return true; }
     // Ctrl+X hands off to the external editor from every Workspace focus
     // region (B5 §6.1); caught here so it also covers the composer region and
     // is intercepted before the editable source textarea can consume it.
-    if (isCtrl(key, "x") && !key.shift) { void handoffToExternal(); return true; }
+    if (isCtrl(key, "x") && !key.shift) { void externalEditor.handoffToExternal(); return true; }
     if (key.name === "f6") { cycleFocus(key.shift ? -1 : 1); return true; }
+    return false;
+  }
+
+  /** Focus-region dispatch (tree / viewer / editable source / composer). */
+  function handleRegionKeys(key: TuiKeyEvent): boolean {
     const region = focusRegion();
     if (region === "editor" && openFile()) {
       if (isEditing()) return handleEditableKey(key);
@@ -705,6 +651,24 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     if (region === "editor") { setFocusRegion("tree"); return true; }
     if (region === "tree") return handleTreeKey(normalizeVimKey(key));
     return false; // composer region: fall through to the shared composer
+  }
+
+  const routerPorts: import("./input-router").WorkspaceRouterPorts = {
+    pageIsWorkspace: () => page() === "workspace",
+    dialogActionPending: () => fileOps.dialogActionPending(),
+    quickOpen: surface(() => tree.quickOpenActive(), handleQuickOpenKey),
+    findings: surface(() => validation.findingsOpen(), (key) => validation.handleFindingsKey(key)),
+    dialog: surface(() => fileOps.dialog() !== null, handleDialogKey),
+    opsBar: surface(() => fileOps.opsBar() !== null, handleOpsBarKey),
+    find: surface(() => buffer.findActive(), handleFindKey),
+    goto: surface(() => buffer.gotoActive(), handleGotoKey),
+    saveAs: surface(() => buffer.saveAsActive(), handleSaveAsKey),
+    globalKeys: handleGlobalKeys,
+    regionKeys: handleRegionKeys,
+  };
+
+  function surface(active: () => boolean, handle: (key: TuiKeyEvent) => boolean): InputSurface {
+    return { active, handle };
   }
 
   return {
@@ -730,7 +694,7 @@ export function createWorkspaceController(rootDir: string = process.cwd()) {
     toggleViewMode,
     registerViewerScroller,
     // external editor handoff (B5)
-    registerExternalEditor,
+    registerExternalEditor: externalEditor.registerExternalEditor,
     // editor pool
     editorOrder: buffer.editorOrder,
     activeEditorPath: buffer.activeEditorPath,

--- a/src/tui/workspace/external-editor-owner.ts
+++ b/src/tui/workspace/external-editor-owner.ts
@@ -1,0 +1,139 @@
+import { loadSettings, type Settings } from "../../config/settings";
+import { assertProjectRelativePath } from "./paths";
+import { statEntry } from "./tree-data";
+import type { ExternalEditOutcome } from "./buffer-owner";
+import {
+  resolveEditorCommand,
+  runExternalEditor,
+  type EditorRuntime,
+} from "./external-editor-runtime";
+import type { EditorStatusTone } from "./types";
+
+/**
+ * Workspace external-editor owner (Scope B / #62, milestone B5 §6). Owns the
+ * Ctrl+X handoff use case: target handoff, dirty gate, renderer suspend /
+ * spawn / resume through the injected runtime, and the return reconciliation
+ * that distinguishes unchanged / modified / removed / unreadable / non-
+ * resident outcomes.
+ *
+ * Boundary: the owner never holds the Workspace controller or another owner's
+ * signals. It requests state through narrow BufferPort / TreePort / ViewerPort
+ * objects wired by the facade, and reports status through `onStatus`.
+ */
+
+export type ExternalBufferPort = {
+  /** Whether the path has an unsaved buffer (dirty gate). */
+  isDirty: (path: string) => boolean;
+  /** Reconcile a resident buffer after the editor returned. */
+  reconcile: (path: string) => Promise<ExternalEditOutcome>;
+};
+
+export type ExternalTreePort = {
+  /** Drop the scan-cache entries for a path's ancestors. */
+  invalidateCache: (relPath: string) => void;
+  /** Rebuild tree rows + quick-open index. */
+  refreshRowsAndIndex: () => Promise<void>;
+};
+
+export type ExternalViewerPort = {
+  /** Re-read the preview if the viewer is showing this path. */
+  reloadIfShowing: (relPath: string) => Promise<void>;
+  /** Close the viewer (and return focus to the tree) if it shows this path. */
+  closeIfShowing: (relPath: string) => void;
+};
+
+export type ExternalEditorOwnerPorts = {
+  rootDir: string;
+  /** Status-line write (facade owns the line). */
+  onStatus: (text: string, tone?: EditorStatusTone) => void;
+  /** Resolve the Ctrl+X target by focus region (page state lives in the facade). */
+  resolveHandoffTarget: () => string | null;
+  buffer: ExternalBufferPort;
+  tree: ExternalTreePort;
+  viewer: ExternalViewerPort;
+};
+
+function errMsg(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createExternalEditorOwner(options: ExternalEditorOwnerPorts) {
+  const { rootDir, onStatus } = options;
+
+  /** Renderer + spawn primitives, injected by the component (see WorkspacePage). */
+  let externalEditorRuntime: EditorRuntime | null = null;
+  function registerExternalEditor(runtime: EditorRuntime): () => void {
+    externalEditorRuntime = runtime;
+    return () => { externalEditorRuntime = null; };
+  }
+
+  async function handoffToExternal(): Promise<void> {
+    const target = options.resolveHandoffTarget();
+    if (!target) return;
+    let abs: string;
+    try {
+      abs = assertProjectRelativePath(rootDir, target);
+    } catch (error) {
+      onStatus(errMsg(error), "error");
+      return;
+    }
+    const stat = await statEntry(rootDir, target);
+    if (stat?.kind === "dir") { onStatus(`${target} is a directory`, "error"); return; }
+    // dirty gate (plan §6.1): an unsaved buffer would be silently overwritten
+    // by whatever the external editor writes, so refuse and point at Ctrl+S.
+    if (options.buffer.isDirty(target)) {
+      onStatus(`${target} has unsaved edits — press Ctrl+S before the external editor`, "error");
+      return;
+    }
+    const runtime = externalEditorRuntime;
+    if (!runtime) { onStatus("external editor is unavailable in this build", "error"); return; }
+
+    let settings: Settings;
+    try {
+      settings = await loadSettings();
+    } catch (error) {
+      onStatus(`settings.yaml is malformed — ${errMsg(error)} (fix or remove it)`, "error");
+      return;
+    }
+    const editor = resolveEditorCommand({ env: process.env, settings });
+    onStatus(`opening ${target} in ${editor.command}…`, "info");
+    let exitCode = 0;
+    try {
+      const result = await runExternalEditor({ absPath: abs, editor, runtime });
+      exitCode = result.exitCode;
+    } catch (error) {
+      onStatus(`editor "${editor.command}" failed to start — ${errMsg(error)}`, "error");
+      return;
+    }
+    if (exitCode !== 0) onStatus(`editor exited with code ${exitCode}`, "warn");
+    await refreshAfterExternalEdit(target);
+  }
+
+  /**
+   * React to whatever the external editor did. A resident buffer is reconciled
+   * by the buffer port (unchanged / modified / removed / unreadable, with
+   * status + revalidation inside the buffer owner); a non-resident file just
+   * has its tree cache + index invalidated and the viewer re-read when it was
+   * showing the file.
+   */
+  async function refreshAfterExternalEdit(relPath: string): Promise<void> {
+    const outcome = await options.buffer.reconcile(relPath);
+    if (outcome === "not-resident") {
+      options.tree.invalidateCache(relPath);
+      await options.tree.refreshRowsAndIndex();
+      await options.viewer.reloadIfShowing(relPath);
+      return;
+    }
+    if (outcome === "removed") {
+      options.viewer.closeIfShowing(relPath);
+    }
+  }
+
+  return {
+    registerExternalEditor,
+    handoffToExternal,
+    refreshAfterExternalEdit,
+  };
+}
+
+export type ExternalEditorOwner = ReturnType<typeof createExternalEditorOwner>;

--- a/src/tui/workspace/external-editor-runtime.ts
+++ b/src/tui/workspace/external-editor-runtime.ts
@@ -1,4 +1,4 @@
-import type { Settings } from "../config/settings";
+import type { Settings } from "../../config/settings";
 
 /**
  * External-editor handoff for the Workspace page (Scope B / #62, milestone

--- a/src/tui/workspace/input-router.ts
+++ b/src/tui/workspace/input-router.ts
@@ -1,0 +1,54 @@
+import type { TuiKeyEvent } from "../decision-interaction";
+
+/**
+ * Workspace keyboard routing (Scope B / #62). Owns ONLY the input priority:
+ * quick-open → findings → dialog → ops bar → find → goto → save-as → global
+ * Workspace keys → focused region. Each step delegates to a surface handler
+ * wired by the facade; no file I/O, mutation, validation, or external-process
+ * algorithm lives here.
+ *
+ * The global paste rule stays outside this router: it lives in the host
+ * `input-routing.ts`, which consults the workspace controller's
+ * `editableSourcePasteActive()` predicate so an unobscured editable textarea
+ * receives bracketed paste directly.
+ */
+
+export type InputSurface = {
+  /** Whether the surface currently owns keyboard input. */
+  active: () => boolean;
+  /** Route the key to the surface; true when consumed. */
+  handle: (key: TuiKeyEvent) => boolean;
+};
+
+export type WorkspaceRouterPorts = {
+  /** Keys only reach the router while the Workspace page is active. */
+  pageIsWorkspace: () => boolean;
+  /** Dialog actions awaiting filesystem I/O own all input. */
+  dialogActionPending: () => boolean;
+  quickOpen: InputSurface;
+  findings: InputSurface;
+  dialog: InputSurface;
+  opsBar: InputSurface;
+  find: InputSurface;
+  goto: InputSurface;
+  saveAs: InputSurface;
+  /** Global Workspace keys (Ctrl+P / Ctrl+X / F6); true when consumed. */
+  globalKeys: (key: TuiKeyEvent) => boolean;
+  /** Focus-region dispatch (tree / viewer / editable / composer); true when consumed. */
+  regionKeys: (key: TuiKeyEvent) => boolean;
+};
+
+/** Returns true when the key was consumed by the Workspace page. */
+export function routeWorkspaceKey(key: TuiKeyEvent, ports: WorkspaceRouterPorts): boolean {
+  if (!ports.pageIsWorkspace()) return false;
+  if (ports.dialogActionPending()) return true;
+  if (ports.quickOpen.active()) return ports.quickOpen.handle(key);
+  if (ports.findings.active()) return ports.findings.handle(key);
+  if (ports.dialog.active()) return ports.dialog.handle(key);
+  if (ports.opsBar.active()) return ports.opsBar.handle(key);
+  if (ports.find.active()) return ports.find.handle(key);
+  if (ports.goto.active()) return ports.goto.handle(key);
+  if (ports.saveAs.active()) return ports.saveAs.handle(key);
+  if (ports.globalKeys(key)) return true;
+  return ports.regionKeys(key);
+}

--- a/tests/unit/tui/workspace-external-editor-owner.test.ts
+++ b/tests/unit/tui/workspace-external-editor-owner.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { ExternalEditOutcome } from "../../../src/tui/workspace/buffer-owner";
+import { createExternalEditorOwner } from "../../../src/tui/workspace/external-editor-owner";
+import type { EditorRuntime } from "../../../src/tui/workspace/external-editor-runtime";
+
+let root: string;
+let savedEnv: NodeJS.ProcessEnv;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "vesicle-ws-ext-owner-"));
+  await mkdir(join(root, "sub"), { recursive: true });
+  await writeFile(join(root, "notes.txt"), "line one\nline two\n");
+  // Pin env so editor resolution + settings.yaml are deterministic and don't
+  // touch the real user config.
+  savedEnv = { ...process.env };
+  process.env.VESICLE_EDITOR = "mockedit";
+  process.env.VESICLE_CONFIG_DIR = root;
+});
+
+afterEach(async () => {
+  process.env = savedEnv;
+  await rm(root, { recursive: true, force: true });
+});
+
+function mockRuntime() {
+  const calls = { suspend: 0, resume: 0, spawn: [] as string[], exitCode: 0, spawnError: false };
+  const runtime = {
+    suspend: () => { calls.suspend += 1; },
+    resume: () => { calls.resume += 1; },
+    spawn: async (command: string, args: string[]) => {
+      if (calls.spawnError) throw new Error("ENOENT");
+      calls.spawn.push([command, ...args].join(" "));
+      return calls.exitCode;
+    },
+    calls,
+  };
+  return runtime as typeof runtime & EditorRuntime;
+}
+
+function makeOwner(overrides: {
+  target?: string | null;
+  dirty?: boolean;
+  reconcileOutcome?: ExternalEditOutcome;
+} = {}) {
+  const calls = {
+    status: [] as Array<[string, string | undefined]>,
+    reconciles: [] as string[],
+    invalidated: [] as string[],
+    refreshes: 0,
+    viewerReloads: [] as string[],
+    viewerCloses: [] as string[],
+  };
+  const runtime = mockRuntime();
+  const owner = createExternalEditorOwner({
+    rootDir: root,
+    onStatus: (text, tone) => { calls.status.push([text, tone]); },
+    resolveHandoffTarget: () => ("target" in overrides ? overrides.target : "notes.txt") ?? null,
+    buffer: {
+      isDirty: () => overrides.dirty === true,
+      reconcile: async (path) => {
+        calls.reconciles.push(path);
+        return overrides.reconcileOutcome ?? "unchanged";
+      },
+    },
+    tree: {
+      invalidateCache: (path) => { calls.invalidated.push(path); },
+      refreshRowsAndIndex: async () => { calls.refreshes += 1; },
+    },
+    viewer: {
+      reloadIfShowing: async (path) => { calls.viewerReloads.push(path); },
+      closeIfShowing: (path) => { calls.viewerCloses.push(path); },
+    },
+  });
+  const unregister = owner.registerExternalEditor(runtime);
+  return { owner, calls, unregister, runtime };
+}
+
+describe("workspace external-editor owner: handoff", () => {
+  test("handoff spawns the resolved editor over the abs path and reconciles", async () => {
+    const { owner, calls, runtime } = makeOwner();
+    await owner.handoffToExternal();
+    expect(runtime.calls.suspend).toBe(1);
+    expect(runtime.calls.resume).toBe(1);
+    expect(runtime.calls.spawn).toEqual([`mockedit ${join(root, "notes.txt")}`]);
+    expect(calls.status.some(([t]) => t.startsWith("opening notes.txt in mockedit"))).toBe(true);
+    expect(calls.reconciles).toEqual(["notes.txt"]);
+  });
+
+  test("a null handoff target aborts before any spawn", async () => {
+    const { owner, calls, runtime } = makeOwner({ target: null });
+    await owner.handoffToExternal();
+    expect(runtime.calls.spawn.length).toBe(0);
+    expect(calls.invalidated.length).toBe(0);
+  });
+
+  test("a directory target is refused", async () => {
+    const { owner, calls, runtime } = makeOwner({ target: "sub" });
+    await owner.handoffToExternal();
+    expect(runtime.calls.spawn.length).toBe(0);
+    expect(calls.status.some(([t]) => t.includes("is a directory"))).toBe(true);
+  });
+
+  test("the dirty gate refuses an unsaved buffer", async () => {
+    const { owner, calls, runtime } = makeOwner({ dirty: true });
+    await owner.handoffToExternal();
+    expect(runtime.calls.spawn.length).toBe(0);
+    expect(calls.status.some(([t]) => t.includes("has unsaved edits"))).toBe(true);
+  });
+
+  test("malformed settings.yaml refuses the handoff", async () => {
+    await writeFile(join(root, "settings.yaml"), "malformed line without colon\n");
+    const { owner, calls, runtime } = makeOwner();
+    await owner.handoffToExternal();
+    expect(runtime.calls.spawn.length).toBe(0);
+    expect(calls.status.some(([t]) => t.includes("settings.yaml is malformed"))).toBe(true);
+  });
+
+  test("a non-zero exit code warns but still reconciles", async () => {
+    const { owner, calls, runtime } = makeOwner();
+    runtime.calls.exitCode = 7;
+    await owner.handoffToExternal();
+    expect(runtime.calls.spawn.length).toBe(1);
+    expect(calls.status.some(([t]) => t.includes("editor exited with code 7"))).toBe(true);
+    expect(calls.reconciles).toEqual(["notes.txt"]);
+  });
+
+  test("a spawn failure reports it and skips reconciliation", async () => {
+    const { owner, calls, runtime } = makeOwner();
+    runtime.calls.spawnError = true;
+    await owner.handoffToExternal();
+    expect(calls.status.some(([t]) => t.includes("failed to start"))).toBe(true);
+    expect(calls.invalidated.length).toBe(0);
+  });
+});
+
+describe("workspace external-editor owner: return reconciliation", () => {
+  test("not-resident refreshes the tree and the viewer", async () => {
+    const { owner, calls } = makeOwner({ reconcileOutcome: "not-resident" });
+    await owner.refreshAfterExternalEdit("notes.txt");
+    expect(calls.invalidated).toEqual(["notes.txt"]);
+    expect(calls.refreshes).toBe(1);
+    expect(calls.viewerReloads).toEqual(["notes.txt"]);
+    expect(calls.viewerCloses.length).toBe(0);
+  });
+
+  test("removed closes the viewer; modified/unchanged touch neither", async () => {
+    const { owner, calls } = makeOwner({ reconcileOutcome: "removed" });
+    await owner.refreshAfterExternalEdit("notes.txt");
+    expect(calls.viewerCloses).toEqual(["notes.txt"]);
+    expect(calls.viewerReloads.length).toBe(0);
+
+    const modified = makeOwner({ reconcileOutcome: "modified" });
+    await modified.owner.refreshAfterExternalEdit("notes.txt");
+    expect(modified.calls.viewerReloads.length).toBe(0);
+    expect(modified.calls.viewerCloses.length).toBe(0);
+    expect(modified.calls.refreshes).toBe(0);
+  });
+
+  test("unregister clears the injected runtime so handoff reports unavailable", async () => {
+    const { owner, calls, runtime, unregister } = makeOwner();
+    unregister();
+    await owner.handoffToExternal();
+    expect(runtime.calls.spawn.length).toBe(0);
+    expect(calls.status.some(([t]) => t.includes("unavailable in this build"))).toBe(true);
+  });
+});

--- a/tests/unit/tui/workspace-external-editor.test.ts
+++ b/tests/unit/tui/workspace-external-editor.test.ts
@@ -7,7 +7,7 @@ import {
   runExternalEditor,
   splitCommandLine,
   type EditorRuntime,
-} from "../../../src/tui/workspace-external-editor";
+} from "../../../src/tui/workspace/external-editor-runtime";
 import { loadSettings, settingsPath } from "../../../src/config/settings";
 
 describe("splitCommandLine", () => {

--- a/tests/unit/tui/workspace-input-router.test.ts
+++ b/tests/unit/tui/workspace-input-router.test.ts
@@ -71,6 +71,32 @@ describe("workspace input router: fixed priority order", () => {
     expect(ports.calls.global ?? 0).toBe(0);
   });
 
+  test("with two surfaces active the earlier priority wins and the later is never called", () => {
+    // This pins the ORDER itself: a permuted if-chain would pass the
+    // single-surface tests but fails here (the plan's stop condition forbids
+    // relaxing the priority).
+    const quickFind = makePorts();
+    quickFind.surfaces.quickOpen = true;
+    quickFind.surfaces.findings = true;
+    expect(routeWorkspaceKey(key("x"), quickFind)).toBe(true);
+    expect(quickFind.calls.quickOpen).toBe(1);
+    expect(quickFind.calls.findings ?? 0).toBe(0);
+
+    const dialogFind = makePorts();
+    dialogFind.surfaces.dialog = true;
+    dialogFind.surfaces.find = true;
+    expect(routeWorkspaceKey(key("x"), dialogFind)).toBe(true);
+    expect(dialogFind.calls.dialog).toBe(1);
+    expect(dialogFind.calls.find ?? 0).toBe(0);
+
+    const findSave = makePorts();
+    findSave.surfaces.find = true;
+    findSave.surfaces.saveAs = true;
+    expect(routeWorkspaceKey(key("x"), findSave)).toBe(true);
+    expect(findSave.calls.find).toBe(1);
+    expect(findSave.calls.saveAs ?? 0).toBe(0);
+  });
+
   test("global keys run before the region dispatch", () => {
     const ports = makePorts();
     ports.globalKeys = () => { ports.calls.global = 1; return true; };

--- a/tests/unit/tui/workspace-input-router.test.ts
+++ b/tests/unit/tui/workspace-input-router.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { routeWorkspaceKey, type WorkspaceRouterPorts } from "../../../src/tui/workspace/input-router";
+import type { TuiKeyEvent } from "../../../src/tui/decision-interaction";
+
+function key(name: string, mods: Partial<TuiKeyEvent> = {}): TuiKeyEvent {
+  return { name, ...mods } as TuiKeyEvent;
+}
+
+function makePorts(overrides: Partial<WorkspaceRouterPorts> = {}): WorkspaceRouterPorts & {
+  calls: Record<string, number>;
+  surfaces: Record<string, boolean>;
+} {
+  const calls: Record<string, number> = {};
+  const surfaces: Record<string, boolean> = {
+    quickOpen: false, findings: false, dialog: false, opsBar: false,
+    find: false, goto: false, saveAs: false,
+  };
+  const surface = (name: string) => ({
+    active: () => surfaces[name]!,
+    handle: () => { calls[name] = (calls[name] ?? 0) + 1; return true; },
+  });
+  return {
+    pageIsWorkspace: () => true,
+    dialogActionPending: () => false,
+    quickOpen: surface("quickOpen"),
+    findings: surface("findings"),
+    dialog: surface("dialog"),
+    opsBar: surface("opsBar"),
+    find: surface("find"),
+    goto: surface("goto"),
+    saveAs: surface("saveAs"),
+    globalKeys: () => { calls.global = (calls.global ?? 0) + 1; return false; },
+    regionKeys: () => { calls.region = (calls.region ?? 0) + 1; return true; },
+    ...overrides,
+    calls,
+    surfaces,
+  };
+}
+
+describe("workspace input router: fixed priority order", () => {
+  test("quick-open outranks every later surface and the regions", () => {
+    const ports = makePorts();
+    ports.surfaces.quickOpen = true;
+    expect(routeWorkspaceKey(key("x"), ports)).toBe(true);
+    expect(ports.calls.quickOpen).toBe(1);
+    expect(ports.calls.findings ?? 0).toBe(0);
+    expect(ports.calls.dialog ?? 0).toBe(0);
+    expect(ports.calls.region ?? 0).toBe(0);
+  });
+
+  test("priority is quick-open → findings → dialog → ops → find → goto → save-as", () => {
+    const order = ["quickOpen", "findings", "dialog", "opsBar", "find", "goto", "saveAs"] as const;
+    for (const [i, surface] of order.entries()) {
+      const ports = makePorts();
+      ports.surfaces[surface] = true;
+      // Every earlier surface is inactive; only `surface` may consume.
+      routeWorkspaceKey(key("x"), ports);
+      for (const [j, other] of order.entries()) {
+        if (j < i) expect(ports.calls[other] ?? 0).toBe(0);
+      }
+      expect(ports.calls[surface]).toBe(1);
+      expect(ports.calls.region ?? 0).toBe(0);
+    }
+  });
+
+  test("a consuming surface short-circuits the regions", () => {
+    const ports = makePorts();
+    ports.surfaces.findings = true;
+    expect(routeWorkspaceKey(key("x"), ports)).toBe(true);
+    expect(ports.calls.region ?? 0).toBe(0);
+    expect(ports.calls.global ?? 0).toBe(0);
+  });
+
+  test("global keys run before the region dispatch", () => {
+    const ports = makePorts();
+    ports.globalKeys = () => { ports.calls.global = 1; return true; };
+    expect(routeWorkspaceKey(key("f6"), ports)).toBe(true);
+    expect(ports.calls.region ?? 0).toBe(0);
+  });
+
+  test("region dispatch consumes the key when its handler returns true", () => {
+    const ports = makePorts();
+    expect(routeWorkspaceKey(key("x"), ports)).toBe(true);
+    expect(ports.calls.region).toBe(1);
+  });
+
+  test("non-workspace pages fall through before any surface check", () => {
+    const ports = makePorts({ pageIsWorkspace: () => false });
+    ports.surfaces.quickOpen = true;
+    expect(routeWorkspaceKey(key("x"), ports)).toBe(false);
+    expect(ports.calls.quickOpen ?? 0).toBe(0);
+    expect(ports.calls.region ?? 0).toBe(0);
+  });
+
+  test("pending dialog actions swallow all input before surfaces", () => {
+    const ports = makePorts({ dialogActionPending: () => true });
+    ports.surfaces.quickOpen = true;
+    expect(routeWorkspaceKey(key("x"), ports)).toBe(true);
+    expect(ports.calls.quickOpen ?? 0).toBe(0);
+    expect(ports.calls.region ?? 0).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Code Smell Round 3, Wave W4 (External-editor owner + input router), per `dev/docs/working/CODE_SMELL_REMEDIATION_IMPLEMENTATION_PLAN.md` §6.

- `workspace-external-editor.ts` → `workspace/external-editor-runtime.ts` (equivalent move, byte-identical except imports; old file removed, no pass-through).
- New `external-editor-owner.ts` uniquely owns the Ctrl+X handoff use case (target resolution port, path guard, dirty gate, settings resolution, renderer suspend/spawn/resume, return reconciliation across unchanged/modified/removed/unreadable/not-resident) consuming only narrow BufferPort/TreePort/ViewerPort objects + the injected renderer runtime.
- New `input-router.ts` owns only the fixed input priority (quick-open → findings → dialog → ops → find → goto → save-as → global keys → region); `handleKey` is now router wiring. Zero I/O, zero state.
- The global paste exception (`editableSourcePasteActive`) and host `input-routing.ts` are untouched.
- New suites: workspace-input-router (10 tests, including dual-surface priority pins that fail on a permuted if-chain) and workspace-external-editor-owner (10 tests, recording ports covering spawn/exit-code/spawn-failure/dirty/directory/malformed-settings/five outcome classes/unregister).

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` (1868 pass, 6 skip, 0 fail)
- [x] `bun run doctor` (Missing: none)
- [x] `git diff --check`
- [x] PTY smokes at 80×24: `smoke-workspace-paste-pty.ts` + `smoke-workspace-status-pty.ts` (both passed)
- Focused: external-editor + owner suites (39 pass), input-routing + controller + workspace-page component + tui-reactivity contract (84 pass)

## Notes / Follow-ups

- Independent CR (subagent, exact HEAD): Blocking none; 3 Should-fix resolved (priority-pinning tests, direct owner suite, execution record). Plan deviation recorded: ValidationPort would be dead wiring in the return path (revalidation flows through the buffer port's onReloaded), so ViewerPort replaces it — the viewer has no dedicated owner until W5.
- W5 (thin facade + workspace directory completion) next, same plan section.