### PR TITLE
refactor(config): single-owner write primitives and schema validation

### DIFF
--- a/src/cli/commands/config/add-model.ts
+++ b/src/cli/commands/config/add-model.ts
@@ -1,13 +1,10 @@
 // vesicle config add-model — append a model to an existing provider.
-// Validates the JSON entry, ensures the model id is unique within the provider,
-// serializes the registry, and writes atomically. Full re-parse validation after write.
+// The JSON entry is validated by the canonical validator in config/providers
+// (single owner of model-entry shape), the model id must be unique within the
+// provider, and the write goes through the shared registry pipeline.
 
-import { mkdir, rename, rm, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { dirname } from "node:path";
-import { loadProviderRegistry, providerConfigPathFromEnv, parseProviderConfig } from "../../../config/providers";
-import type { ProviderModelProfile } from "../../../config/providers";
-import { serializeProviderRegistry } from "../../../setup/config-writer";
+import { loadProviderRegistry, validateModelEntryShape } from "../../../config/providers";
+import { writeProviderRegistry } from "../../../setup/config-writer";
 
 type AddModelResult = {
   ok: true;
@@ -31,10 +28,15 @@ export async function runAddModel(args: string[]): Promise<void> {
     process.exitCode = 1;
     return;
   }
+  if (args.length !== jsonFlag + 2) {
+    console.error("Unexpected extra arguments. Usage: vesicle config add-model <provider-id> --json '<entry>'");
+    process.exitCode = 1;
+    return;
+  }
   const jsonStr = args[jsonFlag + 1]!;
-  let entry: Record<string, unknown>;
+  let entry: unknown;
   try {
-    entry = JSON.parse(jsonStr) as Record<string, unknown>;
+    entry = JSON.parse(jsonStr);
   } catch {
     console.error("Invalid JSON. Provide a valid JSON object as the --json argument.");
     process.exitCode = 1;
@@ -50,8 +52,8 @@ export async function runAddModel(args: string[]): Promise<void> {
   }
 }
 
-async function addModel(providerId: string, entry: Record<string, unknown>): Promise<AddModelResult> {
-  const model = validateModelEntry(entry);
+async function addModel(providerId: string, entry: unknown): Promise<AddModelResult> {
+  const model = validateModelEntryShape(entry);
   const registry = await loadProviderRegistry();
   const provider = registry.providers.find((entry) => entry.id === providerId);
   if (!provider) {
@@ -63,16 +65,7 @@ async function addModel(providerId: string, entry: Record<string, unknown>): Pro
 
   provider.models.push(model);
 
-  const path = providerConfigPathFromEnv();
-  const source = serializeProviderRegistry(registry);
-
-  // Validate the serialized output by re-parsing. This catches schema violations
-  // that the entry validation missed (e.g. profile-specific model constraints).
-  parseProviderConfig(source, path, process.env);
-
-  await atomicWrite(path, source);
-  // Verify round-trip.
-  await loadProviderRegistry();
+  const path = await writeProviderRegistry(registry);
 
   return {
     ok: true,
@@ -82,144 +75,4 @@ async function addModel(providerId: string, entry: Record<string, unknown>): Pro
     path,
     restartRequired: true,
   };
-}
-
-function validateModelEntry(entry: Record<string, unknown>): ProviderModelProfile {
-  const allowedKeys = new Set(["id", "generation", "capabilities", "limits"]);
-  for (const key of Object.keys(entry)) {
-    if (!allowedKeys.has(key)) {
-      throw new Error(`Unknown model entry field "${key}". Allowed: ${[...allowedKeys].join(", ")}.`);
-    }
-  }
-
-  const id = requireString(entry, "id");
-  if (!/^[^\s]+$/.test(id)) {
-    throw new Error(`Model id "${id}" must not contain whitespace.`);
-  }
-
-  const model: ProviderModelProfile = { id };
-
-  if (entry.generation !== undefined) {
-    model.generation = validateGeneration(entry.generation);
-  }
-  if (entry.capabilities !== undefined) {
-    model.capabilities = validateCapabilities(entry.capabilities);
-  }
-  if (entry.limits !== undefined) {
-    model.limits = validateLimits(entry.limits);
-  }
-
-  return model;
-}
-
-function validateGeneration(value: unknown): NonNullable<ProviderModelProfile["generation"]> {
-  if (!value || typeof value !== "object") {
-    throw new Error("generation must be an object.");
-  }
-  const result: NonNullable<ProviderModelProfile["generation"]> = {};
-  const source = value as Record<string, unknown>;
-  if (source.temperature !== undefined) {
-    result.temperature = readFiniteNumber(source.temperature, "temperature");
-  }
-  if (source.maxTokens !== undefined) {
-    result.maxTokens = readPositiveInteger(source.maxTokens, "maxTokens");
-  }
-  return result;
-}
-
-function validateCapabilities(value: unknown): NonNullable<ProviderModelProfile["capabilities"]> {
-  if (!value || typeof value !== "object") {
-    throw new Error("capabilities must be an object.");
-  }
-  const validKeys = new Set(["streaming", "tools", "reasoningTier", "reasoningContent", "temperature", "maxTokens", "vision", "remoteCompact"]);
-  const result: NonNullable<ProviderModelProfile["capabilities"]> = {};
-  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-    if (!validKeys.has(key)) {
-      throw new Error(`Unknown capability "${key}". Allowed: ${[...validKeys].join(", ")}.`);
-    }
-    if (typeof val !== "boolean") {
-      throw new Error(`Capability "${key}" must be true or false.`);
-    }
-    (result as Record<string, boolean>)[key] = val;
-  }
-  return result;
-}
-
-function validateLimits(value: unknown): NonNullable<ProviderModelProfile["limits"]> {
-  if (!value || typeof value !== "object") {
-    throw new Error("limits must be an object.");
-  }
-  const source = value as Record<string, unknown>;
-  const result: NonNullable<ProviderModelProfile["limits"]> = {};
-  if (source.contextWindow !== undefined) {
-    result.contextWindow = readPositiveInteger(source.contextWindow, "contextWindow");
-  }
-  if (source.maxOutputTokens !== undefined) {
-    result.maxOutputTokens = readPositiveInteger(source.maxOutputTokens, "maxOutputTokens");
-  }
-  if (source.autoCompact !== undefined) {
-    result.autoCompact = validateAutoCompact(source.autoCompact);
-  }
-  return result;
-}
-
-function validateAutoCompact(value: unknown): NonNullable<NonNullable<ProviderModelProfile["limits"]>["autoCompact"]> {
-  if (!value || typeof value !== "object") {
-    throw new Error("autoCompact must be an object.");
-  }
-  const source = value as Record<string, unknown>;
-  const result: NonNullable<NonNullable<ProviderModelProfile["limits"]>["autoCompact"]> = {};
-  if (source.enabled !== undefined) {
-    if (typeof source.enabled !== "boolean") {
-      throw new Error("autoCompact.enabled must be true or false.");
-    }
-    result.enabled = source.enabled;
-  }
-  if (source.threshold !== undefined) {
-    result.threshold = readFraction(source.threshold, "autoCompact.threshold");
-  }
-  if (source.reserveOutputTokens !== undefined) {
-    result.reserveOutputTokens = readPositiveInteger(source.reserveOutputTokens, "autoCompact.reserveOutputTokens");
-  }
-  return result;
-}
-
-function requireString(entry: Record<string, unknown>, field: string): string {
-  const value = entry[field];
-  if (typeof value !== "string" || !value.trim()) {
-    throw new Error(`Model entry requires a non-empty "${field}" string.`);
-  }
-  return value.trim();
-}
-
-function readFiniteNumber(value: unknown, field: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    throw new Error(`${field} must be a finite number.`);
-  }
-  return value;
-}
-
-function readPositiveInteger(value: unknown, field: string): number {
-  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
-    throw new Error(`${field} must be a positive integer.`);
-  }
-  return value;
-}
-
-function readFraction(value: unknown, field: string): number {
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0 || value >= 1) {
-    throw new Error(`${field} must be a number greater than 0 and less than 1.`);
-  }
-  return value;
-}
-
-async function atomicWrite(path: string, content: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const staging = `${path}.staging-${randomUUID()}`;
-  try {
-    await writeFile(staging, content, { encoding: "utf8", flag: "wx", mode: 0o644 });
-    await rename(staging, path);
-  } finally {
-    await rm(staging, { force: true });
-  }
 }

