### PR TITLE
fix(mcp): Bot Review Blocking + Should-fix on #178

### DIFF
--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -17,7 +17,7 @@ Config lives at the user-level `mcp.yaml` beside `providers.yaml`; set `VESICLE_
 - Secrets are expanded from the same sibling `.env` file used by provider and Tavily keys.
 - `transport: streamable-http` and `transport: http` both select the Streamable HTTP client.
 - `negotiation` accepts `legacy`, `modern`, or `auto`. Absent normalizes to `legacy` (no probe, unchanged wire behavior).
-- `protocolVersion` is the legacy revision pin (default `2025-03-26`). It does not select the era.
+- `protocolVersion` is the configured legacy revision (default `2025-03-26`). It does not select the era. The SDK negotiates its own latest legacy revision (`2025-11-25`) during the `initialize` handshake; the configured value is informational and does not override the SDK's negotiation.
 - `supportedProtocolVersions` is an optional modern offer list (default `["2026-07-28"]`). It must contain at least one Vesicle-supported modern revision.
 - `includeTools` and `excludeTools` match either the remote tool name or the Vesicle alias.
 - `enabledEngines` can scope a server to specific Prism engines.

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -2,10 +2,6 @@ import { isRecord } from "./types";
 
 type JsonRpcEnvelope = Record<string, unknown>;
 
-export type McpClientOptions = {
-  fetchImpl?: typeof fetch;
-};
-
 /**
  * Incremental SSE envelope parser used by test fixtures and protocol
  * utilities. Production HTTP/SSE handling is owned by the SDK transport

--- a/src/mcp/connection.ts
+++ b/src/mcp/connection.ts
@@ -170,6 +170,10 @@ function makeConnection(
         }
         // SDK strict validation may reject content Vesicle accepts; fall back
         // to the raw result captured by the fetch wrapper (if available).
+        if (rawHolder.result !== undefined) return rejectInputRequired(rawHolder.result);
+        // Non-validation errors (e.g. JSON-RPC error from server) must surface
+        // their original message rather than a generic placeholder (Bot Review Should-fix).
+        throw error;
       }
       // Prefer the raw result (preserves items stripped by sanitizer for
       // Vesicle's lenient normalization); fall back to the SDK result for
@@ -178,18 +182,7 @@ function makeConnection(
       if (resultToNormalize === undefined) {
         throw new McpError(`MCP server ${config.id} returned no processable tools/call result.`);
       }
-      // Reject modern input_required (MRTR) with a stable unsupported-capability
-      // error — no retry, no side effect, never reported as success.
-      if (isRecord(resultToNormalize) && resultToNormalize.resultType === "input_required") {
-        return {
-          text: [],
-          images: [],
-          deferred: [],
-          diagnostics: [{ code: "invalid-response" }],
-          isError: true,
-        };
-      }
-      return normalizeMcpToolResult(resultToNormalize);
+      return rejectInputRequired(resultToNormalize);
     },
     async close(): Promise<void> {
       await safeClose(currentClient);
@@ -221,7 +214,7 @@ function createTransport(config: McpServerConfig, options: McpConnectionOptions,
   const baseFetch = options.fetchImpl ?? fetch;
   const transportOptions: ConstructorParameters<typeof StreamableHTTPClientTransport>[1] = {
     requestInit: { headers: config.headers },
-    fetch: ((input: RequestInfo | URL, init?: RequestInit) => sanitizeContentResponse(baseFetch, rawHolder, input, init)) as typeof fetch,
+    fetch: ((input: RequestInfo | URL, init?: RequestInit) => sanitizeContentResponse(baseFetch, rawHolder, config, input, init)) as typeof fetch,
   };
   return new StreamableHTTPClientTransport(url, transportOptions);
 }
@@ -235,16 +228,36 @@ function createTransport(config: McpServerConfig, options: McpConnectionOptions,
  * when the SDK accepts it, the raw result is still preferred to preserve items
  * the sanitizer stripped for SDK compliance.
  */
-/** Safety bound on response body bytes read by the sanitizer (§7.3). */
+/**
+ * The fetch wrapper enforces the configured per-server timeout (Blocking fix
+ * for Bot Review: the old client used setTimeoutController on every request),
+ * captures the raw tools/call result before SDK Zod validation, and sanitizes
+ * content items the SDK would reject. Only tools/call responses are captured
+ * to prevent cross-contamination of overlapping requests.
+ */
 const maxSanitizerResponseBytes = 32 * 1024 * 1024;
 
 async function sanitizeContentResponse(
   baseFetch: typeof fetch,
   rawHolder: RawResultHolder,
+  config: McpServerConfig,
   input: RequestInfo | URL,
   init?: RequestInit,
 ): Promise<Response> {
-  const response = await baseFetch(input, init);
+  // Enforce configured timeout on every HTTP request (Bot Review Blocking fix).
+  const callerSignal = init?.signal;
+  const timeoutMs = Math.max(1, config.timeoutSeconds) * 1000;
+  const timeoutController = new AbortController();
+  const timeoutHandle = setTimeout(() => timeoutController.abort(), timeoutMs);
+  const combinedSignal = callerSignal
+    ? AbortSignal.any([callerSignal, timeoutController.signal])
+    : timeoutController.signal;
+  let response: Response;
+  try {
+    response = await baseFetch(input, { ...init, signal: combinedSignal });
+  } finally {
+    clearTimeout(timeoutHandle);
+  }
   if (!response.ok) return response;
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.includes("application/json")) return response;
@@ -264,7 +277,10 @@ async function sanitizeContentResponse(
   if (!isRecord(parsed) || !("result" in parsed)) return new Response(text, { status: response.status, headers: response.headers });
   const result = parsed.result;
   if (!isRecord(result)) return new Response(text, { status: response.status, headers: response.headers });
-  rawHolder.result = result;
+  // Only capture tools/call results to prevent cross-contamination (Bot Review Should-fix).
+  if (isToolsCallRequest(init?.body)) {
+    rawHolder.result = result;
+  }
   if (!Array.isArray(result.content)) return new Response(text, { status: response.status, headers: response.headers });
   const sanitized = result.content.filter((item: unknown) => isRecord(item) && passesSdkContentValidation(item));
   if (sanitized.length === result.content.length) return new Response(text, { status: response.status, headers: response.headers });
@@ -272,6 +288,16 @@ async function sanitizeContentResponse(
     status: response.status,
     headers: { "content-type": "application/json" },
   });
+}
+
+function isToolsCallRequest(body: BodyInit | null | undefined): boolean {
+  if (typeof body !== "string") return false;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    return isRecord(parsed) && parsed.method === "tools/call";
+  } catch {
+    return false;
+  }
 }
 
 const knownContentTypes = new Set(["text", "image", "audio", "resource", "resource_link"]);
@@ -383,4 +409,22 @@ async function safeClose(client: Client): Promise<void> {
  */
 function abortReason(signal: AbortSignal): unknown {
   return signal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+}
+
+/**
+ * Reject modern input_required (MRTR) with a stable unsupported-capability
+ * error — no retry, no side effect, never reported as success. Otherwise
+ * normalize normally.
+ */
+function rejectInputRequired(raw: unknown): McpToolCallResult {
+  if (isRecord(raw) && raw.resultType === "input_required") {
+    return {
+      text: [],
+      images: [],
+      deferred: [],
+      diagnostics: [{ code: "invalid-response" }],
+      isError: true,
+    };
+  }
+  return normalizeMcpToolResult(raw);
 }

--- a/src/mcp/registry.ts
+++ b/src/mcp/registry.ts
@@ -172,7 +172,7 @@ async function buildRegistry(
         toolCount: 0,
         negotiation: server.negotiation,
         era: connection.info.era,
-        failureKind: "legacy-handshake",
+        failureKind: connection.info.era === "modern" ? "protocol" : "legacy-handshake",
         error: error instanceof Error ? error.message : String(error),
       });
     }


### PR DESCRIPTION
## Summary

Fix-forward for the Bot Review Blocking and Should-fix findings on #178 (already merged to `develop`).

### 🔴 Blocking fix

- **`config.timeoutSeconds` wired into every HTTP request.** The fetch wrapper now creates an `AbortSignal.timeout(config.timeoutSeconds * 1000)` and combines it with the caller's signal via `AbortSignal.any`. The old hand-written client enforced this on every request via `setTimeoutController`; the SDK-backed connection had silently dropped it.

### 🟡 Should-fix

- **Server error messages surface correctly.** When `callTool` fails with a non-validation error (e.g. JSON-RPC `-32602`), the original error is rethrown instead of the generic "returned no processable result" placeholder.
- **`rawHolder.result` capture restricted to `tools/call` responses.** The fetch wrapper now inspects the request body's `method` field and only captures results for `tools/call`, preventing cross-contamination if requests overlap.
- **`protocolVersion` documentation corrected.** The SDK negotiates its own latest legacy revision (`2025-11-25`) during `initialize`; the configured value is informational and does not override SDK negotiation.

### ⚪ Nits

- Removed dead `McpClientOptions` export from `client.ts`.
- Post-connect `failureKind` derived from era (`modern → protocol`, `legacy → legacy-handshake`) instead of hardcoded.
- Consolidated `input_required` rejection into a `rejectInputRequired` helper used by both success and fallback paths.

### About #179

PR #179 (revert of #178) should be **closed without merging**. This fix-forward PR addresses all Blocking/Should-fix findings on top of the already-merged #178, which is cleaner than revert + remerge.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` (1912 pass, 10 skip, 0 fail)
- [x] `bun run skills:docs:check`
- [x] Real-server acceptance on `quickquip-v4` (legacy PRTS Wiki + modern autotel-mcp 0.4.1 + auto negotiation + mixed Registry — all passed pre-fix; timeout fix is mechanical)