### PR TITLE
fix(skills): consume VESICLE_HOST_CONFIG_DIR and mask .env comment secrets

### DIFF
--- a/src/cli/commands/config/show.ts
+++ b/src/cli/commands/config/show.ts
@@ -88,9 +88,9 @@ async function showEnvSanitized(): Promise<void> {
       continue;
     }
     if (trimmed.startsWith("#")) {
-      // Mask comment lines that contain a KEY= pattern — a commented-out
-      // credential assignment (e.g. # OPENAI_API_KEY=sk-...) is a common
-      // .env pattern and must not leak through the sanitization boundary.
+      // Conservatively mask any comment containing "=" — a commented-out
+      // credential assignment (e.g. # OPENAI_API_KEY=sk-...) must not leak
+      // through the sanitization boundary.
       console.log(trimmed.includes("=") ? "<comment>" : raw);
       continue;
     }

--- a/src/cli/commands/config/show.ts
+++ b/src/cli/commands/config/show.ts
@@ -83,8 +83,15 @@ async function showEnvSanitized(): Promise<void> {
   console.log("");
   for (const raw of source.split(/\r?\n/)) {
     const trimmed = raw.trim();
-    if (!trimmed || trimmed.startsWith("#")) {
+    if (!trimmed) {
       console.log(raw);
+      continue;
+    }
+    if (trimmed.startsWith("#")) {
+      // Mask comment lines that contain a KEY= pattern — a commented-out
+      // credential assignment (e.g. # OPENAI_API_KEY=sk-...) is a common
+      // .env pattern and must not leak through the sanitization boundary.
+      console.log(trimmed.includes("=") ? "<comment>" : raw);
       continue;
     }
     const equals = trimmed.indexOf("=");

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -5,6 +5,9 @@ import { dirname, join } from "node:path";
 export function userConfigDirectory(env: NodeJS.ProcessEnv = process.env): string {
   if (env.VESICLE_PROVIDERS_FILE) return dirname(env.VESICLE_PROVIDERS_FILE);
   if (env.VESICLE_CONFIG_DIR) return env.VESICLE_CONFIG_DIR;
+  // Host-injected resolved value, only present in filtered run_skill_script
+  // child environments where the explicit overrides above have been stripped.
+  if (env.VESICLE_HOST_CONFIG_DIR) return env.VESICLE_HOST_CONFIG_DIR;
   if (env.APPDATA) return join(env.APPDATA, "prism-vesicle");
   if (env.XDG_CONFIG_HOME) return join(env.XDG_CONFIG_HOME, "prism-vesicle");
   return join(homedir(), ".config", "prism-vesicle");

--- a/tests/integration/cli/config.test.ts
+++ b/tests/integration/cli/config.test.ts
@@ -12,8 +12,8 @@ import { runCli, seedProvidersConfig, withTempProject } from "./support";
 describe("vesicle config CLI", () => {
   test("config path honors VESICLE_HOST_CONFIG_DIR when explicit overrides are absent", async () => {
     await withTempProject("vesicle-config-hostdir-", async (projectDir, configDir) => {
-      // Simulate a run_skill_script child: no VESICLE_CONFIG_DIR, no APPDATA,
-      // no XDG_CONFIG_HOME — only the Host-injected resolved value.
+      // No explicit VESICLE_CONFIG_DIR; VESICLE_HOST_CONFIG_DIR must win
+      // over any passed-through platform defaults (APPDATA, HOME).
       const result = await runCli(["config", "path"], {
         cwd: projectDir,
         env: { VESICLE_HOST_CONFIG_DIR: configDir },

--- a/tests/integration/cli/config.test.ts
+++ b/tests/integration/cli/config.test.ts
@@ -10,6 +10,36 @@ import { runCli, seedProvidersConfig, withTempProject } from "./support";
  * resulting config files.
  */
 describe("vesicle config CLI", () => {
+  test("config path honors VESICLE_HOST_CONFIG_DIR when explicit overrides are absent", async () => {
+    await withTempProject("vesicle-config-hostdir-", async (projectDir, configDir) => {
+      // Simulate a run_skill_script child: no VESICLE_CONFIG_DIR, no APPDATA,
+      // no XDG_CONFIG_HOME — only the Host-injected resolved value.
+      const result = await runCli(["config", "path"], {
+        cwd: projectDir,
+        env: { VESICLE_HOST_CONFIG_DIR: configDir },
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(configDir);
+    });
+  });
+
+  test("show env masks comment lines containing KEY= patterns", async () => {
+    await withTempProject("vesicle-config-comment-", async (projectDir, configDir) => {
+      await writeFile(join(configDir, ".env"), [
+        "ACTIVE_KEY=value",
+        "# OPENAI_API_KEY=sk-commented-out-secret",
+        "# This is a plain comment without equals",
+        "",
+      ].join("\n"), "utf8");
+      const result = await runCli(["config", "show", "env"], { cwd: projectDir, configDir });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain("sk-commented-out-secret");
+      expect(result.stdout).toContain("<comment>");
+      expect(result.stdout).toContain("# This is a plain comment without equals");
+      expect(result.stdout).toContain("ACTIVE_KEY=<set>");
+    });
+  });
+
   test("config path prints the resolved config directory", async () => {
     await withTempProject("vesicle-config-path-", async (projectDir, configDir) => {
       const result = await runCli(["config", "path"], { cwd: projectDir, configDir });

--- a/tests/integration/cli/support.ts
+++ b/tests/integration/cli/support.ts
@@ -39,21 +39,25 @@ const PASSTHROUGH_ENV = [
   "TMP",
 ];
 
-function buildChildEnv(configDir: string): Record<string, string> {
+function buildChildEnv(configDir: string | undefined, extra?: Record<string, string>): Record<string, string> {
   const env: Record<string, string> = {};
   for (const key of PASSTHROUGH_ENV) {
     const value = process.env[key];
     if (value !== undefined) env[key] = value;
   }
-  env.VESICLE_CONFIG_DIR = configDir;
+  if (configDir !== undefined) env.VESICLE_CONFIG_DIR = configDir;
+  if (extra) Object.assign(env, extra);
   return env;
 }
 
 export type CliRunOptions = {
   cwd: string;
-  configDir: string;
+  /** Isolated config directory. Omit to skip setting VESICLE_CONFIG_DIR. */
+  configDir?: string;
   /** Extra argv after the command path (e.g. ["--dangerously-skip-permissions"]). */
   extra?: string[];
+  /** Extra environment variables merged into the child env (overrides defaults). */
+  env?: Record<string, string>;
 };
 
 export type CliRunResult = {
@@ -73,7 +77,7 @@ export async function runCli(args: string[], options: CliRunOptions): Promise<Cl
     cwd: options.cwd,
     stdout: "pipe",
     stderr: "pipe",
-    env: buildChildEnv(options.configDir),
+    env: buildChildEnv(options.configDir, options.env),
     signal: AbortSignal.timeout(30_000),
   });
   const [stdout, stderr, exitCode] = await Promise.all([


### PR DESCRIPTION
## Summary

Fixes Bot Review round 2 findings on the merged #191 (update-config Skill).

- **`userConfigDirectory()` consumes `VESICLE_HOST_CONFIG_DIR`** (`src/config/paths.ts`): the variable was injected into `run_skill_script` children by #191 but never read, so wrapper-spawned `vesicle config` subprocesses resolved the wrong config directory on Windows and with env overrides — the filtered child env strips `VESICLE_CONFIG_DIR`/`APPDATA`/`XDG_CONFIG_HOME`, leaving only the Host-injected value. Now honored after `VESICLE_PROVIDERS_FILE`/`VESICLE_CONFIG_DIR`.
- **`show env` masks comment lines containing `KEY=` patterns** (`src/cli/commands/config/show.ts`): commented-out credentials (`# OPENAI_API_KEY=sk-...`) were echoed verbatim through the sanitization boundary. Now masked as `<comment>`; plain comments without `=` are preserved.

## Test Plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun test` — 1976 pass / 10 skip / 0 fail
- [x] New tests: VESICLE_HOST_CONFIG_DIR consumption in filtered child env (no VESICLE_CONFIG_DIR), comment-with-equals masking
- [x] Test support module extended (optional configDir, extra env vars)

## Notes

- The Style Review's architectural items (atomicWrite consolidation, cross-layer domain ownership, validateProviderEntry schema export) remain deferred to a separate refactor.