### PR TITLE
fix(tui): isolate shell tests from startup splash

### DIFF
--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -16,7 +16,7 @@ import { loadArtifactPreview, scanArtifacts } from "../core/artifacts/workbench"
 import type { ArtifactEntry } from "../core/artifacts/workbench";
 import type { QualityWarning } from "../core/quality";
 import { resolveTuiLayout } from "./layout";
-import { resolveSplashMode } from "./brand-mark";
+import { resolveSplashMode, type SplashMode } from "./brand-mark";
 import { Splash } from "./widgets/Splash";
 import { Sidebar } from "./views/Sidebar";
 import { MessageStream } from "./views/MessageStream";
@@ -89,6 +89,8 @@ export type AppProps = {
   dangerouslySkipPermissions?: boolean;
   initialResume?: boolean;
   bootstrapOnly?: boolean;
+  /** Explicit startup-splash mode for deterministic host and test rendering. */
+  splashMode?: SplashMode;
   /** Effective theme-preference owner (source precedence, session override, project persistence). */
   theme?: ThemePreferenceController;
   /** Called after the renderer has been destroyed to finish a CLI TUI exit. */
@@ -196,7 +198,7 @@ export function App(props: AppProps = {}) {
   const [restoringSession, setRestoringSession] = createSignal(false);
   // M1 startup splash: the mode is decided once from terminal capabilities and
   // environment; "skip" (non-interactive terminal) never mounts the overlay.
-  const splashMode = resolveSplashMode({
+  const splashMode = props.splashMode ?? resolveSplashMode({
     isTty: Boolean(process.stdout.isTTY),
     rgb: renderer.capabilities?.rgb ?? true,
     reducedMotion: process.env.VESICLE_REDUCED_MOTION === "1",

--- a/tests/component/tui/shell-sidebar.test.tsx
+++ b/tests/component/tui/shell-sidebar.test.tsx
@@ -6,7 +6,7 @@ import { backgroundProcess } from "./fixtures/tui";
 
 describe("tui: shell and sidebar", () => {
   test("renders a readable balanced shell at 100 columns", async () => {
-    const setup = await testRender(() => <App />, { width: 100, height: 28 });
+    const setup = await testRender(() => <App splashMode="skip" />, { width: 100, height: 28 });
     await setup.flush();
     const frame = setup.captureCharFrame();
     setup.renderer.destroy();
@@ -18,7 +18,7 @@ describe("tui: shell and sidebar", () => {
     expect(frame).toContain("┌─ Status");
     expect(frame).not.toContain("Output / Validation");
     // Empty sessions show the brand hero (M2) instead of the old bare "Ready"
-    // system notice; the splash skips non-interactive renders like this one.
+    // system notice; this layout test explicitly skips the startup overlay.
     expect(frame).toContain("one beam in, the spectrum out");
     expect(frame).not.toContain("system>");
     // Input bar present; provider registry loads asynchronously before the first send.
@@ -26,7 +26,7 @@ describe("tui: shell and sidebar", () => {
   });
 
   test("renders the sidebar and telemetry footer at wide width (no activity pane)", async () => {
-    const setup = await testRender(() => <App />, { width: 124, height: 28 });
+    const setup = await testRender(() => <App splashMode="skip" />, { width: 124, height: 28 });
     await setup.flush();
     const frame = setup.captureCharFrame();
     setup.renderer.destroy();


### PR DESCRIPTION
## Summary

- let App accept an explicit startup splash mode for deterministic host and test rendering
- make shell/sidebar layout tests skip the startup overlay explicitly
- preserve normal CLI splash auto-detection when the override is omitted

## Why

Running the documented bare bun test command from an interactive PTY exposed the startup splash, so two layout tests captured the overlay instead of the shell. CI was green because its non-interactive stdout skipped the splash. The tests now declare the surface they intend to render instead of depending on the terminal that launched Bun.

## Verification

- focused PTY suite: 7 pass, 0 fail
- focused PTY suite with --rerun-each 20: 140 pass, 0 fail
- full interactive PTY suite: 2167 pass, 10 expected skips, 0 fail
- bun run lint
- bun run typecheck
- bun run doctor (Missing: none)
- bun run skills:docs:check
- git diff --check
