### PR TITLE
feat(mcp): support multimodal tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Typed MCP multimodal tool results (#175).** Streamable HTTP MCP calls now cross a protocol-neutral, untrusted result normalizer instead of flattening unknown `content` objects into text. Ordered text remains compatible, while valid inline PNG/JPEG/GIF/WebP `ImageContent` is strictly base64-decoded, checked against declared MIME and magic bytes, stored in the existing content-addressed attachment store, and materialized only for a vision-capable main or SubAgent provider request. Session JSONL, resume, and compact history retain only `source: "mcp"` references and host-derived labels. Non-vision models, MCP error results, malformed or mismatched images, attachment failures, and the provisional shared 20 MiB decoded-image ceiling degrade to bounded payload-free notices; resource, audio, URL/link, and unknown items remain explicitly unsupported and are never auto-fetched or injected.
+
 ### Fixed
 
 - **Light-theme text selection and Workspace editor contrast (#158).** Selectable TUI text now receives one theme-owned foreground/background selection pair instead of relying on OpenTUI's implicit transparent-buffer color swap. Markdown propagates the same pair through prose, list markers, fenced code, and tables, including mounted selections during theme changes. The Workspace textarea now explicitly follows the active theme for ordinary and focused text, cursor, and selection colors, fixing its white-on-light editor text.

--- a/STATUS.md
+++ b/STATUS.md
@@ -35,7 +35,7 @@ Release candidate: **1.0.0-alpha.8**. The `State` column tracks the candidate's 
 | TUI | Rewind: conversation branches plus per-turn file checkpoints | released |
 | Tools | Guarded filesystem loop, `request_confirmation` gate, engine handoff, clarifying question | released |
 | Tools | Tavily web tools (`web_search` / `web_fetch` / `web_map` / `web_crawl` / `web_research`) | released |
-| Tools | Streamable-HTTP MCP tools | released |
+| Tools | Streamable-HTTP MCP tools with typed, vision-gated inline image results | released |
 | Tools | Opt-in `shell_exec` with bounded Process Runtime | released |
 | Tools | Tool Permission Runtime (`MANUAL` / `INERTIA` / `MOMENTUM` / `YOLO`) | released |
 | Agents | Foreground/background SubAgents with contract-bound Harness delegation | released |
@@ -70,7 +70,7 @@ prism-vesicle/
 │   │   ├── agent-loop/   # Provider calls, tool loop, gate pause/resume
 │   │   ├── agents/       # Agent profiles, child runtime, scheduling, inbox
 │   │   ├── artifacts/    # Artifact scanning, preview bounds, validation selection
-│   │   ├── attachments/  # Clipboard image content-addressed store
+│   │   ├── attachments/  # Image content-addressed store and request materialization
 │   │   ├── checkpoints/  # Per-turn file snapshots, diff stats, restore
 │   │   ├── compact/      # Context compaction service
 │   │   ├── engine/       # Engine profile YAML loader
@@ -211,7 +211,7 @@ Grouped by subsystem. Each item states the current limit or deferral; behavioral
 
 ### Web & MCP
 
-- MCP currently supports Streamable HTTP tools only. Local stdio servers, classic HTTP+SSE, prompts/resources, and background tool-list-change handling are deferred.
+- MCP currently supports Streamable HTTP tools and strictly validated inline PNG/JPEG/GIF/WebP tool-result images. Resource, audio, URL/link, and unknown result kinds are omitted without auto-fetch or prompt injection. Local stdio servers, classic HTTP+SSE, prompts/resources APIs, non-image media delivery, and background tool-list-change handling are deferred.
 - Web tools are limited to the five Tavily host tools on ETL and Evaluate profiles.
 
 ### Host Shell

--- a/docs/dev/ARCHITECTURE.md
+++ b/docs/dev/ARCHITECTURE.md
@@ -12,7 +12,7 @@ setup/  # guided onboarding and validated configuration transactions
 core/agent-loop/  # provider rounds, tool loop, and continuation orchestration
 core/agents/  # Agent profiles, child lifecycle, concurrency, and delivery
 core/artifacts/  # artifact discovery, preview bounds, and validation selection
-core/attachments/  # clipboard image content-addressed store
+core/attachments/  # image content-addressed store and request-only materialization
 core/checkpoints/  # per-turn file snapshots and restore
 core/compact/  # context compaction service
 core/engine/  # Engine profile loading
@@ -56,6 +56,7 @@ host-assets/  # restricted Vesicle prompts and generic Agent extensions
 - Provider adapters translate normalized requests and responses; they do not own host policy. See [`PROVIDERS.md`](./PROVIDERS.md).
 - Responses capability profiles are explicit configuration data consumed only by the Responses adapter. Core/session/TUI own normalized effects and opaque state, never OpenAI, MiMo, or DeepSeek wire fields; Setup may write reviewed profiles but must not infer them from provider or model identity. See [`OPENAI_RESPONSES_CONFORMANCE.md`](./OPENAI_RESPONSES_CONFORMANCE.md).
 - Model-visible tools remain behind host capability, path, permission, and process enforcement. See [`TOOLS.md`](./TOOLS.md). Project-root taxonomy (source, artifact, scratch, content, and model-writable categories) and scratch-path classification live in `core/project/roots.ts`; consumers must select the semantically correct set instead of re-deriving root lists.
+- `mcp` owns protocol-neutral result normalization and untrusted per-kind validation. It may deliver accepted media through `core/attachments`, but provider adapters receive only the established normalized message shape and never parse MCP payloads, fetch MCP references, or decide MCP media policy.
 - Sessions are append-only durable history. Projection, rewind, checkpoints, compaction, and continuation recovery must preserve that invariant. See [`SESSIONS.md`](./SESSIONS.md).
 - Prompt assets are runtime files resolved through the active verified asset stack; Engine prompts are not TypeScript literals. See [`ASSETS.md`](./ASSETS.md).
 - Generation prompts receive only the role, task, relevant input, effective actions, output contract, and concise task-specific quality guidance. Host enforcement — tool allowlists, permissions, path guards, integrity hashes, session identity, and the Quality lifecycle — is applied at runtime and must not be duplicated as prompt prose. Harness contract data stays declarative unless the active model must act on the exact binding in the current task; a profile with no tools must not be told about tools, Agents, shell, Web, state roots, or resource paths it cannot use. Prompt ledgers and prompt inspection keep capability and audience drift measurable without turning a review budget into a runtime admission threshold.

--- a/docs/dev/SESSIONS.md
+++ b/docs/dev/SESSIONS.md
@@ -28,7 +28,7 @@ This document defines durable conversation history, provider projection, file ch
 
 ## Attachments And File Checkpoints
 
-- Image bytes live in the ignored content-addressed `.vesicle/attachments/` store. JSONL records ids, hashes, MIME types, sizes, and relative paths, never base64 payloads.
+- Clipboard, guarded-project, and accepted MCP image bytes live in the ignored content-addressed `.vesicle/attachments/` store. JSONL records ids, hashes, MIME types, sizes, origins, host-derived labels, and relative paths, never base64 payloads. Main and child provider requests materialize base64 only on their in-memory request copy; resume and compact projection retain the durable reference.
 - A real user prompt owns the guarded-file checkpoint for the work it initiates.
 - Mutation tools capture every affected writable path before changing it. Checkpoint metadata remains host-only.
 - Checkpoints preserve absent paths, file contents, and directory topology. Directory-tree moves capture both the source tree and target path so empty directories can be restored.

--- a/docs/dev/SUBAGENTS.md
+++ b/docs/dev/SUBAGENTS.md
@@ -50,7 +50,7 @@ Session branching and SubAgent ownership are different graphs. `SessionRecord.pa
 
 Background completion and failure are written to a durable inbox before they are exposed to the parent. Inbox entries move through `pending`, `delivered`, and `acknowledged` states so restart recovery cannot lose or duplicate results. Explicit cancellation persists the Agent terminal state but does not enqueue a result or wake the parent because there is no child result to integrate.
 
-Child tool results preserve their success/failure outcome in both the in-memory provider conversation and the durable record. Protocol adapters may therefore map a failed child result to their native error form, including Anthropic `tool_result.is_error: true`, on the next child round and after resume.
+Child tool results preserve their success/failure outcome in both the in-memory provider conversation and the durable record. Protocol adapters may therefore map a failed child result to their native error form, including Anthropic `tool_result.is_error: true`, on the next child round and after resume. Accepted MCP image results follow the child's selected-model vision capability, persist as content-addressed references without base64, and materialize only on the next child provider-request copy.
 
 ## Parent Continuation
 

--- a/docs/dev/TOOLS.md
+++ b/docs/dev/TOOLS.md
@@ -68,7 +68,11 @@ This document defines the capability boundary for model-visible tools, external 
 
 - Tavily web tools are host-executed research tools, not provider adapter features. They persist structured web metadata and do not mutate project files directly.
 - MCP configuration is user-level host state. Secret header values expand from the sibling user `.env` and must not be logged or persisted.
-- MCP discovery and calls are normalized into ordinary host tool definitions and results; provider adapters remain unaware of MCP transport.
+- MCP discovery and calls are normalized into ordinary host tool definitions and typed, untrusted results; provider adapters remain unaware of MCP transport and result parsing.
 - The effective Engine and server configuration scope MCP availability. Model arguments and permission modes cannot widen that scope.
+- MCP text items keep their upstream order. Raw unknown content arrays and `structuredContent` are never JSON-stringified as a provider-visible fallback; the host emits bounded, payload-free diagnostics for unsupported or malformed items.
+- The supported multimodal result path is inline `ImageContent` with strict base64, declared MIME, and detected magic bytes that agree. Accepted PNG, JPEG, GIF, and WebP bytes use the existing content-addressed attachment store with `source: "mcp"`; server-provided filenames are ignored. The shared decoded-image ceiling is currently 20 MiB and is an internal, provisional safety policy rather than a configurable product limit.
+- A vision-capable selected model receives accepted MCP images through ordinary `ToolResult.images` materialization. A non-vision model keeps safe text plus an omission notice without decoding or persisting the image. An MCP error result never imports media; cancellation, invalid data, a MIME mismatch, an over-budget item, or an attachment-write failure cannot expose the binary payload to model text, session metadata, logs, or a provider request.
+- Resource, audio, URL/link, and unknown result items remain explicitly unsupported. Vesicle does not auto-read, download, transcribe, play, inject, or otherwise promote them into a prompt or a wider tool scope.
 
 The current tool inventory belongs in [`STATUS.md`](../../STATUS.md); user-facing shell guidance belongs in the language-mirrored user manual.

--- a/docs/user/en/reference/configuration.md
+++ b/docs/user/en/reference/configuration.md
@@ -159,6 +159,10 @@ Doctor checks route selection only; it does not prove that the proxy or provider
 
 Start from [`docs/examples/mcp.yaml`](../../../examples/mcp.yaml). Each server can set `transport` (streamable-http), `url`, `timeoutSeconds`, `toolPrefix`, `headers` (supports `${ENV_VAR}` expansion from `.env`), `includeTools`/`excludeTools` filters, and `enabledEngines` (which engines can use it). A present `mcp.yaml` defaults to enabled; secrets go in `.env`.
 
+MCP tool results first cross the host's untrusted-content boundary. Ordinary text keeps its original order. When the selected model declares `capabilities.vision: true`, strictly validated inline PNG, JPEG, GIF, and WebP images are delivered as image attachments. Sessions retain only content-addressed references, never base64. The current 20 MiB decoded-image ceiling is a provisional safety boundary, not a configurable long-term product commitment.
+
+For a non-vision model, images are neither decoded nor persisted; safe text continues with an omission notice. MCP error results also do not import images. Resource, audio, URL/link, and unknown results currently produce only bounded unsupported-item notices; Vesicle does not automatically download, read, transcribe, play, or inject them.
+
 ## Persistent Instructions (optional)
 
 If you keep re-stating the same sub-workflow or specification under an engine, write it into a Persistent Instructions file — the host loads it into the system prompt automatically at the start of every session, so you no longer have to ask the model to write a spec to a file and remind it to read it next session.

--- a/docs/user/zh-CN/reference/configuration.md
+++ b/docs/user/zh-CN/reference/configuration.md
@@ -159,6 +159,10 @@ Doctor 只检查路由选择,不会尝试证明代理或供应商实际可达;�
 
 从 [`docs/examples/mcp.yaml`](../../../examples/mcp.yaml) 起步。每个服务器可设 `transport`(streamable-http)、`url`、`timeoutSeconds`、`toolPrefix`、`headers`(支持 `${ENV_VAR}` 从 `.env` 展开)、`includeTools`/`excludeTools` 过滤、`enabledEngines`(限定哪些引擎能用)。文件存在即默认启用;密钥放 `.env`。
 
+MCP 工具结果会先经过宿主的不可信内容边界。普通文本保持原顺序；如果当前模型声明 `capabilities.vision: true`，严格校验后的内联 PNG/JPEG/GIF/WebP 图片会作为图片附件交给模型。会话只保存内容寻址引用，不保存 base64。当前解码上限是临时的 20 MiB 安全边界，不是可配置的长期产品承诺。
+
+如果当前模型不支持视觉，图片不会被解码或落盘，安全文本仍会继续并附带省略提示。MCP 错误结果也不会导入图片。resource、audio、URL/link 和未知结果目前只会给出有界的“不支持”提示；Vesicle 不会自动下载、读取、转录、播放或注入这些内容。
+
 ## 持久化指令(可选)
 
 如果你经常要在某个引擎下重复同一套子工作流或规范,可以写进持久化指令文件——宿主在每个会话启动时自动把它们加载进系统 prompt,不需要再让模型写文件、下次会话再提醒它去读。

--- a/host-assets/skills/vesicle-docs/references/dev-architecture.md
+++ b/host-assets/skills/vesicle-docs/references/dev-architecture.md
@@ -14,7 +14,7 @@ setup/  # guided onboarding and validated configuration transactions
 core/agent-loop/  # provider rounds, tool loop, and continuation orchestration
 core/agents/  # Agent profiles, child lifecycle, concurrency, and delivery
 core/artifacts/  # artifact discovery, preview bounds, and validation selection
-core/attachments/  # clipboard image content-addressed store
+core/attachments/  # image content-addressed store and request-only materialization
 core/checkpoints/  # per-turn file snapshots and restore
 core/compact/  # context compaction service
 core/engine/  # Engine profile loading
@@ -58,6 +58,7 @@ host-assets/  # restricted Vesicle prompts and generic Agent extensions
 - Provider adapters translate normalized requests and responses; they do not own host policy. See [`PROVIDERS.md`](./PROVIDERS.md).
 - Responses capability profiles are explicit configuration data consumed only by the Responses adapter. Core/session/TUI own normalized effects and opaque state, never OpenAI, MiMo, or DeepSeek wire fields; Setup may write reviewed profiles but must not infer them from provider or model identity. See [`OPENAI_RESPONSES_CONFORMANCE.md`](./OPENAI_RESPONSES_CONFORMANCE.md).
 - Model-visible tools remain behind host capability, path, permission, and process enforcement. See [`TOOLS.md`](./TOOLS.md). Project-root taxonomy (source, artifact, scratch, content, and model-writable categories) and scratch-path classification live in `core/project/roots.ts`; consumers must select the semantically correct set instead of re-deriving root lists.
+- `mcp` owns protocol-neutral result normalization and untrusted per-kind validation. It may deliver accepted media through `core/attachments`, but provider adapters receive only the established normalized message shape and never parse MCP payloads, fetch MCP references, or decide MCP media policy.
 - Sessions are append-only durable history. Projection, rewind, checkpoints, compaction, and continuation recovery must preserve that invariant. See [`SESSIONS.md`](./SESSIONS.md).
 - Prompt assets are runtime files resolved through the active verified asset stack; Engine prompts are not TypeScript literals. See [`ASSETS.md`](./ASSETS.md).
 - Generation prompts receive only the role, task, relevant input, effective actions, output contract, and concise task-specific quality guidance. Host enforcement — tool allowlists, permissions, path guards, integrity hashes, session identity, and the Quality lifecycle — is applied at runtime and must not be duplicated as prompt prose. Harness contract data stays declarative unless the active model must act on the exact binding in the current task; a profile with no tools must not be told about tools, Agents, shell, Web, state roots, or resource paths it cannot use. Prompt ledgers and prompt inspection keep capability and audience drift measurable without turning a review budget into a runtime admission threshold.

--- a/host-assets/skills/vesicle-docs/references/dev-sessions.md
+++ b/host-assets/skills/vesicle-docs/references/dev-sessions.md
@@ -30,7 +30,7 @@ This document defines durable conversation history, provider projection, file ch
 
 ## Attachments And File Checkpoints
 
-- Image bytes live in the ignored content-addressed `.vesicle/attachments/` store. JSONL records ids, hashes, MIME types, sizes, and relative paths, never base64 payloads.
+- Clipboard, guarded-project, and accepted MCP image bytes live in the ignored content-addressed `.vesicle/attachments/` store. JSONL records ids, hashes, MIME types, sizes, origins, host-derived labels, and relative paths, never base64 payloads. Main and child provider requests materialize base64 only on their in-memory request copy; resume and compact projection retain the durable reference.
 - A real user prompt owns the guarded-file checkpoint for the work it initiates.
 - Mutation tools capture every affected writable path before changing it. Checkpoint metadata remains host-only.
 - Checkpoints preserve absent paths, file contents, and directory topology. Directory-tree moves capture both the source tree and target path so empty directories can be restored.

--- a/host-assets/skills/vesicle-docs/references/dev-subagents.md
+++ b/host-assets/skills/vesicle-docs/references/dev-subagents.md
@@ -52,7 +52,7 @@ Session branching and SubAgent ownership are different graphs. `SessionRecord.pa
 
 Background completion and failure are written to a durable inbox before they are exposed to the parent. Inbox entries move through `pending`, `delivered`, and `acknowledged` states so restart recovery cannot lose or duplicate results. Explicit cancellation persists the Agent terminal state but does not enqueue a result or wake the parent because there is no child result to integrate.
 
-Child tool results preserve their success/failure outcome in both the in-memory provider conversation and the durable record. Protocol adapters may therefore map a failed child result to their native error form, including Anthropic `tool_result.is_error: true`, on the next child round and after resume.
+Child tool results preserve their success/failure outcome in both the in-memory provider conversation and the durable record. Protocol adapters may therefore map a failed child result to their native error form, including Anthropic `tool_result.is_error: true`, on the next child round and after resume. Accepted MCP image results follow the child's selected-model vision capability, persist as content-addressed references without base64, and materialize only on the next child provider-request copy.
 
 ## Parent Continuation
 

--- a/host-assets/skills/vesicle-docs/references/dev-tools.md
+++ b/host-assets/skills/vesicle-docs/references/dev-tools.md
@@ -70,7 +70,11 @@ This document defines the capability boundary for model-visible tools, external 
 
 - Tavily web tools are host-executed research tools, not provider adapter features. They persist structured web metadata and do not mutate project files directly.
 - MCP configuration is user-level host state. Secret header values expand from the sibling user `.env` and must not be logged or persisted.
-- MCP discovery and calls are normalized into ordinary host tool definitions and results; provider adapters remain unaware of MCP transport.
+- MCP discovery and calls are normalized into ordinary host tool definitions and typed, untrusted results; provider adapters remain unaware of MCP transport and result parsing.
 - The effective Engine and server configuration scope MCP availability. Model arguments and permission modes cannot widen that scope.
+- MCP text items keep their upstream order. Raw unknown content arrays and `structuredContent` are never JSON-stringified as a provider-visible fallback; the host emits bounded, payload-free diagnostics for unsupported or malformed items.
+- The supported multimodal result path is inline `ImageContent` with strict base64, declared MIME, and detected magic bytes that agree. Accepted PNG, JPEG, GIF, and WebP bytes use the existing content-addressed attachment store with `source: "mcp"`; server-provided filenames are ignored. The shared decoded-image ceiling is currently 20 MiB and is an internal, provisional safety policy rather than a configurable product limit.
+- A vision-capable selected model receives accepted MCP images through ordinary `ToolResult.images` materialization. A non-vision model keeps safe text plus an omission notice without decoding or persisting the image. An MCP error result never imports media; cancellation, invalid data, a MIME mismatch, an over-budget item, or an attachment-write failure cannot expose the binary payload to model text, session metadata, logs, or a provider request.
+- Resource, audio, URL/link, and unknown result items remain explicitly unsupported. Vesicle does not auto-read, download, transcribe, play, inject, or otherwise promote them into a prompt or a wider tool scope.
 
 The current tool inventory belongs in [`STATUS.md`](../../STATUS.md); user-facing shell guidance belongs in the language-mirrored user manual.

--- a/host-assets/skills/vesicle-docs/references/user-en-reference-configuration.md
+++ b/host-assets/skills/vesicle-docs/references/user-en-reference-configuration.md
@@ -161,6 +161,10 @@ Doctor checks route selection only; it does not prove that the proxy or provider
 
 Start from [`docs/examples/mcp.yaml`](../../../examples/mcp.yaml). Each server can set `transport` (streamable-http), `url`, `timeoutSeconds`, `toolPrefix`, `headers` (supports `${ENV_VAR}` expansion from `.env`), `includeTools`/`excludeTools` filters, and `enabledEngines` (which engines can use it). A present `mcp.yaml` defaults to enabled; secrets go in `.env`.
 
+MCP tool results first cross the host's untrusted-content boundary. Ordinary text keeps its original order. When the selected model declares `capabilities.vision: true`, strictly validated inline PNG, JPEG, GIF, and WebP images are delivered as image attachments. Sessions retain only content-addressed references, never base64. The current 20 MiB decoded-image ceiling is a provisional safety boundary, not a configurable long-term product commitment.
+
+For a non-vision model, images are neither decoded nor persisted; safe text continues with an omission notice. MCP error results also do not import images. Resource, audio, URL/link, and unknown results currently produce only bounded unsupported-item notices; Vesicle does not automatically download, read, transcribe, play, or inject them.
+
 ## Persistent Instructions (optional)
 
 If you keep re-stating the same sub-workflow or specification under an engine, write it into a Persistent Instructions file — the host loads it into the system prompt automatically at the start of every session, so you no longer have to ask the model to write a spec to a file and remind it to read it next session.

--- a/host-assets/skills/vesicle-docs/references/user-zh-cn-reference-configuration.md
+++ b/host-assets/skills/vesicle-docs/references/user-zh-cn-reference-configuration.md
@@ -161,6 +161,10 @@ Doctor 只检查路由选择,不会尝试证明代理或供应商实际可达;�
 
 从 [`docs/examples/mcp.yaml`](../../../examples/mcp.yaml) 起步。每个服务器可设 `transport`(streamable-http)、`url`、`timeoutSeconds`、`toolPrefix`、`headers`(支持 `${ENV_VAR}` 从 `.env` 展开)、`includeTools`/`excludeTools` 过滤、`enabledEngines`(限定哪些引擎能用)。文件存在即默认启用;密钥放 `.env`。
 
+MCP 工具结果会先经过宿主的不可信内容边界。普通文本保持原顺序；如果当前模型声明 `capabilities.vision: true`，严格校验后的内联 PNG/JPEG/GIF/WebP 图片会作为图片附件交给模型。会话只保存内容寻址引用，不保存 base64。当前解码上限是临时的 20 MiB 安全边界，不是可配置的长期产品承诺。
+
+如果当前模型不支持视觉，图片不会被解码或落盘，安全文本仍会继续并附带省略提示。MCP 错误结果也不会导入图片。resource、audio、URL/link 和未知结果目前只会给出有界的“不支持”提示；Vesicle 不会自动下载、读取、转录、播放或注入这些内容。
+
 ## 持久化指令(可选)
 
 如果你经常要在某个引擎下重复同一套子工作流或规范,可以写进持久化指令文件——宿主在每个会话启动时自动把它们加载进系统 prompt,不需要再让模型写文件、下次会话再提醒它去读。

--- a/src/core/agent-loop/permission-continuation.ts
+++ b/src/core/agent-loop/permission-continuation.ts
@@ -286,7 +286,11 @@ async function executeApprovedEntry(
   const mutationOwner = `${context.session.sessionId}:${call.id}`;
   try {
     return context.toolSurface.mcp.hasTool(call.name)
-      ? await context.toolSurface.mcp.execute(call)
+      ? await context.toolSurface.mcp.execute(call, {
+        rootDir: context.rootDir,
+        visionEnabled: context.config.capabilities?.vision === true,
+        signal: options.signal,
+      })
       : await executeHostTool(context.rootDir, call, {
         signal: options.signal,
         processManager: getProcessManager(context.rootDir),

--- a/src/core/agent-loop/provider-round.ts
+++ b/src/core/agent-loop/provider-round.ts
@@ -106,7 +106,7 @@ export function emitAssistantResponse(response: VesicleResponse, onEvent?: (even
   });
 }
 
-async function prepareProviderMessages(
+export async function prepareProviderMessages(
   rootDir: string,
   messages: VesicleMessage[],
   visionEnabled: boolean,

--- a/src/core/agent-loop/provider-round.ts
+++ b/src/core/agent-loop/provider-round.ts
@@ -1,5 +1,5 @@
 import type { ProviderAdapter, VesicleMessage, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
-import { materializeMessageImages } from "../attachments/store";
+import { prepareProviderMessages } from "../attachments/store";
 import type { EngineId } from "../engine/profile";
 import type { ProviderSelection } from "../../config/providers";
 import type { SessionStore } from "../session/store";
@@ -10,7 +10,6 @@ import type { AgentLoopEvent } from "./types";
 import { renderBackgroundProcessNotifications } from "./background-process";
 import { cloneSideQuestionMessages, type SideQuestionContextSnapshot } from "../side-question/types";
 import { ProviderAttemptCommitBarrier } from "../../providers/shared/attempt-commit";
-import { cloneProviderStateEnvelope } from "../../providers/shared/state";
 
 type ProviderRoundOptions = {
   rootDir: string;
@@ -104,25 +103,6 @@ export function emitAssistantResponse(response: VesicleResponse, onEvent?: (even
     ...(response.usage ? { usage: response.usage } : {}),
     toolCalls: toolCalls.map((call) => ({ id: call.id, name: call.name, arguments: call.arguments })),
   });
-}
-
-export async function prepareProviderMessages(
-  rootDir: string,
-  messages: VesicleMessage[],
-  visionEnabled: boolean,
-): Promise<VesicleMessage[]> {
-  const hasImages = messages.some((message) => (message.images?.length ?? 0) > 0);
-  if (hasImages && !visionEnabled) {
-    throw new Error("The selected model does not declare capabilities.vision: true; image attachments were not sent.");
-  }
-  return Promise.all(messages.map(async (message) => {
-    const images = await materializeMessageImages(rootDir, message.images);
-    return {
-      ...message,
-      ...(message.providerState ? { providerState: cloneProviderStateEnvelope(message.providerState) } : {}),
-      ...(images ? { images } : {}),
-    };
-  }));
 }
 
 async function completeWithStreaming(

--- a/src/core/agent-loop/tool-round-executor.ts
+++ b/src/core/agent-loop/tool-round-executor.ts
@@ -274,7 +274,11 @@ async function executeHostCall(
   const mutationOwner = `${options.session.sessionId}:${call.id}`;
   try {
     return options.mcpRegistry.hasTool(call.name)
-      ? await options.mcpRegistry.execute(call, { signal: options.signal })
+      ? await options.mcpRegistry.execute(call, {
+        rootDir: options.rootDir,
+        visionEnabled: options.config.capabilities?.vision === true,
+        signal: options.signal,
+      })
       : await executeHostTool(options.rootDir, call, {
         signal: options.signal,
         processManager: options.processManager,

--- a/src/core/agents/child-run-durability.ts
+++ b/src/core/agents/child-run-durability.ts
@@ -15,6 +15,7 @@ import {
 import type { SessionStore } from "../session/store";
 import type { ToolCall, ToolResult } from "../tools";
 import type { AgentInvocationContext, AgentRunOutput } from "./types";
+import { persistedImageAttachments } from "../attachments/store";
 
 export type ChildRunState = {
   messages: VesicleMessage[];
@@ -129,6 +130,7 @@ export async function recordChildToolResult(
       ...(result.fileEvent ? { fileEvent: result.fileEvent } : {}),
       ...(result.webEvent ? { webEvent: result.webEvent } : {}),
       ...(result.mcpEvent ? { mcpEvent: result.mcpEvent } : {}),
+      ...(result.images ? { images: persistedImageAttachments(result.images) } : {}),
     },
   });
   const qualityTarget = qualityArtifactTargetFromResult(profileId, result);

--- a/src/core/agents/child-runner.ts
+++ b/src/core/agents/child-runner.ts
@@ -11,6 +11,7 @@ import { agentToolProgress, executeChildTool } from "./child-tool-executor";
 import { providerRetryLabel } from "../../providers/shared/retry-label";
 import type { AgentRunner } from "./manager";
 import { closeProviderSession } from "../../providers/lifecycle";
+import { prepareProviderMessages } from "../agent-loop/provider-round";
 
 export { composeChildSystemPrompts, resolveChildTools } from "./child-bootstrap";
 export { agentToolProgress } from "./child-tool-executor";
@@ -35,11 +36,16 @@ export const runChildAgent: AgentRunner = async ({
       if (signal.aborted) throw signal.reason;
       await appendChildParentMessages(state, takeMessages(), runtime.session, runId, handle);
       onProgress(`request ${iteration + 1}`);
+      const providerMessages = await prepareProviderMessages(
+        invocation.rootDir,
+        state.messages,
+        runtime.config.capabilities?.vision === true,
+      );
       const response = await runChildProviderRound(runtime.provider, {
         id: runtime.session.sessionId,
         model: { provider: runtime.config.providerId, model: runtime.config.model },
         system: runtime.systemPrompts,
-        messages: state.messages,
+        messages: providerMessages,
         tools: runtime.tools,
         generation: invocation.generation,
         signal,
@@ -75,6 +81,7 @@ export const runChildAgent: AgentRunner = async ({
           invocation,
           session: runtime.session,
           mcp: runtime.mcp,
+          visionEnabled: runtime.config.capabilities?.vision === true,
           checkpoint: runtime.checkpoint,
           claimMutation,
         });

--- a/src/core/agents/child-runner.ts
+++ b/src/core/agents/child-runner.ts
@@ -11,7 +11,7 @@ import { agentToolProgress, executeChildTool } from "./child-tool-executor";
 import { providerRetryLabel } from "../../providers/shared/retry-label";
 import type { AgentRunner } from "./manager";
 import { closeProviderSession } from "../../providers/lifecycle";
-import { prepareProviderMessages } from "../agent-loop/provider-round";
+import { prepareProviderMessages } from "../attachments/store";
 
 export { composeChildSystemPrompts, resolveChildTools } from "./child-bootstrap";
 export { agentToolProgress } from "./child-tool-executor";

--- a/src/core/agents/child-tool-executor.ts
+++ b/src/core/agents/child-tool-executor.ts
@@ -27,6 +27,7 @@ type ChildToolContext = {
   invocation: AgentInvocationContext;
   session: SessionStore;
   mcp: McpRegistry;
+  visionEnabled: boolean;
   checkpoint: FileCheckpointManager;
   claimMutation(paths: string[]): Promise<void>;
 };
@@ -40,6 +41,7 @@ export async function executeChildTool({
   invocation,
   session,
   mcp,
+  visionEnabled,
   checkpoint,
   claimMutation,
 }: ChildToolContext): Promise<ChildToolExecution> {
@@ -96,7 +98,7 @@ export async function executeChildTool({
 
   async function executeApprovedTool(): Promise<ToolResult> {
     return mcp.hasTool(call.name)
-      ? mcp.execute(call)
+      ? mcp.execute(call, { rootDir: invocation.rootDir, visionEnabled, signal })
       : executeHostTool(invocation.rootDir, call, {
         signal,
         shellInterpreter: permission.shellInterpreter,

--- a/src/core/attachments/store.ts
+++ b/src/core/attachments/store.ts
@@ -3,9 +3,9 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, join, relative, resolve, sep } from "node:path";
 import type { ImageDetail, VesicleImageAttachment } from "../../providers/shared/types";
 
-export const maxImageAttachmentBytes = 5 * 1024 * 1024;
+export const maxImageAttachmentBytes = 20 * 1024 * 1024;
 
-type SupportedImageMime = VesicleImageAttachment["mediaType"];
+export type SupportedImageMime = VesicleImageAttachment["mediaType"];
 
 export async function ingestImageBytes(
   rootDir: string,
@@ -15,6 +15,7 @@ export async function ingestImageBytes(
     filename?: string;
     sourcePath?: string;
     detail?: ImageDetail;
+    expectedMediaType?: SupportedImageMime;
   },
 ): Promise<VesicleImageAttachment> {
   if (bytes.byteLength === 0) throw new Error("Image attachment is empty.");
@@ -24,6 +25,9 @@ export async function ingestImageBytes(
 
   const mediaType = detectImageMediaType(bytes);
   if (!mediaType) throw new Error("Unsupported image format. Use PNG, JPEG, GIF, or WebP.");
+  if (options.expectedMediaType && mediaType !== options.expectedMediaType) {
+    throw new Error(`Image attachment MIME mismatch: declared ${options.expectedMediaType}, detected ${mediaType}.`);
+  }
   const sha256 = createHash("sha256").update(bytes).digest("hex");
   const extension = extensionForMime(mediaType);
   const attachmentPath = `.vesicle/attachments/${sha256}.${extension}`;
@@ -55,6 +59,7 @@ export async function ingestImageFile(
     filename?: string;
     sourcePath?: string;
     detail?: ImageDetail;
+    expectedMediaType?: SupportedImageMime;
   },
 ): Promise<VesicleImageAttachment> {
   return ingestImageBytes(rootDir, await readFile(absolutePath), {
@@ -120,7 +125,7 @@ function isImageAttachment(value: unknown): value is VesicleImageAttachment {
     && typeof image.path === "string"
     && typeof image.bytes === "number"
     && typeof image.sha256 === "string"
-    && (image.source === "clipboard" || image.source === "project")
+    && (image.source === "clipboard" || image.source === "project" || image.source === "mcp")
     && ["image/png", "image/jpeg", "image/gif", "image/webp"].includes(image.mediaType ?? "");
 }
 

--- a/src/core/attachments/store.ts
+++ b/src/core/attachments/store.ts
@@ -1,7 +1,8 @@
 import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { basename, join, relative, resolve, sep } from "node:path";
-import type { ImageDetail, VesicleImageAttachment } from "../../providers/shared/types";
+import { cloneProviderStateEnvelope } from "../../providers/shared/state";
+import type { ImageDetail, VesicleImageAttachment, VesicleMessage } from "../../providers/shared/types";
 
 export const maxImageAttachmentBytes = 20 * 1024 * 1024;
 
@@ -20,7 +21,7 @@ export async function ingestImageBytes(
 ): Promise<VesicleImageAttachment> {
   if (bytes.byteLength === 0) throw new Error("Image attachment is empty.");
   if (bytes.byteLength > maxImageAttachmentBytes) {
-    throw new Error(`Image attachment exceeds the ${formatBytes(maxImageAttachmentBytes)} limit.`);
+    throw new Error(`Image attachment exceeds the ${formatImageAttachmentBytes(maxImageAttachmentBytes)} limit.`);
   }
 
   const mediaType = detectImageMediaType(bytes);
@@ -86,6 +87,25 @@ export async function materializeMessageImages(
   }));
 }
 
+export async function prepareProviderMessages(
+  rootDir: string,
+  messages: VesicleMessage[],
+  visionEnabled: boolean,
+): Promise<VesicleMessage[]> {
+  const hasImages = messages.some((message) => (message.images?.length ?? 0) > 0);
+  if (hasImages && !visionEnabled) {
+    throw new Error("The selected model does not declare capabilities.vision: true; image attachments were not sent.");
+  }
+  return Promise.all(messages.map(async (message) => {
+    const images = await materializeMessageImages(rootDir, message.images);
+    return {
+      ...message,
+      ...(message.providerState ? { providerState: cloneProviderStateEnvelope(message.providerState) } : {}),
+      ...(images ? { images } : {}),
+    };
+  }));
+}
+
 export function persistedImageAttachments(
   images: VesicleImageAttachment[] | undefined,
 ): VesicleImageAttachment[] | undefined {
@@ -138,6 +158,6 @@ function extensionForMime(mime: SupportedImageMime): string {
   return mime.slice("image/".length);
 }
 
-function formatBytes(bytes: number): string {
-  return `${Math.round(bytes / 1024 / 1024)} MB`;
+export function formatImageAttachmentBytes(bytes: number): string {
+  return `${Math.round(bytes / 1024 / 1024)} MiB`;
 }

--- a/src/core/session/compact-checkpoint.ts
+++ b/src/core/session/compact-checkpoint.ts
@@ -335,7 +335,7 @@ function parseImages(value: unknown, label: string): NonNullable<ResumedMessage[
       || entry.bytes < 0
       || typeof entry.sha256 !== "string"
       || !/^[a-f0-9]{64}$/.test(entry.sha256)
-      || (entry.source !== "clipboard" && entry.source !== "project")
+      || (entry.source !== "clipboard" && entry.source !== "project" && entry.source !== "mcp")
     ) throw new Error(`Session compact checkpoint ${imageLabel} is malformed.`);
     for (const key of ["filename", "sourcePath"] as const) {
       if (Object.hasOwn(entry, key) && typeof entry[key] !== "string") throw new Error(`Session compact checkpoint ${imageLabel}.${key} is malformed.`);

--- a/src/core/tools/types.ts
+++ b/src/core/tools/types.ts
@@ -96,6 +96,9 @@ export type McpToolEvent = {
   alias: string;
   toolName: string;
   isError: boolean;
+  imageCount?: number;
+  omittedContentCount?: number;
+  hasStructuredContent?: boolean;
 };
 
 export type ProcessToolEvent = {

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -9,5 +9,7 @@ Vesicle's first MCP milestone is a tools-only Streamable HTTP client.
 - Tools are discovered with `initialize` + paginated `tools/list`, then exposed as `mcp_<prefix>_<tool>` aliases.
 - `includeTools` and `excludeTools` match either the remote tool name or the Vesicle alias.
 - `enabledEngines` can scope a server to specific Prism engines.
+- Tool results are normalized as untrusted typed content. Ordered text remains text; supported inline PNG/JPEG/GIF/WebP images are strictly validated and enter the existing attachment path only for vision-capable models.
+- Non-vision models and MCP error results receive safe text plus an omission notice without importing image bytes. Resource, audio, link, and unknown result items are not fetched or injected.
 
 The client intentionally does not launch local stdio servers yet. That transport needs a separate process-management pass for Windows PE distribution and local path/env behavior.

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -1,6 +1,6 @@
 import packageJson from "../../package.json";
 import type { McpServerConfig, McpToolCallResult, McpRawTool } from "./types";
-import { formatMcpToolResult, isRecord, McpError } from "./types";
+import { isRecord, McpError, normalizeMcpToolResult } from "./types";
 
 type JsonRpcEnvelope = Record<string, unknown>;
 
@@ -50,7 +50,7 @@ export class McpStreamableHttpClient {
       name: toolName,
       arguments: args,
     }, options);
-    return formatMcpToolResult(result);
+    return normalizeMcpToolResult(result);
   }
 
   private async request(method: string, params: Record<string, unknown>, options: { signal?: AbortSignal } = {}): Promise<Record<string, unknown>> {

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -4,6 +4,7 @@ import type { EngineId } from "../core/engine/profile";
 import type { ToolCall, ToolDefinition, ToolResult } from "../core/tools/types";
 import { McpStreamableHttpClient, type McpClientOptions } from "./client";
 import { loadMcpConfig, mcpConfigPathFromEnv } from "./config";
+import { deliverMcpToolResult, type McpResultDeliveryContext } from "./result-delivery";
 import type { McpConfig, McpRawTool, McpServerConfig, McpServerStatus, McpToolBinding, McpToolEvent } from "./types";
 import {
   buildMcpToolAlias,
@@ -21,7 +22,7 @@ export type McpRegistry = {
   definitions: ToolDefinition[];
   statuses: McpServerStatus[];
   hasTool: (name: string) => boolean;
-  execute: (call: ToolCall, options?: { signal?: AbortSignal }) => Promise<ToolResult>;
+  execute: (call: ToolCall, context: Pick<McpResultDeliveryContext, "rootDir" | "visionEnabled" | "signal">) => Promise<ToolResult>;
 };
 
 export type McpInspection = {
@@ -159,7 +160,7 @@ async function buildRegistry(
     definitions: [...bindings.values()].map(toolDefinitionFromMcpBinding),
     statuses,
     hasTool: (name) => bindings.has(name),
-    execute: async (call, executeOptions = {}) => {
+    execute: async (call, executeContext) => {
       const binding = bindings.get(call.name);
       if (!binding) {
         return {
@@ -190,16 +191,26 @@ async function buildRegistry(
         };
       }
       try {
-        const result = await client.callTool(binding.toolName, args.value, executeOptions);
+        const result = await client.callTool(binding.toolName, args.value, { signal: executeContext.signal });
+        const delivered = await deliverMcpToolResult(result, {
+          ...executeContext,
+          serverId: binding.serverId,
+          toolName: binding.toolName,
+        });
         return {
           callId: call.id,
           name: call.name,
           ok: !result.isError,
-          content: result.content,
-          mcpEvent: eventFromBinding(binding, result.isError),
+          content: delivered.content,
+          ...(delivered.images ? { images: delivered.images } : {}),
+          mcpEvent: eventFromBinding(binding, result.isError, {
+            imageCount: delivered.imageCount,
+            omittedContentCount: delivered.omittedContentCount,
+            hasStructuredContent: result.structuredContent !== undefined,
+          }),
         };
       } catch (error) {
-        if (executeOptions.signal?.aborted) throw error;
+        if (executeContext.signal?.aborted) throw error;
         return {
           callId: call.id,
           name: call.name,
@@ -268,13 +279,20 @@ function disconnectedStatus(server: McpServerConfig, detail: string): McpServerS
   };
 }
 
-function eventFromBinding(binding: McpToolBinding, isError: boolean): McpToolEvent {
+function eventFromBinding(
+  binding: McpToolBinding,
+  isError: boolean,
+  summary?: { imageCount: number; omittedContentCount: number; hasStructuredContent: boolean },
+): McpToolEvent {
   return {
     kind: "mcp_tool",
     serverId: binding.serverId,
     alias: binding.alias,
     toolName: binding.toolName,
     isError,
+    ...(summary?.imageCount ? { imageCount: summary.imageCount } : {}),
+    ...(summary?.omittedContentCount ? { omittedContentCount: summary.omittedContentCount } : {}),
+    ...(summary?.hasStructuredContent ? { hasStructuredContent: true } : {}),
   };
 }
 

--- a/src/mcp/result-delivery.ts
+++ b/src/mcp/result-delivery.ts
@@ -1,0 +1,200 @@
+import type { VesicleImageAttachment } from "../providers/shared/types";
+import {
+  detectImageMediaType,
+  ingestImageBytes,
+  maxImageAttachmentBytes,
+  type SupportedImageMime,
+} from "../core/attachments/store";
+import type { McpToolCallResult } from "./types";
+import { sanitizeToolName } from "./types";
+
+export type McpResultDeliveryContext = {
+  rootDir: string;
+  visionEnabled: boolean;
+  serverId: string;
+  toolName: string;
+  signal?: AbortSignal;
+};
+
+export type DeliveredMcpToolResult = {
+  content: string;
+  images?: VesicleImageAttachment[];
+  imageCount: number;
+  omittedContentCount: number;
+};
+
+type ImageOmissionReason =
+  | "tool-error"
+  | "vision-disabled"
+  | "unsupported-mime"
+  | "invalid-base64"
+  | "over-budget"
+  | "mime-mismatch"
+  | "attachment-write-failed";
+
+const supportedImageMimes = new Set<SupportedImageMime>([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+const maxMcpImageLabelChars = 128;
+
+export async function deliverMcpToolResult(
+  result: McpToolCallResult,
+  context: McpResultDeliveryContext,
+): Promise<DeliveredMcpToolResult> {
+  throwIfAborted(context.signal);
+  const images: VesicleImageAttachment[] = [];
+  const omissions = new Map<ImageOmissionReason, number>();
+  const notices: string[] = [];
+
+  if (result.isError) {
+    addOmission(omissions, "tool-error", result.images.length);
+  } else if (!context.visionEnabled) {
+    addOmission(omissions, "vision-disabled", result.images.length);
+  } else {
+    for (const candidate of result.images) {
+      throwIfAborted(context.signal);
+      const mediaType = supportedImageMime(candidate.mimeType);
+      if (!mediaType) {
+        addOmission(omissions, "unsupported-mime");
+        continue;
+      }
+      const decoded = decodeInlineBase64(candidate.data);
+      if (!decoded.ok) {
+        addOmission(omissions, decoded.reason);
+        continue;
+      }
+      const detected = detectImageMediaType(decoded.bytes);
+      if (!detected || detected !== mediaType) {
+        addOmission(omissions, "mime-mismatch");
+        continue;
+      }
+      throwIfAborted(context.signal);
+      try {
+        images.push(await ingestImageBytes(context.rootDir, decoded.bytes, {
+          source: "mcp",
+          filename: imageLabel(context, candidate.contentIndex, mediaType),
+          expectedMediaType: mediaType,
+        }));
+      } catch (error) {
+        if (context.signal?.aborted) throw context.signal.reason ?? error;
+        addOmission(omissions, "attachment-write-failed");
+      }
+    }
+  }
+
+  const diagnosticCount = result.diagnostics.length;
+  if (diagnosticCount > 0) {
+    notices.push(`MCP result omitted ${formatCount(diagnosticCount, "malformed or unknown content item")}.`);
+  }
+  const deferredCounts = countDeferredKinds(result);
+  if (deferredCounts.total > 0) {
+    const descriptions = [
+      deferredCounts.audio > 0 ? formatCount(deferredCounts.audio, "audio item") : "",
+      deferredCounts.resource > 0 ? formatCount(deferredCounts.resource, "resource item") : "",
+      deferredCounts.link > 0 ? formatCount(deferredCounts.link, "link item") : "",
+    ].filter(Boolean);
+    notices.push(`MCP result omitted unsupported content: ${descriptions.join(", ")}.`);
+  }
+  for (const [reason, count] of omissions) {
+    if (count > 0) notices.push(imageOmissionNotice(reason, count));
+  }
+
+  const safeText = result.text.join("\n").trim();
+  const baseContent = safeText
+    || (result.structuredContent !== undefined ? "MCP tool returned structured content." : "")
+    || (images.length > 0 ? `MCP tool returned ${formatCount(images.length, "image")}.` : "")
+    || (result.isError
+      ? "MCP tool returned an error with no displayable text."
+      : "MCP tool returned no displayable content.");
+  const omittedContentCount = diagnosticCount + deferredCounts.total
+    + [...omissions.values()].reduce((sum, count) => sum + count, 0);
+  return {
+    content: [baseContent, ...notices].join("\n"),
+    ...(images.length > 0 ? { images } : {}),
+    imageCount: images.length,
+    omittedContentCount,
+  };
+}
+
+function decodeInlineBase64(
+  data: string,
+): { ok: true; bytes: Uint8Array } | { ok: false; reason: "invalid-base64" | "over-budget" } {
+  if (data.length === 0 || data.length % 4 !== 0) {
+    return { ok: false, reason: "invalid-base64" };
+  }
+  const padding = data.endsWith("==") ? 2 : data.endsWith("=") ? 1 : 0;
+  const body = data.slice(0, data.length - padding);
+  if (body.includes("=") || padding > 2 || /[^A-Za-z0-9+/]/.test(body)) {
+    return { ok: false, reason: "invalid-base64" };
+  }
+  const decodedBytes = (data.length / 4) * 3 - padding;
+  if (decodedBytes > maxImageAttachmentBytes) return { ok: false, reason: "over-budget" };
+  const bytes = Buffer.from(data, "base64");
+  if (bytes.toString("base64") !== data) return { ok: false, reason: "invalid-base64" };
+  return { ok: true, bytes };
+}
+
+function supportedImageMime(value: string): SupportedImageMime | undefined {
+  const normalized = value.trim().toLowerCase() as SupportedImageMime;
+  return supportedImageMimes.has(normalized) ? normalized : undefined;
+}
+
+function countDeferredKinds(result: McpToolCallResult): {
+  audio: number;
+  resource: number;
+  link: number;
+  total: number;
+} {
+  let audio = 0;
+  let resource = 0;
+  let link = 0;
+  for (const candidate of result.deferred) {
+    if (candidate.kind === "audio") audio += 1;
+    else if (candidate.kind === "resource") resource += 1;
+    else link += 1;
+  }
+  return { audio, resource, link, total: audio + resource + link };
+}
+
+function addOmission(
+  omissions: Map<ImageOmissionReason, number>,
+  reason: ImageOmissionReason,
+  count = 1,
+): void {
+  if (count > 0) omissions.set(reason, (omissions.get(reason) ?? 0) + count);
+}
+
+function imageOmissionNotice(reason: ImageOmissionReason, count: number): string {
+  const cause: Record<ImageOmissionReason, string> = {
+    "tool-error": "the tool returned an error",
+    "vision-disabled": "the selected model does not support vision",
+    "unsupported-mime": "the declared MIME type is unsupported",
+    "invalid-base64": "the inline data is not strict base64",
+    "over-budget": `the decoded data exceeds the ${formatBytes(maxImageAttachmentBytes)} limit`,
+    "mime-mismatch": "the declared MIME type does not match the image bytes",
+    "attachment-write-failed": "the attachment could not be stored",
+  };
+  return `MCP result omitted ${formatCount(count, "image")}: ${cause[reason]}.`;
+}
+
+function imageLabel(context: McpResultDeliveryContext, contentIndex: number, mediaType: SupportedImageMime): string {
+  const extension = mediaType === "image/jpeg" ? "jpg" : mediaType.slice("image/".length);
+  const suffix = `-image-${contentIndex + 1}.${extension}`;
+  const base = `${sanitizeToolName(context.serverId)}-${sanitizeToolName(context.toolName)}`;
+  return `${base.slice(0, maxMcpImageLabelChars - suffix.length)}${suffix}`;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) throw signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
+function formatCount(count: number, singular: string): string {
+  return `${count} ${singular}${count === 1 ? "" : "s"}`;
+}
+
+function formatBytes(bytes: number): string {
+  return `${Math.round(bytes / 1024 / 1024)} MiB`;
+}

--- a/src/mcp/result-delivery.ts
+++ b/src/mcp/result-delivery.ts
@@ -1,6 +1,7 @@
 import type { VesicleImageAttachment } from "../providers/shared/types";
 import {
   detectImageMediaType,
+  formatImageAttachmentBytes,
   ingestImageBytes,
   maxImageAttachmentBytes,
   type SupportedImageMime,
@@ -73,11 +74,13 @@ export async function deliverMcpToolResult(
       }
       throwIfAborted(context.signal);
       try {
-        images.push(await ingestImageBytes(context.rootDir, decoded.bytes, {
+        const image = await ingestImageBytes(context.rootDir, decoded.bytes, {
           source: "mcp",
           filename: imageLabel(context, candidate.contentIndex, mediaType),
           expectedMediaType: mediaType,
-        }));
+        });
+        throwIfAborted(context.signal);
+        images.push(image);
       } catch (error) {
         if (context.signal?.aborted) throw context.signal.reason ?? error;
         addOmission(omissions, "attachment-write-failed");
@@ -173,7 +176,7 @@ function imageOmissionNotice(reason: ImageOmissionReason, count: number): string
     "vision-disabled": "the selected model does not support vision",
     "unsupported-mime": "the declared MIME type is unsupported",
     "invalid-base64": "the inline data is not strict base64",
-    "over-budget": `the decoded data exceeds the ${formatBytes(maxImageAttachmentBytes)} limit`,
+    "over-budget": `the decoded data exceeds the ${formatImageAttachmentBytes(maxImageAttachmentBytes)} limit`,
     "mime-mismatch": "the declared MIME type does not match the image bytes",
     "attachment-write-failed": "the attachment could not be stored",
   };
@@ -193,8 +196,4 @@ function throwIfAborted(signal: AbortSignal | undefined): void {
 
 function formatCount(count: number, singular: string): string {
   return `${count} ${singular}${count === 1 ? "" : "s"}`;
-}
-
-function formatBytes(bytes: number): string {
-  return `${Math.round(bytes / 1024 / 1024)} MiB`;
 }

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -50,8 +50,46 @@ export type McpServerStatus = {
 };
 
 export type McpToolCallResult = {
-  content: string;
+  text: string[];
+  structuredContent?: unknown;
+  images: McpInlineImageCandidate[];
+  deferred: McpDeferredContentCandidate[];
+  diagnostics: McpResultDiagnostic[];
   isError: boolean;
+};
+
+export type McpInlineImageCandidate = {
+  kind: "image";
+  contentIndex: number;
+  data: string;
+  mimeType: string;
+};
+
+export type McpDeferredContentCandidate =
+  | {
+    kind: "audio";
+    contentIndex: number;
+    mimeType?: string;
+  }
+  | {
+    kind: "resource";
+    contentIndex: number;
+    mimeType?: string;
+    scheme?: string;
+    hasText: boolean;
+    hasBlob: boolean;
+  }
+  | {
+    kind: "link";
+    contentIndex: number;
+    mimeType?: string;
+    scheme?: string;
+  };
+
+export type McpResultDiagnostic = {
+  contentIndex?: number;
+  code: "invalid-response" | "invalid-content-item" | "invalid-image" | "unknown-content-type";
+  declaredType?: string;
 };
 
 export type McpToolEvent = {
@@ -60,6 +98,9 @@ export type McpToolEvent = {
   alias: string;
   toolName: string;
   isError: boolean;
+  imageCount?: number;
+  omittedContentCount?: number;
+  hasStructuredContent?: boolean;
 };
 
 export class McpError extends Error {
@@ -108,34 +149,116 @@ export function mcpToolFilterMatches(filters: Set<string>, binding: Pick<McpTool
   return filters.has(binding.toolName) || filters.has(binding.alias);
 }
 
-export function formatMcpToolResult(payload: unknown): McpToolCallResult {
+export function normalizeMcpToolResult(payload: unknown): McpToolCallResult {
   if (!isRecord(payload)) {
-    return { content: "MCP tool returned an unrecognized response.", isError: true };
+    return {
+      text: [],
+      images: [],
+      deferred: [],
+      diagnostics: [{ code: "invalid-response" }],
+      isError: true,
+    };
   }
 
-  const parts: string[] = [];
+  const text: string[] = [];
+  const images: McpInlineImageCandidate[] = [];
+  const deferred: McpDeferredContentCandidate[] = [];
+  const diagnostics: McpResultDiagnostic[] = [];
   const content = payload.content;
   if (Array.isArray(content)) {
-    for (const item of content) {
-      if (!isRecord(item)) continue;
-      if (item.type === "text" && typeof item.text === "string" && item.text.trim()) {
-        parts.push(item.text.trim());
+    for (const [contentIndex, item] of content.entries()) {
+      if (!isRecord(item)) {
+        diagnostics.push({ contentIndex, code: "invalid-content-item" });
+        continue;
       }
+      if (item.type === "text" && typeof item.text === "string") {
+        const normalizedText = item.text.trim();
+        if (normalizedText) text.push(normalizedText);
+        continue;
+      }
+      if (item.type === "image") {
+        if (typeof item.data === "string" && item.data.length > 0
+          && typeof item.mimeType === "string" && item.mimeType.trim()) {
+          images.push({
+            kind: "image",
+            contentIndex,
+            data: item.data,
+            mimeType: item.mimeType.trim(),
+          });
+        } else {
+          diagnostics.push({ contentIndex, code: "invalid-image", declaredType: "image" });
+        }
+        continue;
+      }
+      if (item.type === "audio") {
+        deferred.push({
+          kind: "audio",
+          contentIndex,
+          ...optionalMimeType(item),
+        });
+        continue;
+      }
+      if (item.type === "resource") {
+        if (!isRecord(item.resource)) {
+          diagnostics.push({ contentIndex, code: "invalid-content-item", declaredType: "resource" });
+          continue;
+        }
+        const resource = item.resource;
+        deferred.push({
+          kind: "resource",
+          contentIndex,
+          ...optionalMimeType(resource),
+          ...referenceScheme(resource.uri),
+          hasText: typeof resource.text === "string",
+          hasBlob: typeof resource.blob === "string",
+        });
+        continue;
+      }
+      if (item.type === "resource_link" || item.type === "url" || item.type === "link") {
+        deferred.push({
+          kind: "link",
+          contentIndex,
+          ...optionalMimeType(item),
+          ...referenceScheme(item.uri ?? item.url),
+        });
+        continue;
+      }
+      diagnostics.push({
+        contentIndex,
+        code: "unknown-content-type",
+        ...declaredContentType(item.type),
+      });
     }
+  } else if (content !== undefined) {
+    diagnostics.push({ code: "invalid-response" });
   }
 
-  if (parts.length === 0 && payload.structuredContent !== undefined) {
-    parts.push(JSON.stringify(payload.structuredContent));
-  }
-  if (parts.length === 0 && payload.content !== undefined) {
-    parts.push(JSON.stringify(payload.content));
-  }
-
-  const text = parts.filter(Boolean).join("\n").trim();
   return {
-    content: text || "MCP tool returned no displayable content.",
+    text,
+    ...(payload.structuredContent !== undefined ? { structuredContent: payload.structuredContent } : {}),
+    images,
+    deferred,
+    diagnostics,
     isError: payload.isError === true,
   };
+}
+
+function optionalMimeType(value: Record<string, unknown>): { mimeType?: string } {
+  return typeof value.mimeType === "string" && value.mimeType.trim()
+    ? { mimeType: value.mimeType.trim().slice(0, 128) }
+    : {};
+}
+
+function referenceScheme(value: unknown): { scheme?: string } {
+  if (typeof value !== "string") return {};
+  const match = /^([A-Za-z][A-Za-z0-9+.-]*):/.exec(value.trim());
+  return match ? { scheme: match[1]!.toLowerCase().slice(0, 32) } : {};
+}
+
+function declaredContentType(value: unknown): { declaredType?: string } {
+  return typeof value === "string" && value.trim()
+    ? { declaredType: value.trim().replace(/[\u0000-\u001f\u007f]/g, "").slice(0, 64) }
+    : {};
 }
 
 export function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import type { EngineId } from "../core/engine/profile";
 import type { ToolDefinition } from "../core/tools/types";
 
+export type { McpToolEvent } from "../core/tools/types";
+
 export type McpTransport = "streamable-http";
 
 export type McpServerConfig = {
@@ -90,17 +92,6 @@ export type McpResultDiagnostic = {
   contentIndex?: number;
   code: "invalid-response" | "invalid-content-item" | "invalid-image" | "unknown-content-type";
   declaredType?: string;
-};
-
-export type McpToolEvent = {
-  kind: "mcp_tool";
-  serverId: string;
-  alias: string;
-  toolName: string;
-  isError: boolean;
-  imageCount?: number;
-  omittedContentCount?: number;
-  hasStructuredContent?: boolean;
 };
 
 export class McpError extends Error {

--- a/src/providers/shared/types.ts
+++ b/src/providers/shared/types.ts
@@ -30,7 +30,7 @@ export type VesicleImageAttachment = {
   bytes: number;
   sha256: string;
   filename?: string;
-  source: "clipboard" | "project";
+  source: "clipboard" | "project" | "mcp";
   sourcePath?: string;
   detail?: ImageDetail;
   data?: string;

--- a/tests/integration/agent-loop/mcp-multimodal.test.ts
+++ b/tests/integration/agent-loop/mcp-multimodal.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { resolvePermission, runPrompt } from "../../../src/core/agent-loop/run";
+import { loadSessionMessages, loadSessionRecords } from "../../../src/core/session/store";
+import {
+  configureTestProviderEnv,
+  createPromptRoot,
+  restoreAgentLoopTestState,
+  testPng,
+} from "./fixtures/agent-loop";
+
+beforeEach(configureTestProviderEnv);
+afterEach(restoreAgentLoopTestState);
+
+describe("agent loop: MCP multimodal results", () => {
+  test("materializes an MCP image for a vision request and persists only its attachment reference", async () => {
+    await configureTestProviderEnv({ vision: true });
+    const rootDir = await createPromptRoot();
+    await configureMcp();
+    const providerBodies: Record<string, any>[] = [];
+    globalThis.fetch = multimodalFetch(providerBodies);
+
+    const result = await runPrompt({
+      input: "show the artwork",
+      rootDir,
+      permission: { mode: "MOMENTUM" },
+    });
+
+    expect(result.kind).toBe("complete");
+    expect(providerBodies).toHaveLength(2);
+    const imageFollowUp = providerBodies[1]!.messages.find((message: any) =>
+      message.role === "user" && Array.isArray(message.content));
+    expect(imageFollowUp.content).toContainEqual(expect.objectContaining({
+      type: "image_url",
+      image_url: expect.objectContaining({ url: expect.stringContaining("data:image/png;base64,") }),
+    }));
+
+    const records = await loadSessionRecords(rootDir, result.sessionId);
+    const toolRecord = records.find((record) => record.role === "tool" && record.metadata?.toolCallId === "call-artwork");
+    expect(toolRecord?.metadata?.images).toEqual([expect.objectContaining({
+      source: "mcp",
+      mediaType: "image/png",
+      filename: "prts-operator_artwork-image-2.png",
+    })]);
+    const persistedImages = toolRecord?.metadata?.images as Array<{ data?: string }> | undefined;
+    expect(persistedImages?.[0]?.data).toBeUndefined();
+    expect(JSON.stringify(toolRecord)).not.toContain(Buffer.from(testPng()).toString("base64"));
+
+    const resumed = await loadSessionMessages(rootDir, result.sessionId);
+    const projectedTool = resumed.find((message) => message.role === "tool" && message.toolCallId === "call-artwork");
+    expect(projectedTool?.images?.[0]).toMatchObject({ source: "mcp", mediaType: "image/png" });
+    expect(projectedTool?.images?.[0].data).toBeUndefined();
+    expect(await readFile(join(rootDir, projectedTool!.images![0]!.path))).toEqual(Buffer.from(testPng()));
+  });
+
+  test("keeps a non-vision MCP tool loop text-safe without decoding or persisting the image", async () => {
+    const rootDir = await createPromptRoot();
+    await configureMcp();
+    const providerBodies: Record<string, any>[] = [];
+    globalThis.fetch = multimodalFetch(providerBodies);
+
+    const result = await runPrompt({
+      input: "describe the artwork without vision",
+      rootDir,
+      permission: { mode: "MOMENTUM" },
+    });
+
+    expect(result.kind).toBe("complete");
+    expect(providerBodies).toHaveLength(2);
+    expect(JSON.stringify(providerBodies[1])).not.toContain("image_url");
+    expect(JSON.stringify(providerBodies[1])).not.toContain(Buffer.from(testPng()).toString("base64"));
+    expect(JSON.stringify(providerBodies[1])).toContain("selected model does not support vision");
+    expect(await Bun.file(join(rootDir, ".vesicle", "attachments")).exists()).toBe(false);
+  });
+
+  test("uses the same vision delivery context after a MANUAL permission continuation", async () => {
+    await configureTestProviderEnv({ vision: true });
+    const rootDir = await createPromptRoot();
+    await configureMcp();
+    const providerBodies: Record<string, any>[] = [];
+    globalThis.fetch = multimodalFetch(providerBodies);
+
+    const paused = await runPrompt({
+      input: "show the artwork after approval",
+      rootDir,
+      permission: { mode: "MANUAL" },
+    });
+    expect(paused.kind).toBe("needs_permission");
+    if (paused.kind !== "needs_permission") throw new Error("expected MCP permission pause");
+    expect(providerBodies).toHaveLength(1);
+
+    const resumed = await resolvePermission({
+      engine: "etl",
+      rootDir,
+      sessionId: paused.sessionId,
+      messages: paused.messages,
+      request: paused.request,
+      remainingToolCalls: paused.remainingToolCalls,
+      resolution: { decision: "allow_once", resolvedAt: new Date().toISOString() },
+      permission: { mode: "MANUAL" },
+    });
+    expect(resumed.kind).toBe("complete");
+    expect(providerBodies).toHaveLength(2);
+    expect(JSON.stringify(providerBodies[1])).toContain("data:image/png;base64,");
+  });
+
+  test("materializes and persists MCP image results inside a SubAgent tool loop", async () => {
+    await configureTestProviderEnv({ vision: true });
+    const rootDir = await createPromptRoot();
+    await configureMcp();
+    const childBodies: Record<string, any>[] = [];
+    globalThis.fetch = subagentMultimodalFetch(childBodies);
+
+    const result = await runPrompt({
+      input: "delegate the artwork check",
+      rootDir,
+      permission: { mode: "MOMENTUM" },
+    });
+
+    expect(result.kind).toBe("complete");
+    expect(childBodies).toHaveLength(2);
+    expect(JSON.stringify(childBodies[1])).toContain("data:image/png;base64,");
+    const sessionFiles = await readdir(join(rootDir, ".vesicle", "sessions"));
+    const sessionRecords = await Promise.all(sessionFiles.map((file) =>
+      loadSessionRecords(rootDir, file.replace(/\.jsonl$/, ""))));
+    const childToolRecord = sessionRecords.flat().find((record) =>
+      record.metadata?.kind === "subagent-tool-result" && record.metadata?.toolCallId === "child-artwork");
+    expect(childToolRecord?.metadata?.images).toEqual([expect.objectContaining({
+      source: "mcp",
+      filename: "prts-operator_artwork-image-1.png",
+    })]);
+    expect(JSON.stringify(childToolRecord)).not.toContain(Buffer.from(testPng()).toString("base64"));
+  });
+});
+
+async function configureMcp(): Promise<void> {
+  const providerPath = process.env.VESICLE_PROVIDERS_FILE;
+  if (!providerPath) throw new Error("test provider config is missing");
+  await writeFile(join(dirname(providerPath), "mcp.yaml"), [
+    "servers:",
+    "  prts:",
+    "    url: https://mcp.test/prts/mcp",
+    "",
+  ].join("\n"), "utf8");
+}
+
+function multimodalFetch(providerBodies: Record<string, any>[]): typeof fetch {
+  const imageData = Buffer.from(testPng()).toString("base64");
+  return (async (input, init) => {
+    const body = JSON.parse(String(init?.body)) as Record<string, any>;
+    if (String(input).startsWith("https://mcp.test/")) {
+      if (body.method === "initialize") {
+        return Response.json({ jsonrpc: "2.0", id: body.id, result: { serverInfo: { name: "prts" } } });
+      }
+      if (body.method === "notifications/initialized") return new Response("", { status: 202 });
+      if (body.method === "tools/list") {
+        return Response.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { tools: [{ name: "operator_artwork", inputSchema: { type: "object", properties: {} } }] },
+        });
+      }
+      if (body.method === "tools/call") {
+        return Response.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            content: [
+              { type: "text", text: "Artwork for Amiya" },
+              { type: "image", data: imageData, mimeType: "image/png" },
+            ],
+          },
+        });
+      }
+      throw new Error(`unexpected MCP method ${String(body.method)}`);
+    }
+
+    providerBodies.push(body);
+    if (providerBodies.length === 1) {
+      return Response.json({
+        id: "chat-mcp-image-1",
+        choices: [{ message: {
+          content: "",
+          tool_calls: [{
+            id: "call-artwork",
+            type: "function",
+            function: { name: "mcp_prts_operator_artwork", arguments: "{}" },
+          }],
+        } }],
+      });
+    }
+    return Response.json({ id: "chat-mcp-image-2", choices: [{ message: { content: "seen" } }] });
+  }) as typeof fetch;
+}
+
+function subagentMultimodalFetch(childBodies: Record<string, any>[]): typeof fetch {
+  const imageData = Buffer.from(testPng()).toString("base64");
+  let parentRequests = 0;
+  return (async (input, init) => {
+    const body = JSON.parse(String(init?.body)) as Record<string, any>;
+    if (String(input).startsWith("https://mcp.test/")) {
+      if (body.method === "initialize") {
+        return Response.json({ jsonrpc: "2.0", id: body.id, result: { serverInfo: { name: "prts" } } });
+      }
+      if (body.method === "notifications/initialized") return new Response("", { status: 202 });
+      if (body.method === "tools/list") {
+        return Response.json({ jsonrpc: "2.0", id: body.id, result: { tools: [{ name: "operator_artwork" }] } });
+      }
+      if (body.method === "tools/call") {
+        return Response.json({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { content: [{ type: "image", data: imageData, mimeType: "image/png" }] },
+        });
+      }
+      throw new Error(`unexpected MCP method ${String(body.method)}`);
+    }
+
+    const system = String(body.messages?.[0]?.content ?? "");
+    if (system.includes("General Agent")) {
+      childBodies.push(body);
+      if (childBodies.length === 1) {
+        return Response.json({
+          id: "child-mcp-image-1",
+          choices: [{ message: {
+            content: "",
+            tool_calls: [{
+              id: "child-artwork",
+              type: "function",
+              function: { name: "mcp_prts_operator_artwork", arguments: "{}" },
+            }],
+          } }],
+        });
+      }
+      return Response.json({ id: "child-mcp-image-2", choices: [{ message: { content: "artwork checked" } }] });
+    }
+
+    parentRequests += 1;
+    if (parentRequests === 1) {
+      return Response.json({
+        id: "parent-spawn-mcp",
+        choices: [{ message: {
+          content: "",
+          tool_calls: [{
+            id: "spawn-artwork-check",
+            type: "function",
+            function: {
+              name: "spawn_agent",
+              arguments: JSON.stringify({
+                profile: "general",
+                description: "Check artwork",
+                prompt: "Call the artwork tool and inspect its image.",
+                mode: "foreground",
+              }),
+            },
+          }],
+        } }],
+      });
+    }
+    return Response.json({ id: "parent-mcp-complete", choices: [{ message: { content: "delegation complete" } }] });
+  }) as typeof fetch;
+}

--- a/tests/integration/providers/anthropic-provider.test.ts
+++ b/tests/integration/providers/anthropic-provider.test.ts
@@ -40,6 +40,32 @@ describe("Anthropic Messages request shaping", () => {
       ],
     }]);
   });
+
+  test("serializes MCP tool-result images inside the native tool_result block", () => {
+    const body = toAnthropicMessagesBody({
+      ...request(),
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "toolu_mcp", name: "mcp_prts_operator_artwork", arguments: "{}" }],
+        },
+        { role: "tool", toolCallId: "toolu_mcp", content: "artwork", images: [mcpImage()] },
+      ],
+    });
+    expect((body.messages as unknown[])[1]).toEqual({
+      role: "user",
+      content: [{
+        type: "tool_result",
+        tool_use_id: "toolu_mcp",
+        content: [
+          { type: "text", text: "artwork" },
+          { type: "text", text: "[Image #1: prts-operator_artwork-image-1.png]" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "cG5n" } },
+        ],
+      }],
+    });
+  });
   test("serializes messages, thinking blocks, tools, and tool results", () => {
     const body = toAnthropicMessagesBody({
       ...request(),
@@ -439,6 +465,14 @@ function image(): NonNullable<VesicleRequest["messages"][number]["images"]>[numb
     source: "clipboard",
     filename: "capture.png",
     data: "cG5n",
+  };
+}
+
+function mcpImage(): ReturnType<typeof image> {
+  return {
+    ...image(),
+    source: "mcp",
+    filename: "prts-operator_artwork-image-1.png",
   };
 }
 

--- a/tests/integration/providers/gemini-provider.test.ts
+++ b/tests/integration/providers/gemini-provider.test.ts
@@ -39,6 +39,34 @@ describe("Gemini generateContent request shaping", () => {
       ],
     }]);
   });
+
+  test("serializes MCP tool-result images after the function response", () => {
+    const body = toGeminiGenerateContentBody({
+      ...request(),
+      messages: [
+        {
+          role: "assistant",
+          content: "",
+          toolCalls: [{ id: "call_mcp", name: "mcp_prts_operator_artwork", arguments: "{}" }],
+        },
+        { role: "tool", toolCallId: "call_mcp", content: "artwork", images: [mcpImage()] },
+      ],
+    });
+    expect((body.contents as unknown[])[1]).toEqual({
+      role: "user",
+      parts: [
+        {
+          functionResponse: {
+            id: "call_mcp",
+            name: "mcp_prts_operator_artwork",
+            response: { content: "artwork" },
+          },
+        },
+        { text: "[Image #1: prts-operator_artwork-image-1.png]" },
+        { inlineData: { mimeType: "image/png", data: "cG5n" } },
+      ],
+    });
+  });
   test("serializes system, messages, tools, tool results, and thinking config", () => {
     const body = toGeminiGenerateContentBody({
       ...request(),
@@ -491,6 +519,14 @@ function image(): NonNullable<VesicleRequest["messages"][number]["images"]>[numb
     source: "clipboard",
     filename: "capture.png",
     data: "cG5n",
+  };
+}
+
+function mcpImage(): ReturnType<typeof image> {
+  return {
+    ...image(),
+    source: "mcp",
+    filename: "prts-operator_artwork-image-1.png",
   };
 }
 

--- a/tests/integration/providers/provider-backend.test.ts
+++ b/tests/integration/providers/provider-backend.test.ts
@@ -38,7 +38,7 @@ describe("OpenAI-compatible request shaping", () => {
       ...request(),
       messages: [
         { role: "user", content: "inspect", images: [image()] },
-        { role: "tool", toolCallId: "call-view", content: "viewed", images: [image()] },
+        { role: "tool", toolCallId: "call-view", content: "viewed", images: [mcpImage()] },
       ],
     }, false);
     expect(body.messages).toEqual([
@@ -55,7 +55,7 @@ describe("OpenAI-compatible request shaping", () => {
       {
         role: "user",
         content: [
-          { type: "text", text: "[Image #1: source_materials/reference.png]" },
+          { type: "text", text: "[Image #1: prts-operator_artwork-image-1.png]" },
           { type: "image_url", image_url: { url: "data:image/png;base64,cG5n", detail: "high" } },
         ],
       },
@@ -389,6 +389,15 @@ function image(): NonNullable<VesicleRequest["messages"][number]["images"]>[numb
     sourcePath: "source_materials/reference.png",
     detail: "high",
     data: "cG5n",
+  };
+}
+
+function mcpImage(): ReturnType<typeof image> {
+  return {
+    ...image(),
+    source: "mcp",
+    sourcePath: undefined,
+    filename: "prts-operator_artwork-image-1.png",
   };
 }
 

--- a/tests/integration/session/compact-checkpoint.test.ts
+++ b/tests/integration/session/compact-checkpoint.test.ts
@@ -306,7 +306,7 @@ describe("session: compact-checkpoint-v1 projection", () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-ckpt-images-"));
     const store = await createSessionStore(rootDir, "ckpt-images");
     await store.append({ role: "system", content: "prompt", metadata: { engine: "etl" } });
-    const image = { id: "img_reachable", path: ".vesicle/attachments/img_reachable.png", mediaType: "image/png" as const, bytes: 12, sha256: "a".repeat(64), source: "clipboard" as const };
+    const image = { id: "img_reachable", path: ".vesicle/attachments/img_reachable.png", mediaType: "image/png" as const, bytes: 12, sha256: "a".repeat(64), source: "mcp" as const };
     await store.append({
       role: "system",
       content: "compacted",
@@ -329,7 +329,7 @@ describe("session: compact-checkpoint-v1 projection", () => {
       "[conversation summary]\nEarlier work.",
       "kept turn with an image",
     ]);
-    expect(messages[1]!.images?.map((entry) => entry.id)).toEqual(["img_reachable"]);
+    expect(messages[1]!.images).toEqual([image]);
   });
 
   test("toolSkillEvent in the retained tail survives checkpoint round-trip", async () => {

--- a/tests/integration/tools/attachments.test.ts
+++ b/tests/integration/tools/attachments.test.ts
@@ -6,6 +6,7 @@ import {
   detectImageMediaType,
   ingestImageBytes,
   materializeMessageImages,
+  maxImageAttachmentBytes,
   parseImageAttachments,
   persistedImageAttachments,
 } from "../../../src/core/attachments/store";
@@ -36,5 +37,26 @@ describe("image attachment store", () => {
     expect(detectImageMediaType(png)).toBe("image/png");
     expect(detectImageMediaType(Uint8Array.from([0xff, 0xd8, 0xff, 0x00]))).toBe("image/jpeg");
     expect(parseImageAttachments([{ id: "bad" }])).toBeUndefined();
+  });
+
+  test("round-trips MCP attachment references under the shared 20 MiB policy", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vesicle-mcp-attachments-"));
+    const image = await ingestImageBytes(rootDir, png, {
+      source: "mcp",
+      filename: "prts-operator_artwork-image-1.png",
+      expectedMediaType: "image/png",
+    });
+    const persisted = persistedImageAttachments([{
+      ...image,
+      data: Buffer.from(png).toString("base64"),
+    }]);
+
+    expect(maxImageAttachmentBytes).toBe(20 * 1024 * 1024);
+    expect(parseImageAttachments(persisted)).toEqual([image]);
+    expect(JSON.stringify(persisted)).not.toContain(Buffer.from(png).toString("base64"));
+    await expect(ingestImageBytes(rootDir, png, {
+      source: "mcp",
+      expectedMediaType: "image/jpeg",
+    })).rejects.toThrow("MIME mismatch");
   });
 });

--- a/tests/integration/tools/mcp-multimodal.test.ts
+++ b/tests/integration/tools/mcp-multimodal.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { maxImageAttachmentBytes } from "../../../src/core/attachments/store";
+import { createMcpRegistryForEngine } from "../../../src/mcp/registry";
+import { deliverMcpToolResult } from "../../../src/mcp/result-delivery";
+
+describe("MCP multimodal result delivery", () => {
+  test("delivers mixed and pure inline images through the attachment store", async () => {
+    const png = testPng();
+    const data = Buffer.from(png).toString("base64");
+    const { registry, rootDir } = await registryForResults((args) => ({
+      content: args.pure === true
+        ? [{ type: "image", data, mimeType: "image/png", filename: "../../untrusted.png" }]
+        : [
+            { type: "text", text: "operator artwork" },
+            { type: "image", data, mimeType: "image/png", filename: "../../untrusted.png" },
+          ],
+    }));
+
+    const mixed = await registry.execute(
+      { id: "mixed", name: "mcp_media_render", arguments: "{}" },
+      { rootDir, visionEnabled: true },
+    );
+    expect(mixed).toMatchObject({
+      ok: true,
+      content: "operator artwork",
+      images: [{ source: "mcp", mediaType: "image/png", filename: "media-render-image-2.png" }],
+      mcpEvent: { imageCount: 1, isError: false },
+    });
+    expect(mixed.content).not.toContain(data);
+    expect(await readFile(join(rootDir, mixed.images![0]!.path))).toEqual(Buffer.from(png));
+
+    const pure = await registry.execute(
+      { id: "pure", name: "mcp_media_render", arguments: "{\"pure\":true}" },
+      { rootDir, visionEnabled: true },
+    );
+    expect(pure.content).toBe("MCP tool returned 1 image.");
+    expect(pure.images?.[0]).toMatchObject({ source: "mcp", filename: "media-render-image-1.png" });
+  });
+
+  test("degrades image, error, deferred, and unknown results without payload leakage", async () => {
+    const data = Buffer.from(testPng()).toString("base64");
+    const secret = "private-resource-body";
+    const { registry, rootDir } = await registryForResults((args) => ({
+      content: [
+        { type: "text", text: "safe text" },
+        { type: "image", data, mimeType: "image/png" },
+        { type: "audio", data: secret, mimeType: "audio/wav" },
+        { type: "resource", resource: { uri: "https://example.test/private?token=secret", text: secret } },
+        { type: "resource_link", uri: "https://example.test/private?token=secret" },
+        { type: "future", payload: secret },
+      ],
+      ...(args.error === true ? { isError: true } : {}),
+    }));
+
+    const nonVision = await registry.execute(
+      { id: "non-vision", name: "mcp_media_render", arguments: "{}" },
+      { rootDir, visionEnabled: false },
+    );
+    expect(nonVision.ok).toBe(true);
+    expect(nonVision.images).toBeUndefined();
+    expect(nonVision.content).toContain("safe text");
+    expect(nonVision.content).toContain("selected model does not support vision");
+    expect(nonVision.content).toContain("unsupported content: 1 audio item, 1 resource item, 1 link item");
+    expect(nonVision.content).not.toContain(data);
+    expect(nonVision.content).not.toContain(secret);
+    expect(nonVision.content).not.toContain("token=");
+    expect(await attachmentEntries(rootDir)).toEqual([]);
+
+    const errored = await registry.execute(
+      { id: "error", name: "mcp_media_render", arguments: "{\"error\":true}" },
+      { rootDir, visionEnabled: true },
+    );
+    expect(errored.ok).toBe(false);
+    expect(errored.images).toBeUndefined();
+    expect(errored.content).toContain("the tool returned an error");
+    expect(await attachmentEntries(rootDir)).toEqual([]);
+  });
+
+  test("rejects malformed base64, MIME mismatches, unsupported MIME, and oversized images", async () => {
+    const pngData = Buffer.from(testPng()).toString("base64");
+    const oversized = Buffer.alloc(maxImageAttachmentBytes + 1).toString("base64");
+    const results: Record<string, Record<string, unknown>> = {
+      base64: { content: [{ type: "image", data: "not/base64", mimeType: "image/png" }] },
+      mismatch: { content: [{ type: "image", data: pngData, mimeType: "image/jpeg" }] },
+      unsupported: { content: [{ type: "image", data: pngData, mimeType: "image/svg+xml" }] },
+      oversized: { content: [{ type: "image", data: oversized, mimeType: "image/png" }] },
+    };
+    const { registry, rootDir } = await registryForResults((args) => results[String(args.case)]!);
+
+    const expected = {
+      base64: "not strict base64",
+      mismatch: "does not match the image bytes",
+      unsupported: "declared MIME type is unsupported",
+      oversized: "exceeds the 20 MiB limit",
+    } as const;
+    for (const [scenario, notice] of Object.entries(expected)) {
+      const result = await registry.execute(
+        { id: scenario, name: "mcp_media_render", arguments: JSON.stringify({ case: scenario }) },
+        { rootDir, visionEnabled: true },
+      );
+      expect(result.ok).toBe(true);
+      expect(result.images).toBeUndefined();
+      expect(result.content).toContain(notice);
+      expect(result.content).not.toContain(pngData);
+    }
+    expect(await attachmentEntries(rootDir)).toEqual([]);
+  });
+
+  test("does not persist an image when delivery is cancelled after the MCP response", async () => {
+    const data = Buffer.from(testPng()).toString("base64");
+    const { registry, rootDir } = await registryForResults(() => ({
+      content: [{ type: "image", data, mimeType: "image/png" }],
+    }));
+    const controller = new AbortController();
+    controller.abort(new DOMException("cancelled", "AbortError"));
+
+    await expect(registry.execute(
+      { id: "cancel", name: "mcp_media_render", arguments: "{}" },
+      { rootDir, visionEnabled: true, signal: controller.signal },
+    )).rejects.toMatchObject({ name: "AbortError" });
+    await expect(registry.execute(
+      { id: "cancel-non-vision", name: "mcp_media_render", arguments: "{}" },
+      { rootDir, visionEnabled: false, signal: controller.signal },
+    )).rejects.toMatchObject({ name: "AbortError" });
+    expect(await attachmentEntries(rootDir)).toEqual([]);
+  });
+
+  test("reports attachment write failures without exposing filesystem or image data", async () => {
+    const data = Buffer.from(testPng()).toString("base64");
+    const { registry, rootDir } = await registryForResults(() => ({
+      content: [{ type: "image", data, mimeType: "image/png" }],
+    }));
+    const invalidRoot = join(rootDir, "not-a-directory");
+    await writeFile(invalidRoot, "file", "utf8");
+
+    const result = await registry.execute(
+      { id: "write-failure", name: "mcp_media_render", arguments: "{}" },
+      { rootDir: invalidRoot, visionEnabled: true },
+    );
+    expect(result.ok).toBe(true);
+    expect(result.images).toBeUndefined();
+    expect(result.content).toContain("attachment could not be stored");
+    expect(result.content).not.toContain(invalidRoot);
+    expect(result.content).not.toContain(data);
+  });
+
+  test("caps host-derived attachment labels from untrusted MCP identifiers", async () => {
+    const rootDir = join(tmpdir(), `prism-vesicle-mcp-label-${crypto.randomUUID()}`);
+    const delivered = await deliverMcpToolResult({
+      text: [],
+      images: [{
+        kind: "image",
+        contentIndex: 0,
+        data: Buffer.from(testPng()).toString("base64"),
+        mimeType: "image/png",
+      }],
+      deferred: [],
+      diagnostics: [],
+      isError: false,
+    }, {
+      rootDir,
+      visionEnabled: true,
+      serverId: "s".repeat(512),
+      toolName: "t".repeat(512),
+    });
+
+    expect(delivered.images?.[0]?.filename?.length).toBeLessThanOrEqual(128);
+    expect(delivered.images?.[0]?.filename).toEndWith("-image-1.png");
+  });
+});
+
+async function registryForResults(
+  resultForArguments: (args: Record<string, unknown>) => Record<string, unknown>,
+): Promise<{ registry: Awaited<ReturnType<typeof createMcpRegistryForEngine>>; rootDir: string }> {
+  const rootDir = join(tmpdir(), `prism-vesicle-mcp-multimodal-${crypto.randomUUID()}`);
+  await mkdir(rootDir, { recursive: true });
+  await writeFile(join(rootDir, "mcp.yaml"), [
+    "servers:",
+    "  media:",
+    "    url: https://mcp.example.test/media/mcp",
+    "",
+  ].join("\n"), "utf8");
+  const fetchImpl = (async (_url, init) => {
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    if (body.method === "initialize") {
+      return Response.json({ jsonrpc: "2.0", id: body.id, result: { serverInfo: { name: "media" } } });
+    }
+    if (body.method === "notifications/initialized") return new Response("", { status: 202 });
+    if (body.method === "tools/list") {
+      return Response.json({ jsonrpc: "2.0", id: body.id, result: { tools: [{ name: "render" }] } });
+    }
+    if (body.method === "tools/call") {
+      const params = body.params as Record<string, unknown>;
+      const args = params.arguments as Record<string, unknown>;
+      return Response.json({ jsonrpc: "2.0", id: body.id, result: resultForArguments(args) });
+    }
+    throw new Error(`unexpected method ${String(body.method)}`);
+  }) as typeof fetch;
+  const env = { VESICLE_PROVIDERS_FILE: join(rootDir, "providers.yaml") };
+  return { registry: await createMcpRegistryForEngine("etl", { env, fetchImpl }), rootDir };
+}
+
+async function attachmentEntries(rootDir: string): Promise<string[]> {
+  return readdir(join(rootDir, ".vesicle", "attachments")).catch(() => []);
+}
+
+function testPng(): Uint8Array {
+  return Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0]);
+}

--- a/tests/integration/tools/mcp.test.ts
+++ b/tests/integration/tools/mcp.test.ts
@@ -6,7 +6,7 @@ import { McpStreamableHttpClient, parseSseEnvelopes } from "../../../src/mcp/cli
 import { parseMcpConfig } from "../../../src/mcp/config";
 import { createMcpRegistryForEngine } from "../../../src/mcp/registry";
 import { inspectMcpConfig } from "../../../src/mcp/registry";
-import { buildMcpToolAlias } from "../../../src/mcp/types";
+import { buildMcpToolAlias, normalizeMcpToolResult } from "../../../src/mcp/types";
 
 describe("MCP config", () => {
   test("defaults an existing mcp.yaml to enabled with minimal server fields", () => {
@@ -105,6 +105,62 @@ describe("MCP alias helpers", () => {
     expect(alias.length).toBeLessThanOrEqual(64);
     expect(alias).toMatch(/_[a-f0-9]{8}$/);
   });
+
+  test("normalizes ordered content kinds without retaining deferred payload bodies", () => {
+    const normalized = normalizeMcpToolResult({
+      content: [
+        { type: "text", text: " first " },
+        { type: "image", data: "aW1hZ2U=", mimeType: "image/png", filename: "remote.png" },
+        { type: "text", text: "second" },
+        { type: "audio", data: "c2VjcmV0", mimeType: "audio/wav" },
+        { type: "resource", resource: { uri: "file:///private/path", mimeType: "text/plain", text: "secret body" } },
+        { type: "resource_link", uri: "https://user:pass@example.test/private?token=secret", name: "private" },
+        { type: "future_binary", data: "must-not-survive" },
+      ],
+      structuredContent: { count: 2 },
+    });
+
+    expect(normalized.text).toEqual(["first", "second"]);
+    expect(normalized.structuredContent).toEqual({ count: 2 });
+    expect(normalized.images).toEqual([{
+      kind: "image",
+      contentIndex: 1,
+      data: "aW1hZ2U=",
+      mimeType: "image/png",
+    }]);
+    expect(normalized.deferred).toEqual([
+      { kind: "audio", contentIndex: 3, mimeType: "audio/wav" },
+      { kind: "resource", contentIndex: 4, mimeType: "text/plain", scheme: "file", hasText: true, hasBlob: false },
+      { kind: "link", contentIndex: 5, scheme: "https" },
+    ]);
+    expect(normalized.diagnostics).toEqual([{
+      contentIndex: 6,
+      code: "unknown-content-type",
+      declaredType: "future_binary",
+    }]);
+    expect(JSON.stringify(normalized.deferred)).not.toContain("secret");
+    expect(JSON.stringify(normalized.diagnostics)).not.toContain("must-not-survive");
+  });
+
+  test("diagnoses malformed result envelopes without misclassifying empty text or resources", () => {
+    const normalized = normalizeMcpToolResult({
+      content: [
+        { type: "text", text: "  " },
+        { type: "resource", resource: "private body" },
+      ],
+    });
+
+    expect(normalized.text).toEqual([]);
+    expect(normalized.deferred).toEqual([]);
+    expect(normalized.diagnostics).toEqual([{
+      contentIndex: 1,
+      code: "invalid-content-item",
+      declaredType: "resource",
+    }]);
+    expect(normalizeMcpToolResult({ content: "private body" }).diagnostics).toEqual([{
+      code: "invalid-response",
+    }]);
+  });
 });
 
 describe("Streamable HTTP MCP client", () => {
@@ -174,7 +230,10 @@ describe("Streamable HTTP MCP client", () => {
       { name: "fetch_url", inputSchema: { type: "object", properties: { url: { type: "string" } } } },
     ]);
     expect(await client.callTool("fetch_url", { url: "https://example.test" })).toEqual({
-      content: "fetched page",
+      text: ["fetched page"],
+      images: [],
+      deferred: [],
+      diagnostics: [],
       isError: false,
     });
     expect(requests.map((request) => request.session)).toEqual([
@@ -269,18 +328,22 @@ describe("MCP registry", () => {
     expect(etl.definitions[0].function.description).toBe("[MCP/math] Add numbers");
     expect(runtime.definitions).toEqual([]);
 
-    const result = await etl.execute({ id: "call-1", name: "mcp_math_add", arguments: "{\"a\":1,\"b\":2}" });
+    const result = await etl.execute(
+      { id: "call-1", name: "mcp_math_add", arguments: "{\"a\":1,\"b\":2}" },
+      { rootDir: configDir, visionEnabled: false },
+    );
     expect(result).toMatchObject({
       callId: "call-1",
       name: "mcp_math_add",
       ok: true,
-      content: "{\"sum\":3}",
+      content: "MCP tool returned structured content.",
       mcpEvent: {
         kind: "mcp_tool",
         serverId: "math",
         alias: "mcp_math_add",
         toolName: "add",
         isError: false,
+        hasStructuredContent: true,
       },
     });
   });


### PR DESCRIPTION
## Summary

Implements the typed MCP multimodal result boundary from #175.

- replaces raw MCP `content`/base64 JSON fallback with ordered text, structured-content presence, inline image candidates, deferred media/reference candidates, and bounded payload-free diagnostics
- validates inline PNG/JPEG/GIF/WebP with strict canonical base64, a shared provisional 20 MiB decoded limit, declared MIME versus magic bytes, and host-derived bounded labels before using the existing content-addressed attachment store
- gates image delivery on the selected model's vision capability across normal rounds, MANUAL continuations, and SubAgents; error, cancellation, invalid, non-vision, and write-failure paths never leak or persist image payloads
- persists only `source: "mcp"` attachment references through JSONL, resume, and compact projection, while materializing bytes only on provider-request copies
- documents the runtime/session/tool contract and synchronizes the bundled `vesicle-docs` mirrors

Resources, audio, URL/link fetching, stdio or modern MCP transport work (#174), and generic result spill/descriptors (#137) remain out of scope.

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun test` (1,891 pass, 6 skip, 0 fail; 1,897 tests across 239 files)
- `bun run doctor`
- `bun run skills:docs:check`
- `git diff --check`
- focused MCP/agent/session/provider suites

Real Streamable HTTP acceptance used the configured `prts_wiki` 2.5.0 server: initialize, 24-tool discovery, `operator_artwork` list/get, one normalized PNG, a 72,145-byte content-addressed write, MIME/size integrity verification, and reference-only metadata without base64.

Closes #175
