### PR TITLE
test(skills): classify cross-process lock-test flakes and prove worker blocking

### DIFF
--- a/tests/unit/skills/store.test.ts
+++ b/tests/unit/skills/store.test.ts
@@ -317,22 +317,25 @@ v2 body
           return exitCode;
         });
         await Bun.sleep(100);
-        if (holderExited) {
-          // The holder holds the SQLite write lock, so its death is the only way the
-          // worker can finish early. A dead holder is environmental (e.g. a runner
-          // OOM-kill), not a store defect, and must not be misread as a locking failure.
-          throw new Error(
+        // The holder holds the SQLite write lock, so its death is the only way the
+        // worker can finish early. A dead holder is environmental (e.g. a runner
+        // OOM-kill), not a store defect, and must not be misread as a locking failure.
+        const holderDeathError = async () =>
+          new Error(
             `Lock holder died while it should have been sleeping: exit ${await holderExit}; `
               + `worker ${workerExited ? `already exited with ${await workerExit}` : "still running"}`,
           );
-        }
+        if (holderExited) throw await holderDeathError();
         if (workerExited) {
           throw new Error(`Index worker exited before the holder: ${await workerExit}\n${await workerStdout}\n${await workerStderr}`);
         }
         // The index write happens inside the cross-process lock, so while the holder
-        // lives the install cannot have landed: this proves the worker was genuinely
-        // blocked on the lock, not merely slow to boot.
-        expect((await readActiveIndex(env)).entries.some((entry) => entry.name === "after-crash")).toBe(false);
+        // lives the install cannot have landed during the observation window. Re-check
+        // holder liveness after the read so a death mid-read still classifies
+        // environmentally instead of failing as an unexplained index mismatch.
+        const landed = (await readActiveIndex(env)).entries.some((entry) => entry.name === "after-crash");
+        if (holderExited) throw await holderDeathError();
+        expect(landed).toBe(false);
         holder.kill("SIGKILL");
         const [exitCode, stderr] = await Promise.all([workerExit, workerStderr]);
         expect(stderr).toBe("");

--- a/tests/unit/skills/store.test.ts
+++ b/tests/unit/skills/store.test.ts
@@ -296,6 +296,11 @@ v2 body
         `await installSnapshot({ sourceDirectory: ${JSON.stringify(source)}, env: { ...process.env, VESICLE_CONFIG_DIR: ${JSON.stringify(env.VESICLE_CONFIG_DIR)} } });`,
       ].join("\n");
       const holder = Bun.spawn({ cmd: [process.execPath, "-e", holderScript], stdout: "pipe", stderr: "pipe" });
+      let holderExited = false;
+      const holderExit = holder.exited.then((exitCode) => {
+        holderExited = true;
+        return exitCode;
+      });
       try {
         for (let attempt = 0; attempt < 200; attempt++) {
           if (await lstat(ready).catch(() => undefined)) break;
@@ -312,9 +317,22 @@ v2 body
           return exitCode;
         });
         await Bun.sleep(100);
+        if (holderExited) {
+          // The holder holds the SQLite write lock, so its death is the only way the
+          // worker can finish early. A dead holder is environmental (e.g. a runner
+          // OOM-kill), not a store defect, and must not be misread as a locking failure.
+          throw new Error(
+            `Lock holder died while it should have been sleeping: exit ${await holderExit}; `
+              + `worker ${workerExited ? `already exited with ${await workerExit}` : "still running"}`,
+          );
+        }
         if (workerExited) {
           throw new Error(`Index worker exited before the holder: ${await workerExit}\n${await workerStdout}\n${await workerStderr}`);
         }
+        // The index write happens inside the cross-process lock, so while the holder
+        // lives the install cannot have landed: this proves the worker was genuinely
+        // blocked on the lock, not merely slow to boot.
+        expect((await readActiveIndex(env)).entries.some((entry) => entry.name === "after-crash")).toBe(false);
         holder.kill("SIGKILL");
         const [exitCode, stderr] = await Promise.all([workerExit, workerStderr]);
         expect(stderr).toBe("");


### PR DESCRIPTION
## Summary

Hardens the flaky-class diagnostics of `cross-process index updates wait for the owner and recover after it exits` (`tests/unit/skills/store.test.ts`), the test that produced a one-off CI failure on the first run of #227.

- **Failure classification.** The observed CI failure was `Index worker exited before the holder: 0` — the sleeping lock holder had been killed by the environment (most plausibly a runner OOM-kill; the run sat in a fast window, worker exit 0, empty streams), SQLite released the cross-process lock with the holder's death, and the worker legitimately completed inside the 100ms liveness window. The test's premise had broken, not the store. The test now tracks holder liveness and reports its death as a distinct environmental failure, carrying the holder's exit code and the worker's state, so any future occurrence is classified in one line instead of requiring log forensics.
- **Oracle strengthening.** While the holder lives, the index write cannot have happened (it runs inside `withIndexLock`). The test now asserts the active index does not yet contain the install before killing the holder, proving the worker was genuinely blocked on the lock rather than merely slow to boot when the liveness check passes.

No production code changes; no behavioral change to the store. Timing structure (2s ready poll, 100ms observation) is unchanged.

## Analysis evidence

- CI first-run failure detail recovered from the Actions log: `error: Index worker exited before the holder: 0` at 138.78ms total — faster than the stable ~196ms local passing baseline, i.e. a fast window, ruling out slowness/timeout paths.
- `installSnapshot` on a fresh store necessarily passes `withIndexLock` (`BEGIN IMMEDIATE` retry, 50ms interval, 10s deadline), so a clean sub-100ms exit is only possible if the lock was already free — i.e. the holder process was gone.
- Not reproducible locally: 40 iterations under 4-way CPU load, all green; CI rerun of the same code green; no prior flake history for this test (introduced in #155).

## Test Plan

- `bun test tests/unit/skills/store.test.ts` × 8: 28 pass / 0 fail each run, per-test duration unchanged (~196ms vs baseline).
- `bun run lint` / `typecheck`: clean. `bun test`: 2124 pass / 0 fail / 10 skip.
