### PR TITLE
docs(workflow): add audit database drift response plan

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -57,7 +57,16 @@ jobs:
       - run: bun run lint
       - run: bun run typecheck
       - run: bun test
-      - run: bun audit
+      - id: audit
+        run: bun audit
+      - name: Audit failure guidance
+        if: failure() && steps.audit.outcome == 'failure'
+        run: |
+          MESSAGE="bun audit failed. If this run did not change bun.lock or package.json, this is likely audit database drift: a new advisory now flags the unchanged lockfile. Rerunning will not recover it. Follow docs/dev/AUDIT_DRIFT.md — fix forward in a dedicated chore(deps) PR."
+          echo "::error title=Audit database drift?::${MESSAGE}"
+          echo "### Audit database drift?" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "${MESSAGE}" >> "$GITHUB_STEP_SUMMARY"
       - run: bun run pack:check
       - run: bun run pack:smoke
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Audit failure guidance
         if: failure() && steps.audit.outcome == 'failure'
         run: |
-          MESSAGE="bun audit failed. If this run did not change bun.lock or package.json, this is likely audit database drift: a new advisory now flags the unchanged lockfile. Rerunning will not recover it. Follow docs/dev/AUDIT_DRIFT.md — fix forward in a dedicated chore(deps) PR."
-          echo "::error title=Audit database drift?::${MESSAGE}"
-          echo "### Audit database drift?" >> "$GITHUB_STEP_SUMMARY"
+          MESSAGE="bun audit failed. Follow docs/dev/AUDIT_DRIFT.md — if this run did not change bun.lock or package.json, rerunning will not recover it."
+          echo "::error title=bun audit failed::${MESSAGE}"
+          echo "### bun audit failed" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "${MESSAGE}" >> "$GITHUB_STEP_SUMMARY"
       - run: bun run pack:check

