### PR TITLE
refactor(agent-loop): extract mid-turn compaction owner (A1)

### DIFF
--- a/src/core/agent-loop/mid-turn-compaction.ts
+++ b/src/core/agent-loop/mid-turn-compaction.ts
@@ -1,0 +1,157 @@
+// Mid-turn automatic compaction owner: provider observation state, soft/hard
+// budget checks, compacted snapshot reload + message rebuild, and hard-failed
+// durable notice + AutoCompactBlockedError translation.
+//
+// This module receives narrow parameters — never the full RunLoopArgs. The
+// caller (turn-loop) owns the seven-step boundary order and decides when to
+// invoke the soft and hard checks.
+
+import type { AutoCompactLimits, GenerationDefaults, ModelLimits } from "../../config/env";
+import type { EngineId } from "../engine/profile";
+import { AutoCompactBlockedError, runAutomaticCompaction } from "../compact/auto-compact";
+import { estimateRequestTokens } from "../compact/context-budget";
+import { toVesicleMessage } from "../compact/summary-generator";
+import { loadSessionSnapshot } from "../session/store";
+import type { SessionStore } from "../session/store";
+import type { VesicleMessage, VesicleRequest } from "../../providers/shared/types";
+import type { ToolDefinition } from "../tools";
+import type { AgentLoopEvent } from "./types";
+
+// ---------------------------------------------------------------------------
+// Provider observation state
+// ---------------------------------------------------------------------------
+
+export type CompactionObservation = {
+  /** Most recent provider-observed context occupancy, for mid-turn budget checks. Cleared after a compact (stale). */
+  lastContextInputTokens: number | undefined;
+  lastRequestObservation: { contextInputTokens: number; estimatedRequestTokens: number } | undefined;
+};
+
+export function createCompactionObservation(): CompactionObservation {
+  return { lastContextInputTokens: undefined, lastRequestObservation: undefined };
+}
+
+/**
+ * Update the observation state from the most recent provider response. The host
+ * estimate paired with the provider observation lets the next projection add
+ * only growth that occurred after the observation.
+ */
+export function updateProviderObservation(
+  observation: CompactionObservation,
+  contextInputTokens: number | undefined,
+  estimatedRequestTokens: number | undefined,
+): void {
+  if (typeof contextInputTokens === "number" && contextInputTokens > 0) {
+    observation.lastContextInputTokens = contextInputTokens;
+    if (estimatedRequestTokens !== undefined) {
+      observation.lastRequestObservation = { contextInputTokens, estimatedRequestTokens };
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mid-turn compaction check
+// ---------------------------------------------------------------------------
+
+export type MidTurnCompactionParams = {
+  rootDir: string;
+  session: SessionStore;
+  engine: EngineId;
+  providerId: string;
+  model: string;
+  generation?: VesicleRequest["generation"];
+  signal?: AbortSignal;
+  onEvent?: (event: AgentLoopEvent) => void;
+  systemPrompt: string;
+  tools: ToolDefinition[];
+  messages: VesicleMessage[];
+  autoCompactConfig: AutoCompactLimits | undefined;
+  limits: ModelLimits | undefined;
+  configGeneration: GenerationDefaults | undefined;
+  turnMaxTokens: number | undefined;
+};
+
+export type MidTurnCompactionResult = {
+  compacted: boolean;
+  blocked: boolean;
+  error?: AutoCompactBlockedError;
+};
+
+/**
+ * One mid-turn automatic-compaction check. The soft check (onlyHardCeiling
+ * false) runs after a complete tool batch; the hard check (onlyHardCeiling true)
+ * runs after queued/background input has been drained, right before the next
+ * provider request. On a compact the active in-memory message array is rebound
+ * to the post-checkpoint history (replacement + retained frontier), and the
+ * stale provider occupancy is cleared so the next check re-estimates. On a
+ * hard-ceiling failure the loop is blocked: a system notice is appended and the
+ * caller breaks before the unsafe request. The compact provider call is a
+ * standalone request (never a bootstrap/loop turn) so it cannot re-enter this
+ * check; the outer loop signal cancels it.
+ */
+export async function runMidTurnCompaction(
+  params: MidTurnCompactionParams,
+  observation: CompactionObservation,
+  onlyHardCeiling: boolean,
+): Promise<MidTurnCompactionResult> {
+  const estimatedNextRequestTokens = estimateRequestTokens(params.messages, params.systemPrompt, params.tools);
+  const result = await runAutomaticCompaction({
+    rootDir: params.rootDir,
+    sessionId: params.session.sessionId,
+    engine: params.engine,
+    providerSelection: { provider: params.providerId, model: params.model },
+    generation: params.generation,
+    signal: params.signal,
+    onEvent: params.onEvent,
+    phase: "mid-turn",
+    onlyHardCeiling,
+    estimateReplacementTokens: (replacement) => estimateRequestTokens(
+      replacement.map(toVesicleMessage),
+      params.systemPrompt,
+      params.tools,
+    ),
+    budget: {
+      config: params.autoCompactConfig,
+      limits: params.limits,
+      generation: params.configGeneration,
+      turnMaxTokens: params.turnMaxTokens,
+      lastContextInputTokens: observation.lastContextInputTokens,
+      lastRequestObservation: observation.lastRequestObservation,
+      estimatedNextRequestTokens,
+    },
+  });
+  if (result.kind === "cancelled") throw result.error;
+  if (result.kind === "compacted") {
+    observation.lastContextInputTokens = undefined;
+    observation.lastRequestObservation = undefined;
+    const snapshot = await loadSessionSnapshot(params.rootDir, params.session.sessionId, { synthesizeDanglingToolResults: false });
+    const rebuilt = snapshot.messages.map(toVesicleMessage);
+    params.messages.length = 0;
+    params.messages.push(...rebuilt);
+    return { compacted: true, blocked: false };
+  }
+  if (result.kind === "hard-failed") {
+    await params.session.append({
+      role: "system",
+      content: `Context budget exceeded and automatic compaction failed: ${result.errorMessage} Run /compact manually or switch to a model with a larger context window.`,
+      metadata: { kind: "compact-blocked" },
+    });
+    return {
+      compacted: false,
+      blocked: true,
+      error: new AutoCompactBlockedError(
+        result.errorMessage,
+        result.check.kind === "hard-ceiling"
+          ? {
+            projectedTokens: result.check.projectedTokens,
+            hardInputCeilingTokens: result.check.hardInputCeilingTokens,
+            softTriggerTokens: result.check.softTriggerTokens,
+            usageSource: result.check.usageSource,
+          }
+          : undefined,
+        true,
+      ),
+    };
+  }
+  return { compacted: false, blocked: false };
+}

--- a/src/core/agent-loop/turn-loop.ts
+++ b/src/core/agent-loop/turn-loop.ts
@@ -9,10 +9,9 @@ import { defaultPermissionRuntime } from "../permissions";
 import type { PermissionRuntimeOptions, ToolPermissionBroker } from "../permissions";
 import { getProcessManager, type ProcessManager } from "../process/manager";
 import type { SessionStore } from "../session/store";
-import { bindExecutionRound, clearExecutionRound, loadSessionSnapshot, newProviderRoundId, withExecutionRound } from "../session/store";
-import { AutoCompactBlockedError, runAutomaticCompaction } from "../compact/auto-compact";
+import { bindExecutionRound, clearExecutionRound, newProviderRoundId, withExecutionRound } from "../session/store";
+import { AutoCompactBlockedError } from "../compact/auto-compact";
 import { estimateRequestTokens } from "../compact/context-budget";
-import { toVesicleMessage } from "../compact/summary-generator";
 import type { ToolDefinition } from "../tools";
 import { createTurnAgentManager } from "./agent-manager";
 import { recordAssistantToolCalls } from "./assistant-recorder";
@@ -22,6 +21,8 @@ import { executeToolRound } from "./tool-round-executor";
 import { planToolRound } from "./tool-round-planner";
 import { validateToolCallArguments } from "../tools/arguments";
 import { finalizeTurn } from "./turn-finalizer";
+import { createCompactionObservation, runMidTurnCompaction, updateProviderObservation } from "./mid-turn-compaction";
+import type { CompactionObservation, MidTurnCompactionParams } from "./mid-turn-compaction";
 import { clearFrozenInstructionBlocks, readFrozenInstructionBlocks } from "../instructions/instruction-context";
 import { composeSkillCatalogBlock, readFrozenSessionSkillCatalog, resolveEngineEligibleCatalog } from "../skills";
 import type { ResolvedSkillCatalog } from "../skills";
@@ -115,9 +116,7 @@ type LoopRuntime = {
   quality: QualityRoundState;
   logicalTurnId: string | undefined;
   providerRoundId: string | undefined;
-  /** Most recent provider-observed context occupancy, for mid-turn budget checks. Cleared after a compact (stale). */
-  lastContextInputTokens: number | undefined;
-  lastRequestObservation: { contextInputTokens: number; estimatedRequestTokens: number } | undefined;
+  compactionObservation: CompactionObservation;
   lastRequestEstimateTokens: number | undefined;
 };
 
@@ -190,21 +189,16 @@ async function runLoopInternal(args: RunLoopArgs): Promise<RunPromptResult> {
     if (!round.hadToolCalls) break;
     // The latest provider-observed context occupancy feeds the mid-turn budget
     // checks (the host estimate covers growth since this observation).
-    const observed = response.usage?.contextInputTokens;
-    if (typeof observed === "number" && observed > 0) {
-      runtime.lastContextInputTokens = observed;
-      if (runtime.lastRequestEstimateTokens !== undefined) {
-        runtime.lastRequestObservation = {
-          contextInputTokens: observed,
-          estimatedRequestTokens: runtime.lastRequestEstimateTokens,
-        };
-      }
-    }
+    updateProviderObservation(
+      runtime.compactionObservation,
+      response.usage?.contextInputTokens,
+      runtime.lastRequestEstimateTokens,
+    );
     // Mid-turn soft check: after a complete assistant/tool batch (any pause has
     // been resolved by advanceRound returning, not pausing), before queued
     // steering is drained for the next round. At most one compact per boundary.
     const soft = args.profile.id !== "stage" && args.config.limits?.autoCompact
-      ? await runMidTurnCompaction(args, runtime, false)
+      ? await runMidTurnCompaction(compactionParams(args), runtime.compactionObservation, false)
       : { compacted: false, blocked: false };
     if (soft.blocked) break;
     // A tool round may have refreshed the in-turn frozen instruction snapshot
@@ -465,8 +459,7 @@ function createLoopRuntime(args: RunLoopArgs): LoopRuntime {
     quality: createQualityRoundState(args.qualityState),
     logicalTurnId: args.logicalTurnId,
     providerRoundId: args.providerRoundId,
-    lastContextInputTokens: undefined,
-    lastRequestObservation: undefined,
+    compactionObservation: createCompactionObservation(),
     lastRequestEstimateTokens: undefined,
   };
 }
@@ -536,7 +529,7 @@ async function prepareExactProviderBoundary(
   if (args.profile.id === "stage" || !args.config.limits?.autoCompact) {
     return { compacted: false, blocked: false };
   }
-  return runMidTurnCompaction(args, runtime, true);
+  return runMidTurnCompaction(compactionParams(args), runtime.compactionObservation, true);
 }
 
 async function recordNoProgressBreak(session: SessionStore, consecutiveFailures: number): Promise<void> {
@@ -547,81 +540,22 @@ async function recordNoProgressBreak(session: SessionStore, consecutiveFailures:
   });
 }
 
-/**
- * One mid-turn automatic-compaction check. The soft check (onlyHardCeiling
- * false) runs after a complete tool batch; the hard check (onlyHardCeiling true)
- * runs after queued/background input has been drained, right before the next
- * provider request. On a compact the active in-memory message array is rebound
- * to the post-checkpoint history (replacement + retained frontier), and the
- * stale provider occupancy is cleared so the next check re-estimates. On a
- * hard-ceiling failure the loop is blocked: a system notice is appended and the
- * caller breaks before the unsafe request. The compact provider call is a
- * standalone request (never a bootstrap/loop turn) so it cannot re-enter this
- * check; the outer loop signal cancels it.
- */
-async function runMidTurnCompaction(
-  args: RunLoopArgs,
-  runtime: LoopRuntime,
-  onlyHardCeiling: boolean,
-): Promise<{ compacted: boolean; blocked: boolean; error?: AutoCompactBlockedError }> {
-  const estimatedNextRequestTokens = estimateRequestTokens(args.messages, args.systemPrompt, args.tools);
-  const result = await runAutomaticCompaction({
+function compactionParams(args: RunLoopArgs): MidTurnCompactionParams {
+  return {
     rootDir: args.rootDir,
-    sessionId: args.session.sessionId,
+    session: args.session,
     engine: args.profile.id,
-    providerSelection: { provider: args.config.providerId, model: args.config.model },
+    providerId: args.config.providerId,
+    model: args.config.model,
     generation: args.generation,
     signal: args.signal,
     onEvent: args.onEvent,
-    phase: "mid-turn",
-    onlyHardCeiling,
-    estimateReplacementTokens: (replacement) => estimateRequestTokens(
-      replacement.map(toVesicleMessage),
-      args.systemPrompt,
-      args.tools,
-    ),
-    budget: {
-      config: args.config.limits?.autoCompact,
-      limits: args.config.limits,
-      generation: args.config.generation,
-      turnMaxTokens: args.generation?.maxTokens,
-      lastContextInputTokens: runtime.lastContextInputTokens,
-      lastRequestObservation: runtime.lastRequestObservation,
-      estimatedNextRequestTokens,
-    },
-  });
-  if (result.kind === "cancelled") throw result.error;
-  if (result.kind === "compacted") {
-    runtime.lastContextInputTokens = undefined;
-    runtime.lastRequestObservation = undefined;
-    const snapshot = await loadSessionSnapshot(args.rootDir, args.session.sessionId, { synthesizeDanglingToolResults: false });
-    const rebuilt = snapshot.messages.map(toVesicleMessage);
-    args.messages.length = 0;
-    args.messages.push(...rebuilt);
-    return { compacted: true, blocked: false };
-  }
-  if (result.kind === "hard-failed") {
-    await args.session.append({
-      role: "system",
-      content: `Context budget exceeded and automatic compaction failed: ${result.errorMessage} Run /compact manually or switch to a model with a larger context window.`,
-      metadata: { kind: "compact-blocked" },
-    });
-    return {
-      compacted: false,
-      blocked: true,
-      error: new AutoCompactBlockedError(
-        result.errorMessage,
-        result.check.kind === "hard-ceiling"
-          ? {
-            projectedTokens: result.check.projectedTokens,
-            hardInputCeilingTokens: result.check.hardInputCeilingTokens,
-            softTriggerTokens: result.check.softTriggerTokens,
-            usageSource: result.check.usageSource,
-          }
-          : undefined,
-        true,
-      ),
-    };
-  }
-  return { compacted: false, blocked: false };
+    systemPrompt: args.systemPrompt,
+    tools: args.tools,
+    messages: args.messages,
+    autoCompactConfig: args.config.limits?.autoCompact,
+    limits: args.config.limits,
+    configGeneration: args.config.generation,
+    turnMaxTokens: args.generation?.maxTokens,
+  };
 }


### PR DESCRIPTION
## Summary

Wave A1 of the Code Smell Round 3 Remediation plan. Extracts the mid-turn compaction logic from `turn-loop.ts` into a new `mid-turn-compaction.ts` owner.

**New module `src/core/agent-loop/mid-turn-compaction.ts` (157 lines) owns:**
- `CompactionObservation` type + `createCompactionObservation()` factory
- `updateProviderObservation()` — provider observation state update (moved from inline loop code)
- `MidTurnCompactionParams` — narrow params type (never full RunLoopArgs)
- `runMidTurnCompaction(params, observation, onlyHardCeiling)` — budget check + result translation + snapshot rebuild + blocked outcome

**`turn-loop.ts` retains the seven-step boundary order:**
1. Materialize background process notifications (`prepareExactProviderBoundary`)
2. Exact provider boundary hard check (`runMidTurnCompaction(true)`)
3. Provider request (`completeProviderRound`)
4. Complete tool batch (`executeToolRound`)
5. Soft compact check (`runMidTurnCompaction(false)`)
6. Advance provider round id (`advanceProviderRound`)
7. Drain queued input (`processInputBoundary`)

## Verification

- **Focused**: pre-turn/mid-turn auto-compact + execution-identity/provider-session/tool-durability + compact/compact-checkpoint → 47 pass / 0 fail.
- **PTY**: `smoke-compact-pty.ts` pass (80×24).
- **Full baseline**: lint pass (667 files); typecheck pass; `bun test` 1868 pass / 6 skip / 0 fail; doctor pass.
- **Independent CR** (general subagent, exact HEAD `8b8ddd2` vs base `1e8b0b5`): Blocking none / Should-fix none / Nits none. Body equivalence verified line-by-line; seven-step boundary confirmed; no RunLoopArgs leak; no threshold/estimator/checkpoint/provider/session-schema changes.

## Plan deviation

none.