--- a/src/cli/commands/config/add-model.ts
+++ b/src/cli/commands/config/add-model.ts
@@ -16,24 +16,13 @@ type AddModelResult = {
 };
 
 export async function runAddModel(args: string[]): Promise<void> {
-  if (args.length < 1) {
+  if (args.length !== 3 || args[1] !== "--json") {
     console.error("Usage: vesicle config add-model <provider-id> --json '<entry>'");
     process.exitCode = 1;
     return;
   }
   const providerId = args[0]!;
-  const jsonFlag = args.indexOf("--json");
-  if (jsonFlag === -1 || jsonFlag + 1 >= args.length) {
-    console.error("Usage: vesicle config add-model <provider-id> --json '<entry>'");
-    process.exitCode = 1;
-    return;
-  }
-  if (args.length !== jsonFlag + 2) {
-    console.error("Unexpected extra arguments. Usage: vesicle config add-model <provider-id> --json '<entry>'");
-    process.exitCode = 1;
-    return;
-  }
-  const jsonStr = args[jsonFlag + 1]!;
+  const jsonStr = args[2]!;
   let entry: unknown;
   try {
     entry = JSON.parse(jsonStr);

--- a/src/cli/commands/config/add.ts
+++ b/src/cli/commands/config/add.ts
@@ -3,12 +3,12 @@
 // canonical serializer, writes atomically, and creates the empty .env slot for
 // the provider's apiKeyEnv. Full re-parse validation after write.
 
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { loadProviderRegistry, providerConfigPathFromEnv, parseProviderConfig, parseEnvFile } from "../../../config/providers";
 import type { ProviderProfile, ProviderModelProfile } from "../../../config/providers";
 import { serializeProviderRegistry, setEnvValues } from "../../../setup/config-writer";
+import { atomicWrite } from "../../../config/atomic-write";
 
 type AddResult = {
   ok: true;
@@ -75,9 +75,9 @@ async function addProvider(entry: Record<string, unknown>): Promise<AddResult> {
   const keyAlreadyExists = fileEnv[profile.apiKeyEnv] !== undefined;
   if (!keyAlreadyExists) {
     const updatedEnv = setEnvValues(existingEnv, { [profile.apiKeyEnv]: "" });
-    await atomicWrite(envPath, updatedEnv, true);
+    await atomicWrite(envPath, updatedEnv, 0o600);
   }
-  await atomicWrite(providerPath, source, false);
+  await atomicWrite(providerPath, source);
 
   return {
     ok: true,
@@ -187,17 +187,6 @@ async function readEnvFile(path: string): Promise<string> {
   } catch (error) {
     if (isEnoent(error)) return "";
     throw error;
-  }
-}
-
-async function atomicWrite(path: string, content: string, secret: boolean): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const staging = `${path}.staging-${randomUUID()}`;
-  try {
-    await writeFile(staging, content, { encoding: "utf8", flag: "wx", mode: secret ? 0o600 : 0o644 });
-    await rename(staging, path);
-  } finally {
-    await rm(staging, { force: true });
   }
 }
 

--- a/src/cli/commands/config/env.ts
+++ b/src/cli/commands/config/env.ts
@@ -3,11 +3,11 @@
 // empty slots, manages the proxy URL, or removes variables. The user fills in
 // actual secret values by editing .env directly.
 
-import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { providerConfigPathFromEnv, parseEnvFile } from "../../../config/providers";
 import { setEnvValues } from "../../../setup/config-writer";
+import { atomicWrite } from "../../../config/atomic-write";
 
 type EnvResult = {
   ok: true;
@@ -94,7 +94,7 @@ async function setEnvKey(key: string, value: string): Promise<EnvResult> {
   const envPath = envFilePath();
   const existing = await readEnvFile(envPath);
   const updated = setEnvValues(existing, { [key]: value });
-  await atomicWrite(envPath, updated, true);
+  await atomicWrite(envPath, updated, 0o600);
   const summary = value === ""
     ? `${key} created with empty value. Edit ${envPath} and paste the value after the = sign, then restart Vesicle.`
     : key === "VESICLE_PROVIDER_PROXY"
@@ -123,7 +123,7 @@ async function removeEnvKey(key: string): Promise<EnvResult> {
     return match?.[1] !== key;
   });
   const updated = filtered.join("\n");
-  await atomicWrite(envPath, updated, true);
+  await atomicWrite(envPath, updated, 0o600);
   return { ok: true, operation: "env-remove", key, path: envPath, summary: `${key} removed. Restart Vesicle to apply.`, restartRequired: true };
 }
 
@@ -153,17 +153,6 @@ function maskProxyUrl(url: string): string {
     return `${parsed.protocol}//${auth}${parsed.host}`;
   } catch {
     return "<invalid-url>";
-  }
-}
-
-async function atomicWrite(path: string, content: string, secret: boolean): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const staging = `${path}.staging-${randomUUID()}`;
-  try {
-    await writeFile(staging, content, { encoding: "utf8", flag: "wx", mode: secret ? 0o600 : 0o644 });
-    await rename(staging, path);
-  } finally {
-    await rm(staging, { force: true });
   }
 }
 

--- a/src/cli/commands/config/remove.ts
+++ b/src/cli/commands/config/remove.ts
@@ -3,11 +3,8 @@
 // cannot be removed without first switching it, and the global default provider
 // cannot be removed without first switching the default.
 
-import { mkdir, rename, rm, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { dirname } from "node:path";
-import { loadProviderRegistry, providerConfigPathFromEnv, parseProviderConfig } from "../../../config/providers";
-import { serializeProviderRegistry } from "../../../setup/config-writer";
+import { loadProviderRegistry } from "../../../config/providers";
+import { writeProviderRegistry } from "../../../setup/config-writer";
 import { loadExperimentalQualitySettings } from "../../../config/quality";
 
 type RemoveModelResult = {
@@ -87,12 +84,7 @@ async function removeModel(providerId: string, modelId: string): Promise<RemoveM
 
   provider.models.splice(modelIndex, 1);
 
-  const path = providerConfigPathFromEnv();
-  const source = serializeProviderRegistry(registry);
-  parseProviderConfig(source, path, process.env);
-
-  await atomicWrite(path, source);
-  await loadProviderRegistry();
+  const path = await writeProviderRegistry(registry);
 
   return { ok: true, operation: "remove-model", providerId, modelId, path, restartRequired: true };
 }
@@ -120,23 +112,7 @@ async function removeProvider(providerId: string): Promise<RemoveProviderResult>
 
   registry.providers.splice(providerIndex, 1);
 
-  const path = providerConfigPathFromEnv();
-  const source = serializeProviderRegistry(registry);
-  parseProviderConfig(source, path, process.env);
-
-  await atomicWrite(path, source);
-  await loadProviderRegistry();
+  const path = await writeProviderRegistry(registry);
 
   return { ok: true, operation: "remove-provider", providerId, path, restartRequired: true };
-}
-
-async function atomicWrite(path: string, content: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const staging = `${path}.staging-${randomUUID()}`;
-  try {
-    await writeFile(staging, content, { encoding: "utf8", flag: "wx", mode: 0o644 });
-    await rename(staging, path);
-  } finally {
-    await rm(staging, { force: true });
-  }
 }

--- a/src/cli/commands/config/set.ts
+++ b/src/cli/commands/config/set.ts
@@ -3,12 +3,9 @@
 // re-parsed by its owning parser to confirm validity. All writes are atomic
 // (temp file + rename) and output a single JSON result envelope.
 
-import { mkdir, rename, rm, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { dirname } from "node:path";
 import { permissionSettingsPath, loadPermissionSettings } from "../../../config/permissions";
 import { settingsPath, loadSettings } from "../../../config/settings";
-import { loadProviderRegistry, providerConfigPathFromEnv, parseProviderConfig } from "../../../config/providers";
+import { loadProviderRegistry } from "../../../config/providers";
 import type { ProviderProfile } from "../../../config/providers";
 import {
   readProtocol,
@@ -17,7 +14,8 @@ import {
   readResponsesTransport,
   readUserAgent,
 } from "../../../config/providers";
-import { serializeProviderRegistry } from "../../../setup/config-writer";
+import { writeProviderRegistry } from "../../../setup/config-writer";
+import { atomicWrite } from "../../../config/atomic-write";
 import { loadExperimentalQualitySettings, writeExperimentalQualitySettings } from "../../../config/quality";
 import type { ExperimentalQualityMode } from "../../../config/quality";
 import { projectPreferencesPath, readProjectThemePreference } from "../../../config/project-preferences";
@@ -240,8 +238,7 @@ async function setProviderField(providerId: string, field: string, value: string
     throw new Error(`Unknown provider "${providerId}". Available: ${registry.providers.map((entry) => entry.id).join(", ")}.`);
   }
 
-  const typedValue = validateProviderField(provider, field, value);
-  (provider as Record<string, unknown>)[field] = typedValue;
+  applyProviderField(provider, field, value);
 
   // Keep the global default selection consistent with a provider-level
   // defaultModel change so the two default concepts cannot diverge.
@@ -249,17 +246,7 @@ async function setProviderField(providerId: string, field: string, value: string
     registry.default.model = value;
   }
 
-  const path = providerConfigPathFromEnv();
-  const source = serializeProviderRegistry(registry);
-
-  // Validate the serialized output before writing so a failed cross-field
-  // constraint (e.g. protocol openai-responses without responsesProfile)
-  // never leaves a corrupted file on disk.
-  parseProviderConfig(source, path, process.env);
-
-  await atomicWrite(path, source);
-  // Verify round-trip.
-  await loadProviderRegistry();
+  const path = await writeProviderRegistry(registry);
 
   return {
     ok: true,
@@ -272,18 +259,12 @@ async function setProviderField(providerId: string, field: string, value: string
   };
 }
 
-function validateProviderField(provider: ProviderProfile, field: string, value: string): unknown {
-  if (PROTECTED_PROVIDER_FIELDS.includes(field)) {
-    throw new Error(`Field "${field}" cannot be modified directly.`);
-  }
-  if (!SETTABLE_PROVIDER_FIELDS.includes(field)) {
-    throw new Error(`Unknown provider field "${field}". Supported fields: ${SETTABLE_PROVIDER_FIELDS.join(", ")}.`);
-  }
-
+function applyProviderField(provider: ProviderProfile, field: string, value: string): void {
   const fieldLabel = `provider "${provider.id}"`;
   switch (field) {
     case "protocol":
-      return readProtocol(value, fieldLabel);
+      provider.protocol = readProtocol(value, fieldLabel);
+      return;
     case "baseUrl": {
       let parsed: URL;
       try {
@@ -297,22 +278,28 @@ function validateProviderField(provider: ProviderProfile, field: string, value: 
       if (parsed.username || parsed.password) {
         throw new Error(`baseUrl must not contain credentials. providers.yaml is a non-secret file.`);
       }
-      return value.replace(/\/+$/, "");
+      provider.baseUrl = value.replace(/\/+$/, "");
+      return;
     }
     case "apiKeyEnv": {
       if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
         throw new Error(`Invalid apiKeyEnv "${value}". Must be a valid environment variable name.`);
       }
-      return value;
+      provider.apiKeyEnv = value;
+      return;
     }
     case "authMethod":
-      return readAuthMethod(value, fieldLabel);
+      provider.authMethod = readAuthMethod(value, fieldLabel);
+      return;
     case "responsesProfile":
-      return readResponsesProfile(value, fieldLabel);
+      provider.responsesProfile = readResponsesProfile(value, fieldLabel);
+      return;
     case "responsesTransport":
-      return readResponsesTransport(value, fieldLabel);
+      provider.responsesTransport = readResponsesTransport(value, fieldLabel);
+      return;
     case "userAgent":
-      return readUserAgent(value, fieldLabel);
+      provider.userAgent = readUserAgent(value, fieldLabel);
+      return;
     case "defaultModel": {
       if (!provider.models.some((model) => model.id === value)) {
         throw new Error(
@@ -320,11 +307,14 @@ function validateProviderField(provider: ProviderProfile, field: string, value: 
           + `Available: ${provider.models.map((model) => model.id).join(", ")}.`,
         );
       }
-      return value;
+      provider.defaultModel = value;
+      return;
     }
     default:
-      // Exhaustive check above makes this unreachable, but TypeScript needs it.
-      return value;
+      if (PROTECTED_PROVIDER_FIELDS.includes(field)) {
+        throw new Error(`Field "${field}" cannot be modified directly.`);
+      }
+      throw new Error(`Unknown provider field "${field}". Supported fields: ${SETTABLE_PROVIDER_FIELDS.join(", ")}.`);
   }
 }
 
@@ -354,21 +344,6 @@ async function setProvidersDefault(key: string, value: string): Promise<SetResul
     }
     registry.default.model = value;
   }
-  const path = providerConfigPathFromEnv();
-  const source = serializeProviderRegistry(registry);
-  await atomicWrite(path, source);
-  // Verify round-trip.
-  await loadProviderRegistry();
+  const path = await writeProviderRegistry(registry);
   return { ok: true, operation: "set", file: "providers", key, value, path, restartRequired: true };
-}
-
-async function atomicWrite(path: string, content: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const staging = `${path}.staging-${randomUUID()}`;
-  try {
-    await writeFile(staging, content, { encoding: "utf8", flag: "wx", mode: 0o644 });
-    await rename(staging, path);
-  } finally {
-    await rm(staging, { force: true });
-  }
 }

--- a/src/cli/commands/config/set.ts
+++ b/src/cli/commands/config/set.ts
@@ -4,7 +4,7 @@
 // (temp file + rename) and output a single JSON result envelope.
 
 import { permissionSettingsPath, loadPermissionSettings } from "../../../config/permissions";
-import { settingsPath, loadSettings } from "../../../config/settings";
+import { settingsPath, loadSettings, SETTINGS_KEYS } from "../../../config/settings";
 import { loadProviderRegistry } from "../../../config/providers";
 import type { ProviderProfile } from "../../../config/providers";
 import {
@@ -18,7 +18,7 @@ import { writeProviderRegistry } from "../../../setup/config-writer";
 import { atomicWrite } from "../../../config/atomic-write";
 import { loadExperimentalQualitySettings, writeExperimentalQualitySettings } from "../../../config/quality";
 import type { ExperimentalQualityMode } from "../../../config/quality";
-import { projectPreferencesPath, readProjectThemePreference } from "../../../config/project-preferences";
+import { projectPreferencesPath, readProjectThemePreference, PROJECT_PREFERENCE_KEYS } from "../../../config/project-preferences";
 import { permissionModes } from "../../../core/permissions";
 import type { ThemePreference } from "../../../tui/theme";
 
@@ -26,9 +26,9 @@ type SettableFile = "permissions" | "preferences" | "quality" | "settings" | "pr
 
 const SETTABLE_KEYS: Record<SettableFile, readonly string[]> = {
   permissions: ["defaultMode", "shellExec"],
-  preferences: ["theme", "mcpOutputPersistence", "mcpOutputAutoTruncate"],
+  preferences: PROJECT_PREFERENCE_KEYS,
   quality: ["mode"],
-  settings: ["editor"],
+  settings: SETTINGS_KEYS,
   providers: ["default.provider", "default.model", "providers.<id>.<field>"],
 };
 

--- a/src/cli/commands/config/unset.ts
+++ b/src/cli/commands/config/unset.ts
@@ -1,16 +1,13 @@
 // vesicle config unset — remove a key from a flat YAML config file.
-// Currently supports project preferences (theme, mcpOutputPersistence, mcpOutputAutoTruncate)
-// and host settings (editor). Removing the last field from preferences removes the file.
+// The unset semantics live in the owning config modules; this command only
+// routes arguments and reports the JSON envelope.
 
-import { mkdir, rename, rm, writeFile, unlink, readFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
-import { dirname } from "node:path";
 import {
   projectPreferencesPath,
-  readProjectThemePreference,
-  PROJECT_PREFERENCES_VERSION,
+  unsetProjectPreference,
+  PROJECT_PREFERENCE_KEYS,
 } from "../../../config/project-preferences";
-import { settingsPath, loadSettings } from "../../../config/settings";
+import { settingsPath, unsetSettingsKey, SETTINGS_KEYS } from "../../../config/settings";
 
 type UnsetResult = {
   ok: true;
@@ -23,8 +20,8 @@ type UnsetResult = {
 };
 
 const UNSETTABLE_FILES: Record<string, readonly string[]> = {
-  preferences: ["theme", "mcpOutputPersistence", "mcpOutputAutoTruncate"],
-  settings: ["editor"],
+  preferences: PROJECT_PREFERENCE_KEYS,
+  settings: SETTINGS_KEYS,
 };
 
 export async function runUnset(args: string[]): Promise<void> {
@@ -53,105 +50,18 @@ async function unset(file: string, key: string): Promise<UnsetResult> {
   }
 
   switch (file) {
-    case "preferences":
-      return unsetPreference(key);
-    case "settings":
-      return unsetSettings(key);
+    case "preferences": {
+      const rootDir = process.cwd();
+      const path = projectPreferencesPath(rootDir);
+      const removed = await unsetProjectPreference(rootDir, key as (typeof PROJECT_PREFERENCE_KEYS)[number]);
+      return { ok: true, operation: "unset", file, key, path, removed, restartRequired: false };
+    }
+    case "settings": {
+      const path = settingsPath();
+      const removed = await unsetSettingsKey(key as (typeof SETTINGS_KEYS)[number]);
+      return { ok: true, operation: "unset", file, key, path, removed, restartRequired: removed };
+    }
     default:
       throw new Error(`Unsupported unset file "${file}".`);
-  }
-}
-
-async function unsetPreference(key: string): Promise<UnsetResult> {
-  const rootDir = process.cwd();
-  const path = projectPreferencesPath(rootDir);
-  const existing = await readProjectThemePreference(rootDir);
-  if (!existing.ok) {
-    throw new Error(`Refusing to modify malformed preferences: ${existing.diagnostic}`);
-  }
-
-  const hasTheme = existing.theme !== undefined;
-  const hasPersist = existing.mcpOutputPersistence === true;
-  const hasTruncate = existing.mcpOutputAutoTruncate === true;
-
-  const wouldRemove =
-    (key === "theme" && hasTheme)
-    || (key === "mcpOutputPersistence" && hasPersist)
-    || (key === "mcpOutputAutoTruncate" && hasTruncate);
-
-  if (!wouldRemove) {
-    return { ok: true, operation: "unset", file: "preferences", key, path, removed: false, restartRequired: false };
-  }
-
-  const newTheme = key === "theme" ? undefined : existing.theme;
-  const newPersist = key === "mcpOutputPersistence" ? false : hasPersist;
-  const newTruncate = key === "mcpOutputAutoTruncate" ? false : hasTruncate;
-
-  if (!newTheme && !newPersist && !newTruncate) {
-    await safeUnlink(path);
-    return { ok: true, operation: "unset", file: "preferences", key, path, removed: true, restartRequired: false };
-  }
-
-  const lines = [`version: ${PROJECT_PREFERENCES_VERSION}`];
-  if (newTheme) lines.push(`theme: ${newTheme}`);
-  if (newPersist) lines.push("mcpOutputPersistence: true");
-  if (newTruncate) lines.push("mcpOutputAutoTruncate: true");
-  await atomicWrite(path, `${lines.join("\n")}\n`);
-
-  return { ok: true, operation: "unset", file: "preferences", key, path, removed: true, restartRequired: false };
-}
-
-async function unsetSettings(key: string): Promise<UnsetResult> {
-  const path = settingsPath();
-  const existing = await loadSettings();
-  if (key === "editor" && existing.editor === undefined) {
-    return { ok: true, operation: "unset", file: "settings", key, path, removed: false, restartRequired: true };
-  }
-
-  // Read the existing source and drop only the target key line, preserving
-  // any other fields and comments for forward compatibility.
-  let source: string;
-  try {
-    source = await readFile(path, "utf8");
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && (error as { code: string }).code === "ENOENT") {
-      return { ok: true, operation: "unset", file: "settings", key, path, removed: false, restartRequired: true };
-    }
-    throw error;
-  }
-
-  const keyPattern = new RegExp(`^\\s*${key}\\s*:`);
-  const remaining = source.split(/\r?\n/).filter((line) => !keyPattern.test(line));
-  const hasContent = remaining.some((line) => {
-    const trimmed = line.trim();
-    return trimmed && !trimmed.startsWith("#") && !/^version\s*:/.test(trimmed);
-  });
-
-  if (hasContent) {
-    await atomicWrite(path, `${remaining.join("\n")}\n`);
-  } else {
-    await safeUnlink(path);
-  }
-
-  return { ok: true, operation: "unset", file: "settings", key, path, removed: true, restartRequired: true };
-}
-
-async function atomicWrite(path: string, content: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const staging = `${path}.staging-${randomUUID()}`;
-  try {
-    await writeFile(staging, content, { encoding: "utf8", flag: "wx", mode: 0o644 });
-    await rename(staging, path);
-  } finally {
-    await rm(staging, { force: true });
-  }
-}
-
-async function safeUnlink(path: string): Promise<void> {
-  try {
-    await unlink(path);
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && (error as { code: string }).code === "ENOENT") return;
-    throw error;
   }
 }

--- a/src/config/atomic-write.ts
+++ b/src/config/atomic-write.ts
@@ -1,0 +1,28 @@
+// Shared atomic-write primitive for config file mutations.
+// Writes go to a uniquely-named sibling staging file and are renamed over the
+// target; the staging file is always cleaned up. Callers choose the mode
+// (0o600 for secret files like .env, 0o644 otherwise).
+
+import { mkdir, rename, rm, writeFile, unlink } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
+
+export async function atomicWrite(path: string, content: string, mode: number = 0o644): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const staging = `${path}.staging-${randomUUID()}`;
+  try {
+    await writeFile(staging, content, { encoding: "utf8", flag: "wx", mode });
+    await rename(staging, path);
+  } finally {
+    await rm(staging, { force: true });
+  }
+}
+
+export async function safeUnlink(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && (error as { code: string }).code === "ENOENT") return;
+    throw error;
+  }
+}

--- a/src/config/project-preferences.ts
+++ b/src/config/project-preferences.ts
@@ -187,7 +187,7 @@ export async function unsetProjectPreference(rootDir: string, key: ProjectPrefer
   const path = projectPreferencesPath(rootDir);
   const existing = await readProjectThemePreference(rootDir);
   if (!existing.ok) {
-    throw new Error(`Refusing to modify malformed ${rel(path, rootDir)}: ${existing.diagnostic}`);
+    throw new Error(`Refusing to modify malformed preferences: ${existing.diagnostic}`);
   }
 
   const present =

--- a/src/config/project-preferences.ts
+++ b/src/config/project-preferences.ts
@@ -34,6 +34,10 @@ import type { ThemePreference } from "../tui/theme";
 export const PROJECT_PREFERENCES_VERSION = 1;
 const VALID_THEMES: readonly ThemePreference[] = ["dark", "light", "default", "auto"];
 
+/** Preference fields the CLI may set/unset; shared by set and unset commands. */
+export const PROJECT_PREFERENCE_KEYS = ["theme", "mcpOutputPersistence", "mcpOutputAutoTruncate"] as const;
+export type ProjectPreferenceKey = (typeof PROJECT_PREFERENCE_KEYS)[number];
+
 export type ProjectPreferencesRead =
   | { ok: true; theme?: ThemePreference; mcpOutputPersistence?: boolean; mcpOutputAutoTruncate?: boolean; path: string }
   | { ok: false; diagnostic: string; path: string };
@@ -170,18 +174,39 @@ export async function readMcpOutputPreferences(
  * theme is a no-op.
  */
 export async function unsetProjectThemePreference(rootDir: string): Promise<void> {
+  await unsetProjectPreference(rootDir, "theme");
+}
+
+/**
+ * Remove one project preference field, preserving the others. The file is
+ * removed when no preference field remains. Returns true when the field was
+ * present and removed, false when it was already absent (a no-op). Refuses to
+ * modify a malformed file.
+ */
+export async function unsetProjectPreference(rootDir: string, key: ProjectPreferenceKey): Promise<boolean> {
   const path = projectPreferencesPath(rootDir);
   const existing = await readProjectThemePreference(rootDir);
   if (!existing.ok) {
     throw new Error(`Refusing to modify malformed ${rel(path, rootDir)}: ${existing.diagnostic}`);
   }
-  if (existing.theme === undefined) return;
-  if (existing.mcpOutputPersistence || existing.mcpOutputAutoTruncate) {
-    await rejectSymlinkTarget(path, rootDir);
-    await atomicWrite(path, preferencesBody(undefined, existing.mcpOutputPersistence === true, existing.mcpOutputAutoTruncate === true));
-    return;
+
+  const present =
+    (key === "theme" && existing.theme !== undefined)
+    || (key === "mcpOutputPersistence" && existing.mcpOutputPersistence === true)
+    || (key === "mcpOutputAutoTruncate" && existing.mcpOutputAutoTruncate === true);
+  if (!present) return false;
+
+  const theme = key === "theme" ? undefined : existing.theme;
+  const persist = key === "mcpOutputPersistence" ? false : existing.mcpOutputPersistence === true;
+  const truncate = key === "mcpOutputAutoTruncate" ? false : existing.mcpOutputAutoTruncate === true;
+
+  if (!theme && !persist && !truncate) {
+    await safeUnlink(path);
+    return true;
   }
-  await safeUnlink(path);
+  await rejectSymlinkTarget(path, rootDir);
+  await atomicWrite(path, preferencesBody(theme, persist, truncate));
+  return true;
 }
 
 function preferencesBody(

--- a/src/config/project-preferences.ts
+++ b/src/config/project-preferences.ts
@@ -1,7 +1,8 @@
-import { lstat, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { lstat, readFile } from "node:fs/promises";
 import type { Stats } from "node:fs";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { readYamlKeyValue, readYamlLines } from "./yaml-line-reader";
+import { atomicWrite, safeUnlink } from "./atomic-write";
 import type { ThemePreference } from "../tui/theme";
 
 /**
@@ -229,27 +230,6 @@ async function rejectSymlinkTarget(path: string, rootDir: string): Promise<void>
     }
   } catch (error) {
     if (!isEnoent(error)) throw error;
-  }
-}
-
-async function atomicWrite(path: string, content: string): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.${process.pid}.tmp`;
-  await writeFile(tmp, content, "utf8");
-  try {
-    await rename(tmp, path);
-  } catch (error) {
-    await safeUnlink(tmp);
-    throw error;
-  }
-}
-
-async function safeUnlink(path: string): Promise<void> {
-  try {
-    await unlink(path);
-  } catch (error) {
-    if (isEnoent(error)) return;
-    throw error;
   }
 }
 

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -699,12 +699,17 @@ function readKeyValue(line: string, index: number, path: string): [string, strin
 }
 
 function readGenerationField(key: string, value: string, index: number, path: string): GenerationDefaults {
+  if (!(generationFieldNames as readonly string[]).includes(key)) {
+    throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown generation field "${key}".`);
+  }
   if (key === "temperature") return { temperature: readFiniteNumber(value, key, index, path) };
-  if (key === "maxTokens") return { maxTokens: readPositiveInteger(value, key, index, path) };
-  throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown generation field "${key}".`);
+  return { maxTokens: readPositiveInteger(value, key, index, path) };
 }
 
 function readCapabilityField(key: string, value: string, index: number, path: string): ModelCapabilities {
+  if (!(capabilityFieldNames as readonly string[]).includes(key)) {
+    throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown capability field "${key}".`);
+  }
   const enabled = readBoolean(value, key, index, path);
   if (key === "streaming") return { streaming: enabled };
   if (key === "tools") return { tools: enabled };
@@ -713,21 +718,24 @@ function readCapabilityField(key: string, value: string, index: number, path: st
   if (key === "temperature") return { temperature: enabled };
   if (key === "maxTokens") return { maxTokens: enabled };
   if (key === "vision") return { vision: enabled };
-  if (key === "remoteCompact") return { remoteCompact: enabled };
-  throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown capability field "${key}".`);
+  return { remoteCompact: enabled };
 }
 
 function readLimitsField(key: string, value: string, index: number, path: string): ModelLimits {
+  if (!(limitsFieldNames as readonly string[]).includes(key)) {
+    throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown limits field "${key}".`);
+  }
   if (key === "contextWindow") return { contextWindow: readPositiveInteger(value, key, index, path) };
-  if (key === "maxOutputTokens") return { maxOutputTokens: readPositiveInteger(value, key, index, path) };
-  throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown limits field "${key}".`);
+  return { maxOutputTokens: readPositiveInteger(value, key, index, path) };
 }
 
 function readAutoCompactField(key: string, value: string, index: number, path: string): AutoCompactLimits {
+  if (!(autoCompactFieldNames as readonly string[]).includes(key)) {
+    throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown autoCompact field "${key}".`);
+  }
   if (key === "enabled") return { enabled: readBoolean(value, key, index, path) };
   if (key === "threshold") return { threshold: readFraction(value, key, index, path) };
-  if (key === "reserveOutputTokens") return { reserveOutputTokens: readPositiveInteger(value, key, index, path) };
-  throw new Error(`Provider config parse error on line ${index + 1} in ${path}: unknown autoCompact field "${key}".`);
+  return { reserveOutputTokens: readPositiveInteger(value, key, index, path) };
 }
 
 function readFiniteNumber(value: string, key: string, index: number, path: string): number {

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -40,6 +40,137 @@ export type ProviderRegistry = {
   path?: string;
 };
 
+/**
+ * Canonical model-entry field names, shared between the YAML parser below and
+ * the JSON-shape validator used by `vesicle config add-model`. Keep these in
+ * sync with readGenerationField/readCapabilityField/readLimitsField/
+ * readAutoCompactField; both live in this module so drift is visible in one diff.
+ */
+export const modelEntryFieldNames = ["id", "generation", "capabilities", "limits"] as const;
+export const generationFieldNames = ["temperature", "maxTokens"] as const;
+export const capabilityFieldNames = [
+  "streaming",
+  "tools",
+  "reasoningTier",
+  "reasoningContent",
+  "temperature",
+  "maxTokens",
+  "vision",
+  "remoteCompact",
+] as const;
+export const limitsFieldNames = ["contextWindow", "maxOutputTokens"] as const;
+export const autoCompactFieldNames = ["enabled", "threshold", "reserveOutputTokens"] as const;
+
+/**
+ * Validate a JSON-shaped model entry (as passed to `vesicle config add-model
+ * --json`) into a ProviderModelProfile. Unlike the YAML readers below, values
+ * here are already JSON-typed, so booleans must be real booleans and numbers
+ * real numbers — no string coercion. Unknown keys are rejected.
+ */
+export function validateModelEntryShape(entry: unknown): ProviderModelProfile {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error("Model entry must be a JSON object.");
+  }
+  const source = entry as Record<string, unknown>;
+  for (const key of Object.keys(source)) {
+    if (!(modelEntryFieldNames as readonly string[]).includes(key)) {
+      throw new Error(`Unknown model entry field "${key}". Allowed: ${modelEntryFieldNames.join(", ")}.`);
+    }
+  }
+
+  const id = source.id;
+  if (typeof id !== "string" || !id.trim()) {
+    throw new Error(`Model entry requires a non-empty "id" string.`);
+  }
+  const modelId = id.trim();
+  if (/\s/.test(modelId)) {
+    throw new Error(`Model id "${modelId}" must not contain whitespace.`);
+  }
+
+  const model: ProviderModelProfile = { id: modelId };
+  if (source.generation !== undefined) model.generation = readGenerationObject(source.generation);
+  if (source.capabilities !== undefined) model.capabilities = readCapabilitiesObject(source.capabilities);
+  if (source.limits !== undefined) model.limits = readLimitsObject(source.limits);
+  return model;
+}
+
+function readGenerationObject(value: unknown): GenerationDefaults {
+  const source = readObjectField(value, "generation", generationFieldNames);
+  const result: GenerationDefaults = {};
+  if (source.temperature !== undefined) result.temperature = readJsonFiniteNumber(source.temperature, "temperature");
+  if (source.maxTokens !== undefined) result.maxTokens = readJsonPositiveInteger(source.maxTokens, "maxTokens");
+  return result;
+}
+
+function readCapabilitiesObject(value: unknown): ModelCapabilities {
+  const source = readObjectField(value, "capabilities", capabilityFieldNames);
+  const result: Record<string, boolean> = {};
+  for (const [key, val] of Object.entries(source)) {
+    if (typeof val !== "boolean") {
+      throw new Error(`Capability "${key}" must be true or false.`);
+    }
+    result[key] = val;
+  }
+  return result as ModelCapabilities;
+}
+
+function readLimitsObject(value: unknown): ModelLimits {
+  const source = readObjectField(value, "limits", limitsFieldNames);
+  const result: ModelLimits = {};
+  if (source.contextWindow !== undefined) result.contextWindow = readJsonPositiveInteger(source.contextWindow, "contextWindow");
+  if (source.maxOutputTokens !== undefined) result.maxOutputTokens = readJsonPositiveInteger(source.maxOutputTokens, "maxOutputTokens");
+  if (source.autoCompact !== undefined) result.autoCompact = readAutoCompactObject(source.autoCompact);
+  return result;
+}
+
+function readAutoCompactObject(value: unknown): AutoCompactLimits {
+  const source = readObjectField(value, "autoCompact", autoCompactFieldNames);
+  const result: AutoCompactLimits = {};
+  if (source.enabled !== undefined) {
+    if (typeof source.enabled !== "boolean") throw new Error("autoCompact.enabled must be true or false.");
+    result.enabled = source.enabled;
+  }
+  if (source.threshold !== undefined) {
+    const threshold = source.threshold;
+    if (typeof threshold !== "number" || !Number.isFinite(threshold) || threshold <= 0 || threshold >= 1) {
+      throw new Error("autoCompact.threshold must be a number greater than 0 and less than 1.");
+    }
+    result.threshold = threshold;
+  }
+  if (source.reserveOutputTokens !== undefined) {
+    result.reserveOutputTokens = readJsonPositiveInteger(source.reserveOutputTokens, "autoCompact.reserveOutputTokens");
+  }
+  return result;
+}
+
+function readObjectField(value: unknown, field: string, allowed: readonly string[]): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${field} must be an object.`);
+  }
+  const source = value as Record<string, unknown>;
+  for (const key of Object.keys(source)) {
+    if (!allowed.includes(key)) {
+      throw new Error(`Unknown ${field} field "${key}". Allowed: ${allowed.join(", ")}.`);
+    }
+  }
+  return source;
+}
+
+function readJsonFiniteNumber(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} must be a finite number.`);
+  }
+  return value;
+}
+
+function readJsonPositiveInteger(value: unknown, field: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${field} must be a positive integer.`);
+  }
+  return value;
+}
+
+
 export type ProviderConfigStatus = VesicleConfig & {
   hasApiKey: boolean;
   missing: string[];

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -103,9 +103,14 @@ function readGenerationObject(value: unknown): GenerationDefaults {
 }
 
 function readCapabilitiesObject(value: unknown): ModelCapabilities {
-  const source = readObjectField(value, "capabilities", capabilityFieldNames);
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("capabilities must be an object.");
+  }
   const result: Record<string, boolean> = {};
-  for (const [key, val] of Object.entries(source)) {
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    if (!(capabilityFieldNames as readonly string[]).includes(key)) {
+      throw new Error(`Unknown capability "${key}". Allowed: ${capabilityFieldNames.join(", ")}.`);
+    }
     if (typeof val !== "boolean") {
       throw new Error(`Capability "${key}" must be true or false.`);
     }

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { userConfigDirectory } from "./paths";
+import { atomicWrite, safeUnlink } from "./atomic-write";
 
 /**
  * User-level `settings.yaml` — a new, deliberately tiny user config file that
@@ -10,6 +11,10 @@ import { userConfigDirectory } from "./paths";
  * is the reserved home for future user settings (#86 theme persistence, …),
  * so unknown fields are ignored rather than rejected.
  */
+
+/** Settings fields the CLI may set/unset; shared by set and unset commands. */
+export const SETTINGS_KEYS = ["editor"] as const;
+export type SettingsKey = (typeof SETTINGS_KEYS)[number];
 
 export type Settings = {
   /** Raw external-editor command line (e.g. `code --wait`, `nano`), if set. */
@@ -50,4 +55,37 @@ export async function loadSettings(env: NodeJS.ProcessEnv = process.env): Promis
   }
   const editor = values.get("editor");
   return { editor: editor && editor.length > 0 ? editor : undefined, exists: true, path };
+}
+
+/**
+ * Remove one settings key by dropping only its line, preserving every other
+ * field and comment for forward compatibility. The file is removed when no
+ * non-version content remains. Returns true when the key was present and
+ * removed, false when it was already absent (a no-op, including a missing file).
+ */
+export async function unsetSettingsKey(key: SettingsKey, env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
+  const path = settingsPath(env);
+  let source: string;
+  try {
+    source = await readFile(path, "utf8");
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && (error as { code: string }).code === "ENOENT") return false;
+    throw error;
+  }
+
+  const keyPattern = new RegExp(`^\\s*${key}\\s*:`);
+  const remaining = source.split(/\r?\n/).filter((line) => !keyPattern.test(line));
+  if (remaining.length === source.split(/\r?\n/).length) return false;
+
+  const hasContent = remaining.some((line) => {
+    const trimmed = line.trim();
+    return trimmed && !trimmed.startsWith("#") && !/^version\s*:/.test(trimmed);
+  });
+  if (!hasContent) {
+    await safeUnlink(path);
+    return true;
+  }
+
+  await atomicWrite(path, `${remaining.join("\n")}\n`);
+  return true;
 }

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -60,22 +60,21 @@ export async function loadSettings(env: NodeJS.ProcessEnv = process.env): Promis
 /**
  * Remove one settings key by dropping only its line, preserving every other
  * field and comment for forward compatibility. The file is removed when no
- * non-version content remains. Returns true when the key was present and
- * removed, false when it was already absent (a no-op, including a missing file).
+ * non-version content remains. Returns true when the key was present with a
+ * value and removed, false when it was absent or empty (a no-op). Malformed
+ * or unsupported-version files are refused via loadSettings.
  */
 export async function unsetSettingsKey(key: SettingsKey, env: NodeJS.ProcessEnv = process.env): Promise<boolean> {
   const path = settingsPath(env);
-  let source: string;
-  try {
-    source = await readFile(path, "utf8");
-  } catch (error) {
-    if (error && typeof error === "object" && "code" in error && (error as { code: string }).code === "ENOENT") return false;
-    throw error;
-  }
+  // Refuse to touch a malformed or unsupported-version file (e.g. written by
+  // a newer Vesicle): parse first and let loadSettings throw.
+  const settings = await loadSettings(env);
+  if (!settings.exists) return false;
+  if (settings[key] === undefined) return false;
 
+  const source = await readFile(path, "utf8");
   const keyPattern = new RegExp(`^\\s*${key}\\s*:`);
   const remaining = source.split(/\r?\n/).filter((line) => !keyPattern.test(line));
-  if (remaining.length === source.split(/\r?\n/).length) return false;
 
   const hasContent = remaining.some((line) => {
     const trimmed = line.trim();

--- a/src/setup/config-writer.ts
+++ b/src/setup/config-writer.ts
@@ -15,6 +15,7 @@ import {
 } from "../config/providers";
 import { parseMcpConfig, mcpConfigPathFromEnv } from "../mcp/config";
 import { loadPermissionSettings } from "../config/permissions";
+import { atomicWrite } from "../config/atomic-write";
 
 export type SetupMcpServer = {
   name: string;
@@ -134,8 +135,22 @@ export function setEnvValues(source: string, updates: Record<string, string>): s
   return `${output.join("\n")}\n`;
 }
 
-export function serializeProviderRegistry(registry: ProviderRegistry): string {
-  const lines = [
+/**
+ * Shared provider-registry write pipeline for config CLI commands:
+ * serialize → validate by re-parsing (before touching disk) → atomic write →
+ * reload to confirm the round-trip. A failed cross-field constraint throws
+ * before any bytes land on disk, leaving the existing providers.yaml intact.
+ */
+export async function writeProviderRegistry(registry: ProviderRegistry): Promise<string> {
+  const path = providerConfigPathFromEnv();
+  const source = serializeProviderRegistry(registry);
+  parseProviderConfig(source, path, process.env);
+  await atomicWrite(path, source);
+  await loadProviderRegistry();
+  return path;
+}
+
+export function serializeProviderRegistry(registry: ProviderRegistry): string {  const lines = [
     "default:",
     `  provider: ${yamlScalar(registry.default.provider)}`,
     `  model: ${yamlScalar(registry.default.model)}`,

--- a/src/setup/config-writer.ts
+++ b/src/setup/config-writer.ts
@@ -150,7 +150,8 @@ export async function writeProviderRegistry(registry: ProviderRegistry): Promise
   return path;
 }
 
-export function serializeProviderRegistry(registry: ProviderRegistry): string {  const lines = [
+export function serializeProviderRegistry(registry: ProviderRegistry): string {
+  const lines = [
     "default:",
     `  provider: ${yamlScalar(registry.default.provider)}`,
     `  model: ${yamlScalar(registry.default.model)}`,

--- a/tests/integration/cli/config.test.ts
+++ b/tests/integration/cli/config.test.ts
@@ -450,6 +450,19 @@ describe("vesicle config CLI", () => {
     });
   });
 
+  test("unset settings refuses an unsupported-version settings.yaml", async () => {
+    await withTempProject("vesicle-config-unset-settings-v2-", async (projectDir, configDir) => {
+      await seedProvidersConfig(configDir);
+      const original = ["version: 2", "editor: nano", ""].join("\n");
+      await writeFile(join(configDir, "settings.yaml"), original, "utf8");
+      const result = await runCli(["config", "unset", "settings", "editor"], { cwd: projectDir, configDir });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("unsupported version");
+      const after = await readFile(join(configDir, "settings.yaml"), "utf8");
+      expect(after).toBe(original);
+    });
+  });
+
   test("env-remove still removes a key when .env contains unparseable lines", async () => {
     await withTempProject("vesicle-config-envrm-unparseable-", async (projectDir, configDir) => {
       await seedProvidersConfig(configDir);

--- a/tests/integration/cli/config.test.ts
+++ b/tests/integration/cli/config.test.ts
@@ -504,6 +504,18 @@ describe("vesicle config CLI", () => {
     });
   });
 
+  test("add-model rejects unknown nested keys in limits", async () => {
+    await withTempProject("vesicle-config-addmodel-nestedkey-", async (projectDir, configDir) => {
+      await seedProvidersConfig(configDir);
+      const entry = JSON.stringify({ id: "local-extra", limits: { contextWindow: 4096, contextWidnow: 1 } });
+      const result = await runCli(["config", "add-model", "local", "--json", entry], { cwd: projectDir, configDir });
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Unknown limits field");
+      const providersContent = await readFile(join(configDir, "providers.yaml"), "utf8");
+      expect(providersContent).not.toContain("local-extra");
+    });
+  });
+
   test("add-model rejects non-numeric JSON values for numeric fields", async () => {
     await withTempProject("vesicle-config-addmodel-nonnum-", async (projectDir, configDir) => {
       await seedProvidersConfig(configDir);


### PR DESCRIPTION
## Summary

Follow-up refactor after #193, addressing the two Style Review should-fixes (duplicated write primitive, duplicated schema whitelists):

- **New \`src/config/atomic-write.ts\`** owns the staging+rename atomic write primitive (mode parameter covers the 0o600 secret-file case). Six per-command copies removed from \`set.ts\`/\`add.ts\`/\`add-model.ts\`/\`remove.ts\`/\`unset.ts\`/\`env.ts\`.
- **New \`writeProviderRegistry()\`** in \`config-writer.ts\` owns the serialize → pre-parse validation → atomic write → reload pipeline; \`set\`, \`add-model\`, and \`remove\` all call it.
- **Model-entry JSON validation moves to \`config/providers.ts\`** as \`validateModelEntryShape()\`, with exported field-name constants (\`modelEntryFieldNames\`, \`capabilityFieldNames\`, …) kept adjacent to the YAML parser readers that own the same sets — drift is now visible within one file.
- **Unset semantics move to the owning modules**: \`unsetProjectPreference()\` covers all three preference keys; \`unsetSettingsKey()\` drops only the target line, preserves unknown fields/comments, and refuses malformed or unsupported-version files via \`loadSettings\`.
- **set/unset key whitelists shared** via \`PROJECT_PREFERENCE_KEYS\` / \`SETTINGS_KEYS\` exported from the owning modules.
- \`setProviderField\` now uses explicit typed assignments instead of a \`Record<string, unknown>\` cast.
- \`add-model\` argument parsing is fully positional (exactly \`<provider-id> --json '<entry>'\`).

## Intentional behavior changes (reviewed and accepted)

1. **\`add-model\` is stricter**: unknown keys inside \`generation\`/\`limits\`/\`autoCompact\` are now rejected (previously silently dropped, e.g. a \`contextWidnow\` typo), and array values for these objects are rejected. This matches the canonical YAML parser's unknown-field policy.
2. **\`unset settings\` envelope**: \`restartRequired\` is now \`true\` only when a key was actually removed (a no-op unset no longer advises a restart).
3. **\`add-model\` rejects extra/trailing arguments** instead of silently ignoring them.

## Test Plan

- [x] \`bun run lint\`
- [x] \`bun run typecheck\`
- [x] \`bun test\` (1998 pass / 0 fail — 37 config CLI integration tests, including a new regression: unset refuses a \`version: 2\` settings.yaml without touching it)
- [x] Local independent SubAgent CR (1 blocking found and fixed: refuse-on-malformed guard restored; wording/arg-parsing nits applied)

## Notes / Follow-ups

- Deferred from #193 review: config-write allowed-root guard (needs a product decision on environment trust), \`add-mcp\` (tracked in #194).