--- a/docs/dev/AUDIT_DRIFT.md
+++ b/docs/dev/AUDIT_DRIFT.md
@@ -34,7 +34,7 @@ Follow the PR #48 / #92 convention. The audit gate stays blocking; the response 
 2. Open a dedicated `chore(deps): patch <package> audit finding` PR. Never bundle the fix into a feature PR, and never widen an in-flight feature PR to absorb it.
 3. For a transitive finding, pin the patched release through `package.json` `overrides` and regenerate `bun.lock`. For a direct finding, bump the declared version normally.
 4. The commit message must name the GHSA/CVE id, the dependency chain, the reachability/real-risk assessment, and the verification list (see PR #92 for the shape).
-5. Verify: `bun audit` green, plus `bun run lint`, `bun run typecheck`, `bun test`, `bun run doctor`, and `bun run pack:check`. An exact override bump adds no tests, per the test value discipline in `AGENTS.md`.
+5. Verify: `bun audit` green, plus `bun run lint`, `bun run typecheck`, `bun test`, `bun run doctor`, `bun run pack:check`, and `bun run pack:smoke` (which includes the consumer `npm audit` gate). An exact override bump adds no tests, per the test value discipline in `AGENTS.md`.
 6. Land the patch PR on `develop` first; in-flight PRs rebase or re-run afterwards. One drift fix unblocks the whole pipeline.
 
 ## Exceptional Waiver Path

--- a/docs/dev/AUDIT_DRIFT.md
+++ b/docs/dev/AUDIT_DRIFT.md
@@ -1,0 +1,56 @@
+# Audit Database Drift
+
+Dependency audit gates compare the local lockfile against a live vulnerability database that only grows. A newly published advisory can therefore turn CI red on a commit that changed nothing — the same lockfile was green the day before. This document is the standing response plan for that situation, codified from the convention established by PR #48 and PR #92 (`chore(deps): patch brace-expansion audit finding`).
+
+## Gates Covered
+
+Three audit gates can go red from drift:
+
+| Gate | Location | Scope |
+|------|----------|-------|
+| `bun audit` | `.github/workflows/release-build.yml` (`checks` job, shared by PR/develop CI and the release pipeline) | Full dependency tree of the checkout |
+| Consumer `npm audit --omit=dev --audit-level=low` | `scripts/smoke-npm-package.ts` (`bun run pack:smoke`) | Production dependencies as installed by an npm consumer |
+| Manual release verification | [`WORKFLOW.md`](./WORKFLOW.md) verification table | `bun audit` before a release tag |
+
+The vulnerability database is monotonic: advisories are added, essentially never removed. Rerunning a failed job (`gh run rerun`) cannot recover a drift red — the same database answer comes back. The retry rules in [`WORKFLOW.md`](./WORKFLOW.md) do not apply to audit failures.
+
+## Recognizing Drift
+
+An audit red is **drift** when all of these hold:
+
+- the failing run's diff does not touch `bun.lock` or `package.json`;
+- the same commit (or the same lockfile) previously passed the same gate;
+- the named advisory (GHSA/CVE) was published after the lockfile was last written.
+
+An audit red on a PR that **does** change dependencies is not drift — it is the PR author's responsibility and is handled inside that PR, not through this plan.
+
+When the `bun audit` step fails in the shared CI workflow, a follow-up step annotates the run and the step summary with a pointer to this document. Treat that annotation as a prompt to run the recognition check above, not as proof of drift.
+
+## Standard Response: Fix Forward
+
+Follow the PR #48 / #92 convention. The audit gate stays blocking; the response is a fast, dedicated repair.
+
+1. Triage the advisory: severity, whether the package is a direct or transitive dependency, the dependency chain that pulls it in, and whether Vesicle actually executes the affected code (shipped production dependency vs. build-only or dev-only chain). Record a real-risk assessment from this triage.
+2. Open a dedicated `chore(deps): patch <package> audit finding` PR. Never bundle the fix into a feature PR, and never widen an in-flight feature PR to absorb it.
+3. For a transitive finding, pin the patched release through `package.json` `overrides` and regenerate `bun.lock`. For a direct finding, bump the declared version normally.
+4. The commit message must name the GHSA/CVE id, the dependency chain, the reachability/real-risk assessment, and the verification list (see PR #92 for the shape).
+5. Verify: `bun audit` green, plus `bun run lint`, `bun run typecheck`, `bun test`, `bun run doctor`, and `bun run pack:check`. An exact override bump adds no tests, per the test value discipline in `AGENTS.md`.
+6. Land the patch PR on `develop` first; in-flight PRs rebase or re-run afterwards. One drift fix unblocks the whole pipeline.
+
+## Exceptional Waiver Path
+
+Use this only when no patched release exists, or the patched release is breaking and cannot be adopted quickly.
+
+1. Complete the triage above. A waiver for a reachable, high/critical, shipped production path is expected to be rare and short-lived.
+2. Add the finding to the `bun audit` invocation as `--ignore=<CVE>` (Bun ignores by CVE id; repeat the flag for multiple ids).
+3. Record the waiver in the commit message and in `CHANGELOG.md`: CVE id, justification from the triage, owner, and an explicit expiry/revisit date.
+4. Before the revisit date, re-triage: adopt a patch if one has appeared, renew with fresh justification, or drop the waiver. Expired waivers are never silently carried forward.
+5. The consumer `npm audit` gate has no ignore mechanism. Waiving a finding there requires changing `scripts/smoke-npm-package.ts` to parse `npm audit --json` and filter waived ids; that code change must be proposed and justified in the same PR as the waiver, and it stays limited to ids with a recorded, unexpired waiver.
+
+## Release Rule
+
+Do not create a release tag while any audit gate is red or any waiver is past its revisit date. This extends the release rules in [`WORKFLOW.md`](./WORKFLOW.md); a drift fix during release preparation follows the same dedicated-PR flow, then the release branch picks it up.
+
+## Considered Alternatives
+
+Two CI relaxations were considered and rejected for now: making the PR-CI audit advisory (`continue-on-error`), and gating the audit only on lockfile changes in the PR diff. Both trade a visible, blocking signal for silent accumulation of unpatched advisories, and the historical fix-forward turnaround has been fast enough that the blocking gate has not materially delayed unrelated work. Revisit this decision if drift frequency or fix latency grows.

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -24,6 +24,7 @@ Promotion flows in one direction. An internal conclusion becomes public only by 
 | [`STYLE.md`](./STYLE.md) | Source-code structure, maintainability, types, errors, naming, comments, and test design |
 | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | Ownership, dependency direction, cross-cutting boundaries, and domain-contract routing |
 | [`WORKFLOW.md`](./WORKFLOW.md) | Branching, verification, review, publication, and documentation workflow |
+| [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md) | Audit-database drift recognition, fix-forward SOP, waiver path, and release rule |
 | [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md) | User agency, disclosure, confirmation, and enforceable-boundary policy |
 
 ### Runtime and product contracts

--- a/docs/dev/WORKFLOW.md
+++ b/docs/dev/WORKFLOW.md
@@ -202,6 +202,7 @@ Repository rules and Environment protection are live GitHub state, not YAML. Aud
 ### Failure And Retry Rules
 
 - A failed PR CI run has no public side effects. Fix the release branch and let the updated PR commit run again.
+- An audit-gate failure on an unchanged lockfile is audit database drift and is not retry-recoverable: the vulnerability database only grows, so rerunning returns the same answer. CI annotates such failures with a pointer to [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md); follow its dedicated fix-forward PR flow instead of rerunning.
 - Do not create the release tag until PR CI and human acceptance are complete.
 - A pushed release tag is immutable publication intent. Do not delete or move it merely to retrigger CI.
 - If a transient failure happens after the tag push, use the CLI to find and rerun the existing workflow: `gh run list --workflow release.yml`, then `gh run rerun <run-id> --failed`. This exceptional recovery needs `gh` because Git cannot truthfully push the same immutable tag twice. The npm job skips an exact version that is already present, and the GitHub Release job updates the release for the same tag.

--- a/docs/dev/WORKFLOW.md
+++ b/docs/dev/WORKFLOW.md
@@ -202,7 +202,7 @@ Repository rules and Environment protection are live GitHub state, not YAML. Aud
 ### Failure And Retry Rules
 
 - A failed PR CI run has no public side effects. Fix the release branch and let the updated PR commit run again.
-- An audit-gate failure on an unchanged lockfile is audit database drift and is not retry-recoverable: the vulnerability database only grows, so rerunning returns the same answer. CI annotates such failures with a pointer to [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md); follow its dedicated fix-forward PR flow instead of rerunning.
+- An audit-gate failure on an unchanged lockfile is audit database drift and is not retry-recoverable. CI annotates such failures with a pointer to [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md); follow its dedicated fix-forward PR flow instead of rerunning.
 - Do not create the release tag until PR CI and human acceptance are complete.
 - A pushed release tag is immutable publication intent. Do not delete or move it merely to retrigger CI.
 - If a transient failure happens after the tag push, use the CLI to find and rerun the existing workflow: `gh run list --workflow release.yml`, then `gh run rerun <run-id> --failed`. This exceptional recovery needs `gh` because Git cannot truthfully push the same immutable tag twice. The npm job skips an exact version that is already present, and the GitHub Release job updates the release for the same tag.

--- a/host-assets/skills/vesicle-docs/references/dev-audit_drift.md
+++ b/host-assets/skills/vesicle-docs/references/dev-audit_drift.md
@@ -1,0 +1,58 @@
+<!-- Generated from docs/dev/AUDIT_DRIFT.md — do not edit. -->
+
+# Audit Database Drift
+
+Dependency audit gates compare the local lockfile against a live vulnerability database that only grows. A newly published advisory can therefore turn CI red on a commit that changed nothing — the same lockfile was green the day before. This document is the standing response plan for that situation, codified from the convention established by PR #48 and PR #92 (`chore(deps): patch brace-expansion audit finding`).
+
+## Gates Covered
+
+Three audit gates can go red from drift:
+
+| Gate | Location | Scope |
+|------|----------|-------|
+| `bun audit` | `.github/workflows/release-build.yml` (`checks` job, shared by PR/develop CI and the release pipeline) | Full dependency tree of the checkout |
+| Consumer `npm audit --omit=dev --audit-level=low` | `scripts/smoke-npm-package.ts` (`bun run pack:smoke`) | Production dependencies as installed by an npm consumer |
+| Manual release verification | [`WORKFLOW.md`](./WORKFLOW.md) verification table | `bun audit` before a release tag |
+
+The vulnerability database is monotonic: advisories are added, essentially never removed. Rerunning a failed job (`gh run rerun`) cannot recover a drift red — the same database answer comes back. The retry rules in [`WORKFLOW.md`](./WORKFLOW.md) do not apply to audit failures.
+
+## Recognizing Drift
+
+An audit red is **drift** when all of these hold:
+
+- the failing run's diff does not touch `bun.lock` or `package.json`;
+- the same commit (or the same lockfile) previously passed the same gate;
+- the named advisory (GHSA/CVE) was published after the lockfile was last written.
+
+An audit red on a PR that **does** change dependencies is not drift — it is the PR author's responsibility and is handled inside that PR, not through this plan.
+
+When the `bun audit` step fails in the shared CI workflow, a follow-up step annotates the run and the step summary with a pointer to this document. Treat that annotation as a prompt to run the recognition check above, not as proof of drift.
+
+## Standard Response: Fix Forward
+
+Follow the PR #48 / #92 convention. The audit gate stays blocking; the response is a fast, dedicated repair.
+
+1. Triage the advisory: severity, whether the package is a direct or transitive dependency, the dependency chain that pulls it in, and whether Vesicle actually executes the affected code (shipped production dependency vs. build-only or dev-only chain). Record a real-risk assessment from this triage.
+2. Open a dedicated `chore(deps): patch <package> audit finding` PR. Never bundle the fix into a feature PR, and never widen an in-flight feature PR to absorb it.
+3. For a transitive finding, pin the patched release through `package.json` `overrides` and regenerate `bun.lock`. For a direct finding, bump the declared version normally.
+4. The commit message must name the GHSA/CVE id, the dependency chain, the reachability/real-risk assessment, and the verification list (see PR #92 for the shape).
+5. Verify: `bun audit` green, plus `bun run lint`, `bun run typecheck`, `bun test`, `bun run doctor`, and `bun run pack:check`. An exact override bump adds no tests, per the test value discipline in `AGENTS.md`.
+6. Land the patch PR on `develop` first; in-flight PRs rebase or re-run afterwards. One drift fix unblocks the whole pipeline.
+
+## Exceptional Waiver Path
+
+Use this only when no patched release exists, or the patched release is breaking and cannot be adopted quickly.
+
+1. Complete the triage above. A waiver for a reachable, high/critical, shipped production path is expected to be rare and short-lived.
+2. Add the finding to the `bun audit` invocation as `--ignore=<CVE>` (Bun ignores by CVE id; repeat the flag for multiple ids).
+3. Record the waiver in the commit message and in `CHANGELOG.md`: CVE id, justification from the triage, owner, and an explicit expiry/revisit date.
+4. Before the revisit date, re-triage: adopt a patch if one has appeared, renew with fresh justification, or drop the waiver. Expired waivers are never silently carried forward.
+5. The consumer `npm audit` gate has no ignore mechanism. Waiving a finding there requires changing `scripts/smoke-npm-package.ts` to parse `npm audit --json` and filter waived ids; that code change must be proposed and justified in the same PR as the waiver, and it stays limited to ids with a recorded, unexpired waiver.
+
+## Release Rule
+
+Do not create a release tag while any audit gate is red or any waiver is past its revisit date. This extends the release rules in [`WORKFLOW.md`](./WORKFLOW.md); a drift fix during release preparation follows the same dedicated-PR flow, then the release branch picks it up.
+
+## Considered Alternatives
+
+Two CI relaxations were considered and rejected for now: making the PR-CI audit advisory (`continue-on-error`), and gating the audit only on lockfile changes in the PR diff. Both trade a visible, blocking signal for silent accumulation of unpatched advisories, and the historical fix-forward turnaround has been fast enough that the blocking gate has not materially delayed unrelated work. Revisit this decision if drift frequency or fix latency grows.

--- a/host-assets/skills/vesicle-docs/references/dev-audit_drift.md
+++ b/host-assets/skills/vesicle-docs/references/dev-audit_drift.md
@@ -36,7 +36,7 @@ Follow the PR #48 / #92 convention. The audit gate stays blocking; the response 
 2. Open a dedicated `chore(deps): patch <package> audit finding` PR. Never bundle the fix into a feature PR, and never widen an in-flight feature PR to absorb it.
 3. For a transitive finding, pin the patched release through `package.json` `overrides` and regenerate `bun.lock`. For a direct finding, bump the declared version normally.
 4. The commit message must name the GHSA/CVE id, the dependency chain, the reachability/real-risk assessment, and the verification list (see PR #92 for the shape).
-5. Verify: `bun audit` green, plus `bun run lint`, `bun run typecheck`, `bun test`, `bun run doctor`, and `bun run pack:check`. An exact override bump adds no tests, per the test value discipline in `AGENTS.md`.
+5. Verify: `bun audit` green, plus `bun run lint`, `bun run typecheck`, `bun test`, `bun run doctor`, `bun run pack:check`, and `bun run pack:smoke` (which includes the consumer `npm audit` gate). An exact override bump adds no tests, per the test value discipline in `AGENTS.md`.
 6. Land the patch PR on `develop` first; in-flight PRs rebase or re-run afterwards. One drift fix unblocks the whole pipeline.
 
 ## Exceptional Waiver Path

--- a/host-assets/skills/vesicle-docs/references/dev-readme.md
+++ b/host-assets/skills/vesicle-docs/references/dev-readme.md
@@ -26,6 +26,7 @@ Promotion flows in one direction. An internal conclusion becomes public only by 
 | [`STYLE.md`](./STYLE.md) | Source-code structure, maintainability, types, errors, naming, comments, and test design |
 | [`ARCHITECTURE.md`](./ARCHITECTURE.md) | Ownership, dependency direction, cross-cutting boundaries, and domain-contract routing |
 | [`WORKFLOW.md`](./WORKFLOW.md) | Branching, verification, review, publication, and documentation workflow |
+| [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md) | Audit-database drift recognition, fix-forward SOP, waiver path, and release rule |
 | [`USER_AGENCY_AND_RISK_DISCLOSURE.md`](./USER_AGENCY_AND_RISK_DISCLOSURE.md) | User agency, disclosure, confirmation, and enforceable-boundary policy |
 
 ### Runtime and product contracts

--- a/host-assets/skills/vesicle-docs/references/dev-workflow.md
+++ b/host-assets/skills/vesicle-docs/references/dev-workflow.md
@@ -204,7 +204,7 @@ Repository rules and Environment protection are live GitHub state, not YAML. Aud
 ### Failure And Retry Rules
 
 - A failed PR CI run has no public side effects. Fix the release branch and let the updated PR commit run again.
-- An audit-gate failure on an unchanged lockfile is audit database drift and is not retry-recoverable: the vulnerability database only grows, so rerunning returns the same answer. CI annotates such failures with a pointer to [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md); follow its dedicated fix-forward PR flow instead of rerunning.
+- An audit-gate failure on an unchanged lockfile is audit database drift and is not retry-recoverable. CI annotates such failures with a pointer to [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md); follow its dedicated fix-forward PR flow instead of rerunning.
 - Do not create the release tag until PR CI and human acceptance are complete.
 - A pushed release tag is immutable publication intent. Do not delete or move it merely to retrigger CI.
 - If a transient failure happens after the tag push, use the CLI to find and rerun the existing workflow: `gh run list --workflow release.yml`, then `gh run rerun <run-id> --failed`. This exceptional recovery needs `gh` because Git cannot truthfully push the same immutable tag twice. The npm job skips an exact version that is already present, and the GitHub Release job updates the release for the same tag.

--- a/host-assets/skills/vesicle-docs/references/dev-workflow.md
+++ b/host-assets/skills/vesicle-docs/references/dev-workflow.md
@@ -204,6 +204,7 @@ Repository rules and Environment protection are live GitHub state, not YAML. Aud
 ### Failure And Retry Rules
 
 - A failed PR CI run has no public side effects. Fix the release branch and let the updated PR commit run again.
+- An audit-gate failure on an unchanged lockfile is audit database drift and is not retry-recoverable: the vulnerability database only grows, so rerunning returns the same answer. CI annotates such failures with a pointer to [`AUDIT_DRIFT.md`](./AUDIT_DRIFT.md); follow its dedicated fix-forward PR flow instead of rerunning.
 - Do not create the release tag until PR CI and human acceptance are complete.
 - A pushed release tag is immutable publication intent. Do not delete or move it merely to retrigger CI.
 - If a transient failure happens after the tag push, use the CLI to find and rerun the existing workflow: `gh run list --workflow release.yml`, then `gh run rerun <run-id> --failed`. This exceptional recovery needs `gh` because Git cannot truthfully push the same immutable tag twice. The npm job skips an exact version that is already present, and the GitHub Release job updates the release for the same tag.

--- a/host-assets/skills/vesicle-docs/references/index.md
+++ b/host-assets/skills/vesicle-docs/references/index.md
@@ -77,6 +77,7 @@ Version-matched public documentation snapshot for the vesicle-docs Skill.
 
 - `docs/dev/ARCHITECTURE.md` → `references/dev-architecture.md` — Prism Vesicle Architecture [en]
 - `docs/dev/ASSETS.md` → `references/dev-assets.md` — Prism Runtime Assets [en]
+- `docs/dev/AUDIT_DRIFT.md` → `references/dev-audit_drift.md` — Audit Database Drift [en]
 - `docs/dev/COMMAND_COMPLETION.md` → `references/dev-command_completion.md` — Command Argument Completion [en]
 - `docs/dev/COMMAND_QUEUE.md` → `references/dev-command_queue.md` — Command Queue [en]
 - `docs/dev/OPENAI_RESPONSES_CONFORMANCE.md` → `references/dev-openai_responses_conformance.md` — OpenAI Responses Conformance Profile [en]

--- a/scripts/smoke-npm-package.ts
+++ b/scripts/smoke-npm-package.ts
@@ -35,7 +35,9 @@ try {
   assertCleanTree("local lockfile dependency tree", localTree);
   const audit = await runCaptured(["npm", "audit", "--omit=dev", "--audit-level=low"], localProject);
   if (audit.exitCode !== 0 || !/found 0 vulnerabilities/i.test(audit.output)) {
-    throw new Error(`local consumer audit failed:\n${audit.output.slice(-4000)}`);
+    throw new Error(
+      `local consumer audit failed:\n${audit.output.slice(-4000)}\nIf production dependencies are unchanged, this is likely audit database drift; follow docs/dev/AUDIT_DRIFT.md (rerunning will not recover it).`,
+    );
   }
   const localExecutable = npmExecutable(join(localProject, "node_modules"), false);
   await assertInstalledCli(localExecutable, localProject, configDir);

--- a/scripts/smoke-npm-package.ts
+++ b/scripts/smoke-npm-package.ts
@@ -36,7 +36,7 @@ try {
   const audit = await runCaptured(["npm", "audit", "--omit=dev", "--audit-level=low"], localProject);
   if (audit.exitCode !== 0 || !/found 0 vulnerabilities/i.test(audit.output)) {
     throw new Error(
-      `local consumer audit failed:\n${audit.output.slice(-4000)}\nIf production dependencies are unchanged, this is likely audit database drift; follow docs/dev/AUDIT_DRIFT.md (rerunning will not recover it).`,
+      `local consumer audit failed:\n${audit.output.slice(-4000)}\nFollow docs/dev/AUDIT_DRIFT.md — if production dependencies are unchanged, rerunning will not recover this failure.`,
     );
   }
   const localExecutable = npmExecutable(join(localProject, "node_modules"), false);


### PR DESCRIPTION
## Summary

Newly published advisories have twice turned CI red on the **unchanged** develop lockfile (PR #48, PR #92 — both `chore(deps): patch brace-expansion audit finding`). Because the vulnerability database only grows, `gh run rerun` can never recover such a failure, and the existing retry rules in WORKFLOW.md do not cover it.

This PR codifies the historical handling as a standing plan and adds a CI-side pointer to it:

- **`docs/dev/AUDIT_DRIFT.md`** (new): audit-database drift recognition (unchanged lockfile + previously green + advisory published later), the dedicated `chore(deps)` fix-forward PR convention from PR #48/#92 (overrides pin, advisory id + dependency chain + reachability assessment in the commit message, no new tests), an exceptional `bun audit --ignore=<CVE>` waiver path with owner and expiry/revisit date, the consumer `npm audit` no-ignore asymmetry, and the release rule (no tag while any audit gate is red or any waiver is past its revisit date). Advisory-CI and lockfile-baseline gating are recorded as considered-and-rejected alternatives.
- **`.github/workflows/release-build.yml`**: when the `bun audit` step fails, a follow-up step annotates the run (`::error` annotation + step summary) with a pointer to the plan. The audit gate itself stays blocking; exit codes unchanged.
- **`scripts/smoke-npm-package.ts`**: the consumer `npm audit` failure message now points at the plan as well.
- **`docs/dev/README.md` / `docs/dev/WORKFLOW.md`**: index entry and a Failure And Retry Rules bullet — drift reds are not retry-recoverable, follow the plan instead of rerunning.

## Verification

- `bun run typecheck`
- `bun run lint`
- YAML parse of the edited workflow
- `git diff --check`
- `rg` link check: every `AUDIT_DRIFT` reference resolves to the new file

**Gap**: the new `if: failure()` guidance step can only be exercised by a real failing Actions run; verified by syntax/semantics review only.

No new tests: docs + CI annotation + error-message text only, per the test value discipline.