### PR TITLE
refactor(tui): extract skill session-activation owner (T1)

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -72,7 +72,7 @@ import { createStartupController } from "./startup-controller";
 
 import { initializeSessionIdentity, type SessionIdentity } from "../core/agent-loop/session-init";
 import { createSessionIdentityCoordinator } from "./session-identity-coordinator";
-import { createSkillActivationOwner } from "./skills/session-activation";
+import { createSkillActivationOwner, type SkillActivationOptions } from "./skills/session-activation";
 import { SideQuestionOverlay } from "./views/SideQuestionOverlay";
 import { WorkspacePage } from "./workspace/view";
 import { copyTextToClipboard } from "./clipboard";
@@ -1001,8 +1001,12 @@ export function App(props: AppProps = {}) {
     onNotice: (card) => setMessages((prev) => [...prev, { role: "system", content: card }]),
     submitTurn: (prompt) => turnController.submitPrompt(prompt),
   });
-  const activateSkill = (name: string, options: { mode: "invoke" | "context-only"; taskText?: string }): Promise<void> =>
-    skillActivation.activate(name, options);
+  // Function declaration (hoisted like the pre-T1 use case) so the picker's
+  // onActivate closure cannot trip a TDZ regardless of construction order;
+  // it only runs post-render, when skillActivation is initialized.
+  async function activateSkill(name: string, options: SkillActivationOptions): Promise<void> {
+    return skillActivation.activate(name, options);
+  }
 
   // Command execution context: the surface slash-command handlers reach
   // through. Built once from component signals/helpers; submitPrompt passes it

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -69,9 +69,10 @@ import { createWorkspaceController } from "./workspace";
 import { createQueuedWorkController } from "./queued-work-controller";
 import { createStageSessionController } from "./stage-session-controller";
 import { createStartupController } from "./startup-controller";
-import { activateSkillForSession } from "../core/skills";
+
 import { initializeSessionIdentity, type SessionIdentity } from "../core/agent-loop/session-init";
 import { createSessionIdentityCoordinator } from "./session-identity-coordinator";
+import { createSkillActivationOwner } from "./skills/session-activation";
 import { SideQuestionOverlay } from "./views/SideQuestionOverlay";
 import { WorkspacePage } from "./workspace/view";
 import { copyTextToClipboard } from "./clipboard";
@@ -504,7 +505,7 @@ export function App(props: AppProps = {}) {
     setStatus,
     setMessages,
     reportError: (error) => turnController.reportError(error),
-    onActivate: (name) => activateSkillCommand(name, { mode: "context-only" }),
+    onActivate: (name) => activateSkill(name, { mode: "context-only" }),
   });
   const {
     skillPicker,
@@ -990,32 +991,18 @@ export function App(props: AppProps = {}) {
       setSessionPath(identity.sessionPath);
     },
   });
-  async function activateSkillCommand(
-    name: string,
-    options: { mode: "invoke" | "context-only"; taskText?: string },
-  ): Promise<void> {
-    const rootDir = process.cwd();
-    const sid = await sessionIdentityCoordinator.ensure();
-    const branchParent = nextSessionParent();
-    const activation = await activateSkillForSession(rootDir, process.env, sid, name, {
-      profile: { id: activeEngine() },
-      mode: options.mode,
-      ...(branchParent ? { parentUuid: branchParent.uuid } : {}),
-      contextWindow: activeModelLimits()?.contextWindow,
-    });
-    if (branchParent && activation.recordUuid) setNextSessionParent({ uuid: activation.recordUuid });
-    const scriptInfo = activation.scripts.length > 0
-      ? ` · ${activation.scripts.length} script${activation.scripts.length > 1 ? "s" : ""}`
-      : "";
-    const card = activation.alreadyActive
-      ? `Skill "${activation.name}" already active [${activation.scope}].`
-      : `Skill "${activation.name}" activated [${activation.scope}] · ${activation.resources.length} resource${activation.resources.length === 1 ? "" : "s"}${scriptInfo}.`;
-    setMessages((prev) => [...prev, { role: "system", content: card }]);
-    if (options.mode === "invoke") {
-      const prompt = options.taskText ?? `Apply the ${activation.name} skill to the current context.`;
-      await turnController.submitPrompt(prompt);
-    }
-  }
+  const skillActivation = createSkillActivationOwner({
+    rootDir: process.cwd(),
+    sessionIdentity: { ensure: () => sessionIdentityCoordinator.ensure() },
+    activeEngine,
+    activeModelLimits,
+    branchParent: nextSessionParent,
+    setBranchParent: setNextSessionParent,
+    onNotice: (card) => setMessages((prev) => [...prev, { role: "system", content: card }]),
+    submitTurn: (prompt) => turnController.submitPrompt(prompt),
+  });
+  const activateSkill = (name: string, options: { mode: "invoke" | "context-only"; taskText?: string }): Promise<void> =>
+    skillActivation.activate(name, options);
 
   // Command execution context: the surface slash-command handlers reach
   // through. Built once from component signals/helpers; submitPrompt passes it
