### PR TITLE
fix(tui): exit cleanly on second Ctrl+C under bun run dev

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -86,6 +86,8 @@ export type AppProps = {
   bootstrapOnly?: boolean;
   /** Effective theme-preference owner (source precedence, session override, project persistence). */
   theme?: ThemePreferenceController;
+  /** Called after the renderer has been destroyed to finish a CLI TUI exit. */
+  onExit?: () => void;
 };
 
 export {
@@ -104,6 +106,7 @@ export type { TokenUsageSummary };
 export function App(props: AppProps = {}) {
   initDebugLogging();
   const renderer = useRenderer();
+  const exitTui = props.onExit ?? (() => {});
   // The controller is constructed in runTui/setup before the first frame. Tests
   // that mount App directly fall back to an env-only controller (no project
   // read) so the palette and `/theme` still work without async I/O on mount.
@@ -117,7 +120,12 @@ export function App(props: AppProps = {}) {
   // only the test fallback controller (props.theme absent) needs it here.
   if (!props.theme) themeController.applyStartup();
   onMount(() => {
-    if (props.bootstrapOnly) process.nextTick(() => renderer.destroy());
+    if (props.bootstrapOnly) {
+      process.nextTick(() => {
+        renderer.destroy();
+        exitTui();
+      });
+    }
   });
   const dimensions = useTerminalDimensions();
   const providerState = createProviderState(props.dangerouslySkipPermissions === true);
@@ -905,6 +913,7 @@ export function App(props: AppProps = {}) {
 
   useInputRouting({
     renderer,
+    onExit: exitTui,
     setStatus,
     splashActive: () => !splashGone(),
     dismissSplash: () => setSplashForceDone(true),

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,5 +1,6 @@
 import { render } from "@opentui/solid";
 import { App, type AppProps } from "./app";
+import { runHostShutdownCleanups } from "../core/process/shutdown";
 import {
   createThemePreferenceController,
   parseEnvTheme,
@@ -31,6 +32,12 @@ export async function runTui(options: RunTuiOptions = {}): Promise<void> {
     initialResume: options.resume === true,
     bootstrapOnly: options.bootstrapOnly === true,
     theme,
+    // The renderer must be destroyed first; only then start host cleanup and
+    // force a normal exit. Waiting for onDestroy before cleanup leaves Bun stuck
+    // after this App has rendered (observed with `bun run dev` Ctrl+C).
+    onExit: () => {
+      void runHostShutdownCleanups().finally(() => process.exit(0));
+    },
   };
   await render(() => <App {...themeProps} />, {
     exitOnCtrlC: false,

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -36,7 +36,7 @@ export async function runTui(options: RunTuiOptions = {}): Promise<void> {
     // force a normal exit. Waiting for onDestroy before cleanup leaves Bun stuck
     // after this App has rendered (observed with `bun run dev` Ctrl+C).
     onExit: () => {
-      void runHostShutdownCleanups().finally(() => process.exit(0));
+      void runHostShutdownCleanups().finally(() => process.exit(process.exitCode ?? 0));
     },
   };
   await render(() => <App {...themeProps} />, {

--- a/src/tui/input-routing.ts
+++ b/src/tui/input-routing.ts
@@ -11,6 +11,8 @@ import type { SkillPickerState } from "./skill-picker-controller";
 
 export type InputRoutingOptions = {
   renderer: ReturnType<typeof useRenderer>;
+  /** Called after the renderer has been destroyed when the user quits the TUI. */
+  onExit?: () => void;
   setStatus: Setter<string>;
   rewindPicker: Accessor<RewindPickerState | null>;
   handleRewindKey: (key: TuiKeyEvent) => boolean;
@@ -107,7 +109,10 @@ export function createInputRouter(options: InputRoutingOptions): InputRouter {
         }
         const now = Date.now();
         if (now - lastCtrlCAt < 3000) {
-          process.nextTick(() => options.renderer.destroy());
+          process.nextTick(() => {
+            options.renderer.destroy();
+            options.onExit?.();
+          });
           return;
         }
         lastCtrlCAt = now;
@@ -116,7 +121,10 @@ export function createInputRouter(options: InputRoutingOptions): InputRouter {
       return;
     }
     if (key.ctrl && key.name === "q") {
-      process.nextTick(() => options.renderer.destroy());
+      process.nextTick(() => {
+        options.renderer.destroy();
+        options.onExit?.();
+      });
       return;
     }
     // The startup splash swallows all other input: the first keypress ends it

--- a/src/tui/input-routing.ts
+++ b/src/tui/input-routing.ts
@@ -82,6 +82,10 @@ function resolveWorkspacePasteOwnership(options: InputRoutingOptions): Workspace
  */
 export function createInputRouter(options: InputRoutingOptions): InputRouter {
   let lastCtrlCAt = 0;
+  const quit = () => process.nextTick(() => {
+    options.renderer.destroy();
+    options.onExit?.();
+  });
   const bottomSurfaceMode = () => resolveBottomSurfaceMode({
     yoloStage: options.yoloConfirmStage(),
     permissionRequest: options.activePermissionRequest(),
@@ -109,10 +113,7 @@ export function createInputRouter(options: InputRoutingOptions): InputRouter {
         }
         const now = Date.now();
         if (now - lastCtrlCAt < 3000) {
-          process.nextTick(() => {
-            options.renderer.destroy();
-            options.onExit?.();
-          });
+          quit();
           return;
         }
         lastCtrlCAt = now;
@@ -121,10 +122,7 @@ export function createInputRouter(options: InputRoutingOptions): InputRouter {
       return;
     }
     if (key.ctrl && key.name === "q") {
-      process.nextTick(() => {
-        options.renderer.destroy();
-        options.onExit?.();
-      });
+      quit();
       return;
     }
     // The startup splash swallows all other input: the first keypress ends it

--- a/tests/unit/tui/input-routing.test.ts
+++ b/tests/unit/tui/input-routing.test.ts
@@ -49,6 +49,75 @@ describe("TUI input routing", () => {
   });
 });
 
+describe("TUI input routing: quit contract", () => {
+  function buildQuitRouter() {
+    let destroyed = 0;
+    let exited = 0;
+    const statuses: string[] = [];
+    const router = createInputRouter({
+      renderer: {
+        destroy: () => { destroyed += 1; },
+        clearSelection: () => {},
+        getSelection: () => undefined,
+      } as unknown as InputRoutingOptions["renderer"],
+      onExit: () => { exited += 1; },
+      setStatus: (value) => { if (typeof value === "string") statuses.push(value); },
+      rewindPicker: () => null,
+      handleRewindKey: () => false,
+      modelPicker: () => null,
+      handleModelPickerKey: () => false,
+      qualityPicker: () => null,
+      handleQualityPickerKey: () => false,
+      qualityRewriteConfirm: () => null,
+      handleRewriteConfirmKey: () => false,
+      sessionPicker: () => null,
+      handleSessionPickerKey: () => false,
+      skillPicker: () => null,
+      handleSkillPickerKey: () => false,
+      yoloConfirmStage: () => null,
+      handleYoloKey: () => false,
+      activePermissionRequest: () => undefined,
+      pendingUserQuestion: () => null,
+      handleQuestionKey: () => false,
+      activeGateRequest: () => null,
+      handleGateKey: () => false,
+      pasteClipboardImage: async () => undefined,
+      handleComposerKey: () => false,
+      handlePromptEscape: () => {},
+      handleDecisionPaste: () => false,
+      insertComposerPaste: () => undefined,
+    });
+    return { router, destroyed: () => destroyed, exited: () => exited, statuses };
+  }
+
+  test("first Ctrl+C only arms exit", async () => {
+    const { router, destroyed, exited, statuses } = buildQuitRouter();
+    router.handleKey(keyEvent("c", { ctrl: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(destroyed()).toBe(0);
+    expect(exited()).toBe(0);
+    expect(statuses).toEqual(["press Ctrl+C again to exit"]);
+  });
+
+  test("second Ctrl+C within 3s destroys then invokes onExit", async () => {
+    const { router, destroyed, exited } = buildQuitRouter();
+    router.handleKey(keyEvent("c", { ctrl: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    router.handleKey(keyEvent("c", { ctrl: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(destroyed()).toBe(1);
+    expect(exited()).toBe(1);
+  });
+
+  test("Ctrl+Q destroys then invokes onExit immediately", async () => {
+    const { router, destroyed, exited } = buildQuitRouter();
+    router.handleKey(keyEvent("q", { ctrl: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(destroyed()).toBe(1);
+    expect(exited()).toBe(1);
+  });
+});
+
 describe("TUI input routing: workspace paste ownership", () => {
   let root: string;
 


### PR DESCRIPTION
## Problem

When running through `bun run dev`, pressing Ctrl+C twice still required a third Ctrl+C to exit, and the process exited with code 130.

The previous attempted fix waited for OpenTUI's `onDestroy` and then ran host cleanup. That approach still left Bun stuck after the App had rendered, so the process never exited on the second Ctrl+C.

## Fix

Drive the exit from the `renderer.destroy()` call site instead of waiting for `onDestroy`:

- `input-routing.ts`: after destroying the renderer on the second Ctrl+C / Ctrl+Q, invoke an optional `onExit` callback.
- `app.tsx`: forwards `onExit` into input routing and also uses it for bootstrap-only destruction.
- `index.tsx`: `runTui` injects the CLI exit callback which runs `runHostShutdownCleanups()` and then `process.exit(0)`.

## Validation

- `bun run typecheck` passes.
- `bun test tests/unit/tui/input-routing.test.ts` passes.
- `bun run src/cli/main.ts debug tui-bootstrap` now exits 0 instead of hanging.