@@ -1081,7 +1068,7 @@ export function App(props: AppProps = {}) {
     openQualityRewriteConfirm: openRewriteConfirm,
     openSideQuestion: (args) => sideQuestionController.openSideQuestion(args),
     openSkillPicker,
-    activateSkill: (name, options) => activateSkillCommand(name, options),
+    activateSkill: (name, options) => activateSkill(name, options),
     openWorkspaceTarget: async (relPath?: string) => {
       setFocusedArtifactPath(null);
       return workspaceController.openWorkspaceTarget(relPath);

--- a/src/tui/skills/session-activation.ts
+++ b/src/tui/skills/session-activation.ts
@@ -1,0 +1,65 @@
+import { activateSkillForSession } from "../../core/skills";
+import type { EngineId } from "../../core/engine/profile";
+
+/**
+ * Skill command / session-activation owner (Phase 2 / `/skill`). Owns the
+ * complete host use case behind `/skill <name> [task]` and the picker: session
+ * identity, branch-parent chaining, catalog activation, system-card
+ * projection, and turn submission.
+ *
+ * Boundary: the owner receives only narrow ports — the session-identity
+ * coordinator's `ensure`, the active Engine / model-limits accessors, the
+ * branch-parent get/set, a system-notice sink, and turn submission. It never
+ * receives the App, CommandContext, TurnControllerOptions, or a signal bundle.
+ */
+
+export type SkillActivationOptions = {
+  mode: "invoke" | "context-only";
+  taskText?: string;
+};
+
+export type SkillActivationOwnerPorts = {
+  rootDir: string;
+  /** Lazy session-identity resolution (serialized by the host coordinator). */
+  sessionIdentity: { ensure: () => Promise<string> };
+  activeEngine: () => EngineId;
+  activeModelLimits: () => { contextWindow?: number } | undefined;
+  /** The current branch head (chain point for the activation record). */
+  branchParent: () => { uuid: string | null } | null;
+  /** Advance the branch head after a branched activation. */
+  setBranchParent: (parent: { uuid: string } | null) => void;
+  /** Append a host system notice to the transcript. */
+  onNotice: (card: string) => void;
+  /** Submit a follow-up turn (invoke mode). */
+  submitTurn: (prompt: string) => Promise<void>;
+};
+
+export function createSkillActivationOwner(options: SkillActivationOwnerPorts) {
+  async function activate(name: string, opts: SkillActivationOptions): Promise<void> {
+    const rootDir = options.rootDir;
+    const sid = await options.sessionIdentity.ensure();
+    const branchParent = options.branchParent();
+    const activation = await activateSkillForSession(rootDir, process.env, sid, name, {
+      profile: { id: options.activeEngine() },
+      mode: opts.mode,
+      ...(branchParent ? { parentUuid: branchParent.uuid } : {}),
+      contextWindow: options.activeModelLimits()?.contextWindow,
+    });
+    if (branchParent && activation.recordUuid) options.setBranchParent({ uuid: activation.recordUuid });
+    const scriptInfo = activation.scripts.length > 0
+      ? ` · ${activation.scripts.length} script${activation.scripts.length > 1 ? "s" : ""}`
+      : "";
+    const card = activation.alreadyActive
+      ? `Skill "${activation.name}" already active [${activation.scope}].`
+      : `Skill "${activation.name}" activated [${activation.scope}] · ${activation.resources.length} resource${activation.resources.length === 1 ? "" : "s"}${scriptInfo}.`;
+    options.onNotice(card);
+    if (opts.mode === "invoke") {
+      const prompt = opts.taskText ?? `Apply the ${activation.name} skill to the current context.`;
+      await options.submitTurn(prompt);
+    }
+  }
+
+  return { activate };
+}
+
+export type SkillActivationOwner = ReturnType<typeof createSkillActivationOwner>;


### PR DESCRIPTION
## Summary

Code Smell Round 3, Wave T1 (Skill command/session activation owner), per `dev/docs/working/CODE_SMELL_REMEDIATION_IMPLEMENTATION_PLAN.md` §7.

- `activateSkillCommand()` moves wholesale out of `App()` into `src/tui/skills/session-activation.ts`.
- The owner receives only an 8-field named port set: `rootDir`, `sessionIdentity.ensure`, `activeEngine`, `activeModelLimits` (narrowed to the consumed `contextWindow`), branch-parent get/set, a system-notice sink, and turn submit. No CommandContext, TurnControllerOptions, or signal bundle.
- App only constructs the owner and hands the `activate(name, options)` port to the `/skill` command and the picker; `session-identity-coordinator.ts` untouched (concurrent-shared pending, release, `/new` reset preserved).
- Moved body is byte-equivalent (independent CR normalized-diff verified); the wrapper is a hoisted function declaration to preserve pre-T1 hoisting and avoid a TDZ order dependency.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` (1868 pass, 6 skip, 0 fail — identical to W5 baseline)
- [x] `bun run doctor` (Missing: none)
- [x] `git diff --check`
- [x] PTY smoke: `smoke-skill-first-input-pty.ts` (identity-before-activation, mode accounting, durable record ordering)
- Focused: session-identity-coordinator + skill-picker (7 pass), session-init + skill-catalog integration (11 pass)

## Notes / Follow-ups

- Independent CR (subagent, exact HEAD): Blocking none; Should-fix (execution record) resolved; nits addressed (rootDir sampling documented, TDZ-order eliminated, options type shared). A direct recording-ports owner suite was judged unnecessary: the owner is stateless and byte-equivalent, and the risky invariants are covered at their owning layers.
- Next: T2 (Turn/Decision ports), plan §7.