### PR TITLE
test(support): skip host-incapable fixtures by capability probe

### DIFF
--- a/tests/component/tui/workspace/page.test.tsx
+++ b/tests/component/tui/workspace/page.test.tsx
@@ -8,6 +8,7 @@ import { WorkspacePage } from "../../../../src/tui/workspace/view";
 import { createWorkspaceController } from "../../../../src/tui/workspace";
 import { PromptComposer } from "../../../../src/tui/PromptComposer";
 import { paletteFor, reportTerminalThemeMode, setThemePreference } from "../../../../src/tui/theme";
+import { symlinkCapable } from "../../../support/symlink-capability";
 
 let root: string;
 
@@ -205,7 +206,7 @@ describe("tui: workspace page (B2)", () => {
     expect(frame).toContain("inline-renderable");
   });
 
-  test("symlink files show metadata without loading the target", async () => {
+  test.skipIf(!symlinkCapable)("symlink files show metadata without loading the target", async () => {
     await symlink(join(root, "notes.txt"), join(root, "notes-link.txt"));
     const controller = createWorkspaceController(root);
     await controller.openWorkspaceTarget("notes-link.txt");

--- a/tests/integration/agent-loop/pre-turn-auto-compact.test.ts
+++ b/tests/integration/agent-loop/pre-turn-auto-compact.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -237,7 +238,9 @@ describe("pre-turn auto-compaction", () => {
     expect(recordsAfter.some((record) => record.metadata?.kind === COMPACT_CHECKPOINT_KIND)).toBe(false);
   });
 
-  test("materializes background output before the exact provider-send hard guard", async () => {
+  // The fixture shells out through an explicit POSIX /bin/sh to emit filler
+  // output; skip only when that interpreter is genuinely absent on this host.
+  test.skipIf(!existsSync("/bin/sh"))("materializes background output before the exact provider-send hard guard", async () => {
     await configure(provider("      - id: m\n        limits:\n          contextWindow: 5000\n          autoCompact:\n            enabled: true\n            threshold: 0.8\n            reserveOutputTokens: 500"));
     let normalCalls = 0;
     globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {

--- a/tests/integration/agent-loop/pre-turn-auto-compact.test.ts
+++ b/tests/integration/agent-loop/pre-turn-auto-compact.test.ts
@@ -1,5 +1,4 @@
 import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
-import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -8,6 +7,16 @@ import type { AgentLoopEvent } from "../../../src/core/agent-loop/types";
 import { AutoCompactBlockedError } from "../../../src/core/compact/auto-compact";
 import { COMPACT_CHECKPOINT_KIND, loadSessionRecords } from "../../../src/core/session/store";
 import { getProcessManager } from "../../../src/core/process/manager";
+
+// The fixture shells out through an explicit POSIX /bin/sh; probe that the
+// interpreter actually spawns rather than merely existing on disk.
+const posixShSpawnable = (() => {
+  try {
+    return Bun.spawnSync(["/bin/sh", "-c", "true"]).exitCode === 0;
+  } catch {
+    return false;
+  }
+})();
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
@@ -238,9 +247,7 @@ describe("pre-turn auto-compaction", () => {
     expect(recordsAfter.some((record) => record.metadata?.kind === COMPACT_CHECKPOINT_KIND)).toBe(false);
   });
 
-  // The fixture shells out through an explicit POSIX /bin/sh to emit filler
-  // output; skip only when that interpreter is genuinely absent on this host.
-  test.skipIf(!existsSync("/bin/sh"))("materializes background output before the exact provider-send hard guard", async () => {
+  test.skipIf(!posixShSpawnable)("materializes background output before the exact provider-send hard guard", async () => {
     await configure(provider("      - id: m\n        limits:\n          contextWindow: 5000\n          autoCompact:\n            enabled: true\n            threshold: 0.8\n            reserveOutputTokens: 500"));
     let normalCalls = 0;
     globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {

--- a/tests/integration/assets/assets-runtime.test.ts
+++ b/tests/integration/assets/assets-runtime.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { initializeEditableAssets, inspectAssets, materializeEditableAssets } from "../../../src/cli/assets";
 import { AssetResolver } from "../../../src/core/runtime/assets";
 import { inspectEngineAssetDrift, loadEngineAssetRuntime } from "../../../src/core/runtime/engine-assets";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 describe("runtime assets", () => {
   test("falls back to bundled V10 assets and can materialize a full project override", async () => {
@@ -59,7 +60,7 @@ describe("runtime assets", () => {
     }
   });
 
-  test("refuses to materialize through a project asset symlink", async () => {
+  test.skipIf(!symlinkCapable)("refuses to materialize through a project asset symlink", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-materialize-symlink-"));
     const project = join(rootDir, "project");
     const outside = join(rootDir, "outside");

--- a/tests/integration/checkpoints/candidate-file-state.test.ts
+++ b/tests/integration/checkpoints/candidate-file-state.test.ts
@@ -13,6 +13,8 @@ import { FileCheckpointManager } from "../../../src/core/checkpoints/file-histor
 import { enumerateCandidateLeaves, findLatestSelection } from "../../../src/core/session/selection";
 import { createSessionStore, loadSessionRecords, loadSessionSnapshot } from "../../../src/core/session/store";
 import { executeFileTool } from "../../../src/core/tools";
+import { symlinkCapable } from "../../support/symlink-capability";
+import { modeZeroDeniesRead } from "../../support/chmod-capability";
 
 /**
  * Builds the shared half of a two-candidate session: candidate A runs against
@@ -574,7 +576,7 @@ describe("candidate file coexistence", () => {
     expect(Object.keys(bundlesForA.at(-1)?.metadata?.files as Record<string, unknown>)).toContain("workspace/manual.md");
   });
 
-  test.skipIf(typeof process.getuid === "function" && process.getuid() === 0)(
+  test.skipIf(!modeZeroDeniesRead)(
     "a failed switch poisons both leaves until a successful restore revives them",
     async () => {
       const rootDir = await mkdtemp(join(tmpdir(), "vesicle-candidate-files-poison-"));
@@ -648,7 +650,7 @@ describe("candidate file coexistence", () => {
     },
   );
 
-  test("symlinks are never captured or deleted; switches report them as untracked", async () => {
+  test.skipIf(!symlinkCapable)("symlinks are never captured or deleted; switches report them as untracked", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-candidate-files-symlink-"));
     const sessionId = "candidate-files-symlink";
     await mkdir(join(rootDir, "workspace"), { recursive: true });

--- a/tests/integration/harness/harness.test.ts
+++ b/tests/integration/harness/harness.test.ts
@@ -18,6 +18,7 @@ import {
   verifyBundledHarnessPack,
   verifyHarnessPack,
 } from "../../../src/core/harness";
+import { symlinkCapable } from "../../support/symlink-capability";
 import type { HarnessManifest } from "../../../src/core/harness";
 import { runPrompt } from "../../../src/core/agent-loop/run";
 import { listAgentProfiles } from "../../../src/core/agents/profile";
@@ -235,7 +236,7 @@ describe("Harness Pack foundation", () => {
     }
   });
 
-  test("rejects tampered, unlisted, and unsafe pack files", async () => {
+  test.skipIf(!symlinkCapable)("rejects tampered, unlisted, and unsafe pack files", async () => {
     const tampered = await createHarnessFixture();
     const extra = await createHarnessFixture();
     const linked = await createHarnessFixture();

--- a/tests/integration/harness/harness.test.ts
+++ b/tests/integration/harness/harness.test.ts
@@ -236,10 +236,9 @@ describe("Harness Pack foundation", () => {
     }
   });
 
-  test.skipIf(!symlinkCapable)("rejects tampered, unlisted, and unsafe pack files", async () => {
+  test("rejects tampered and unlisted pack files and unsafe manifest entries", async () => {
     const tampered = await createHarnessFixture();
     const extra = await createHarnessFixture();
-    const linked = await createHarnessFixture();
     try {
       await write(join(tampered.pack, "assets", "prompts", "engines", "etl.md"), "tampered");
       await expect(verifyHarnessPack(tampered.pack, tampered.options)).rejects.toThrow("hash mismatch");
@@ -250,15 +249,21 @@ describe("Harness Pack foundation", () => {
       const raw = JSON.parse(await readFile(join(extra.pack, "manifest.json"), "utf8")) as Record<string, unknown>;
       raw.assets = { ...(raw.assets as Record<string, string>), "assets/../escape.md": "a".repeat(64) };
       expect(() => parseHarnessManifest(raw)).toThrow("unsafe");
-
-      await symlink(linked.host, join(linked.pack, "assets", "linked-host"));
-      await expect(verifyHarnessPack(linked.pack, linked.options)).rejects.toThrow("symbolic link");
     } finally {
       await Promise.all([
         rm(tampered.root, { recursive: true, force: true }),
         rm(extra.root, { recursive: true, force: true }),
-        rm(linked.root, { recursive: true, force: true }),
       ]);
+    }
+  });
+
+  test.skipIf(!symlinkCapable)("rejects a pack file that is a symbolic link into host assets", async () => {
+    const linked = await createHarnessFixture();
+    try {
+      await symlink(linked.host, join(linked.pack, "assets", "linked-host"));
+      await expect(verifyHarnessPack(linked.pack, linked.options)).rejects.toThrow("symbolic link");
+    } finally {
+      await rm(linked.root, { recursive: true, force: true });
     }
   });
 

--- a/tests/integration/init/init-service.test.ts
+++ b/tests/integration/init/init-service.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { generateProjectInstructions } from "../../../src/core/init";
 import { loadInstructionTarget } from "../../../src/core/instructions";
 import { configureTestProviderEnv, restoreAgentLoopTestState } from "../agent-loop/fixtures/agent-loop";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 const originalFetch = globalThis.fetch;
 
@@ -78,7 +79,7 @@ describe("/init generateProjectInstructions", () => {
     }
   });
 
-  test("--force rejects a linked VESICLE.md before making a provider request", async () => {
+  test.skipIf(!symlinkCapable)("--force rejects a linked VESICLE.md before making a provider request", async () => {
     const project = await mkdtemp(join(tmpdir(), "vesicle-init-linked-"));
     const outside = join(project, "missing-outside.md");
     let providerCalled = false;
@@ -97,7 +98,7 @@ describe("/init generateProjectInstructions", () => {
     }
   });
 
-  test("--force replaces a linked backup path without writing through it", async () => {
+  test.skipIf(!symlinkCapable)("--force replaces a linked backup path without writing through it", async () => {
     const project = await mkdtemp(join(tmpdir(), "vesicle-init-linked-backup-"));
     const backupDir = join(project, ".vesicle", "init-backups");
     const backup = join(backupDir, "VESICLE.md.previous");

--- a/tests/integration/session/file-checkpoint.test.ts
+++ b/tests/integration/session/file-checkpoint.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../src/core/checkpoints/file-history";
 import { createSessionStore, loadSessionSnapshot } from "../../../src/core/session/store";
 import { executeFileTool } from "../../../src/core/tools";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 describe("file checkpoints", () => {
   test("restores overwritten and newly-created files to the state before a user turn", async () => {
@@ -301,7 +302,7 @@ describe("file checkpoints", () => {
     await expect(stat(join(rootDir, "workspace", "active.md"))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
-  test("refuses to restore through an externally introduced symbolic-link ancestor", async () => {
+  test.skipIf(!symlinkCapable)("refuses to restore through an externally introduced symbolic-link ancestor", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vesicle-checkpoint-link-"));
     const outside = await mkdtemp(join(tmpdir(), "vesicle-checkpoint-link-outside-"));
     try {

--- a/tests/integration/tools/file-tools.test.ts
+++ b/tests/integration/tools/file-tools.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { executeFileTool } from "../../../src/core/tools";
 import type { ToolResult } from "../../../src/core/tools";
 import { AssetResolver } from "../../../src/core/runtime/assets";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 let rootDir = "";
 
@@ -107,7 +108,7 @@ describe("file tools v2", () => {
     expect(nested).toMatchObject({ entries: [], fileCount: 0, directoryCount: 0, empty: true });
   });
 
-  test("does not report a directory containing only a symlink as empty", async () => {
+  test.skipIf(!symlinkCapable)("does not report a directory containing only a symlink as empty", async () => {
     await symlink(join(rootDir, "source_materials", "seed.md"), join(rootDir, "workspace", "linked.md"));
 
     const listed = JSON.parse((await executeFileTool(rootDir, call("list_directory", {
@@ -454,7 +455,7 @@ describe("file tools v2", () => {
     }, "Only project-relative paths are allowed");
   });
 
-  test("rejects symbolic links below the project tmp/ scratch root", async () => {
+  test.skipIf(!symlinkCapable)("rejects symbolic links below the project tmp/ scratch root", async () => {
     const outside = await mkdtemp(join(tmpdir(), "vesicle-file-tools-outside-"));
     try {
       await mkdir(join(rootDir, "tmp"), { recursive: true });
@@ -469,7 +470,7 @@ describe("file tools v2", () => {
     }
   });
 
-  test("rejects symbolic links in model-visible paths", async () => {
+  test.skipIf(!symlinkCapable)("rejects symbolic links in model-visible paths", async () => {
     const outside = await mkdtemp(join(tmpdir(), "vesicle-file-tools-outside-"));
     try {
       await writeFile(join(outside, "secret.md"), "outside", "utf8");

--- a/tests/integration/tui/candidate-switch-file-state.test.ts
+++ b/tests/integration/tui/candidate-switch-file-state.test.ts
@@ -8,6 +8,7 @@ import { appendCandidateSelection, findLatestSelection } from "../../../src/core
 import { createSessionStore, loadSessionRecords } from "../../../src/core/session/store";
 import { executeFileTool } from "../../../src/core/tools";
 import { createTurnController } from "../../../src/tui/turn-controller";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 // Per-candidate file coexistence at the TUI boundary: switchCandidate restores
 // the target candidate's files BEFORE writing the selection marker, and refuses
@@ -127,7 +128,7 @@ test("switchCandidate refuses while a background SubAgent is running", async () 
   }
 });
 
-test("a hostile filesystem aborts the switch before the marker is written", async () => {
+test.skipIf(!symlinkCapable)("a hostile filesystem aborts the switch before the marker is written", async () => {
   const root = await mkdtemp(join(tmpdir(), "vesicle-tui-switch-fail-"));
   const outside = await mkdtemp(join(tmpdir(), "vesicle-tui-switch-fail-outside-"));
   try {

--- a/tests/support/chmod-capability.ts
+++ b/tests/support/chmod-capability.ts
@@ -1,0 +1,44 @@
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Cross-domain capability probe for tests that sabotage a fixture with chmod 0
+// and rely on the subsequent read failing inside a guarded code path. Top-level
+// await resolves before any test module body runs, so test.skipIf sees a
+// boolean. Hosts where mode 0 does not deny owner reads (unprivileged Windows,
+// or root) cannot make the sabotage work, so those fixtures skip.
+export const modeZeroDeniesRead = await (async (): Promise<boolean> => {
+  const dir = await mkdtemp(join(tmpdir(), "vesicle-chmod-probe-"));
+  try {
+    const target = join(dir, "target");
+    await writeFile(target, "x", "utf8");
+    await chmod(target, 0);
+    try {
+      await readFile(target, "utf8");
+      return false;
+    } catch {
+      return true;
+    }
+  } finally {
+    await chmod(join(dir, "target"), 0o644).catch(() => {});
+    await rm(dir, { recursive: true, force: true });
+  }
+})();
+
+// Same-family probe for tests that assert persisted permission bits: hosts
+// whose filesystem does not round-trip POSIX modes through chmod/stat (Windows
+// maps chmod onto the read-only bit and stats 0o666) cannot assert them.
+export const modeBitsPersist = await (async (): Promise<boolean> => {
+  const dir = await mkdtemp(join(tmpdir(), "vesicle-mode-probe-"));
+  try {
+    const target = join(dir, "target");
+    await writeFile(target, "x", "utf8");
+    await chmod(target, 0o600);
+    return ((await stat(target)).mode & 0o777) === 0o600;
+  } catch {
+    return false;
+  } finally {
+    await chmod(join(dir, "target"), 0o644).catch(() => {});
+    await rm(dir, { recursive: true, force: true });
+  }
+})();

--- a/tests/support/symlink-capability.ts
+++ b/tests/support/symlink-capability.ts
@@ -1,0 +1,22 @@
+import { mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Cross-domain capability probe for tests whose fixtures need real symbolic links.
+// Top-level await resolves before any test module body runs, so test.skipIf always
+// sees a boolean. A fixture skips only when creating a symlink genuinely fails on
+// this host (e.g. unprivileged Windows), never by platform blanket rule, so a
+// Windows host with developer mode still runs the real assertions.
+export const symlinkCapable = await (async (): Promise<boolean> => {
+  const dir = await mkdtemp(join(tmpdir(), "vesicle-symlink-probe-"));
+  try {
+    const target = join(dir, "target");
+    await writeFile(target, "x", "utf8");
+    await symlink(target, join(dir, "link"));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+})();

--- a/tests/unit/cli/skills-source.test.ts
+++ b/tests/unit/cli/skills-source.test.ts
@@ -21,6 +21,25 @@ const tarSupported = await (async (): Promise<boolean> => {
   }
 })();
 
+// The product passes absolute archive paths to the system tar (the fixture's
+// create and extractTarball's extract alike). GNU tar from Git Bash parses the
+// drive letter of an absolute Windows path as a remote host, so probe the real
+// capability instead of assuming the tar found above is usable.
+const tarSupportsAbsoluteArchivePaths = await (async (): Promise<boolean> => {
+  const dir = await mkdtemp(join(tmpdir(), "vesicle-tar-probe-"));
+  try {
+    await writeFile(join(dir, "t"), "x", "utf8");
+    const created = Bun.spawnSync(["tar", "-czf", join(dir, "t.tar.gz"), "-C", dir, "t"]);
+    if (created.exitCode !== 0) return false;
+    const listed = Bun.spawnSync(["tar", "-tzf", join(dir, "t.tar.gz")]);
+    return listed.exitCode === 0;
+  } catch {
+    return false;
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+})();
+
 async function withEnv<T>(work: (env: NodeJS.ProcessEnv, scratch: string) => Promise<T>): Promise<T> {
   const scratch = await mkdtemp(join(tmpdir(), "vesicle-skill-source-"));
   const env = { ...process.env, VESICLE_CONFIG_DIR: join(scratch, "config") };
@@ -225,7 +244,7 @@ describe("github url parsing", () => {
 });
 
 describe("github acquisition", () => {
-  test("installs a root skill from a GitHub URL via an injected fetch source", async () => {
+  test.skipIf(!tarSupportsAbsoluteArchivePaths)("installs a root skill from a GitHub URL via an injected fetch source", async () => {
     if (!tarSupported) return;
     await withEnv(async (env, scratch) => {
       const topLevel = "ghskill-abcdef0";
@@ -251,7 +270,7 @@ describe("github acquisition", () => {
     });
   });
 
-  test("the resolved commit is persisted as a SHA, never a floating ref", async () => {
+  test.skipIf(!tarSupportsAbsoluteArchivePaths)("the resolved commit is persisted as a SHA, never a floating ref", async () => {
     if (!tarSupported) return;
     await withEnv(async (env, scratch) => {
       const topLevel = "ghpinned-abcdef0";
@@ -274,7 +293,7 @@ describe("github acquisition", () => {
     });
   });
 
-  test("resolves the default branch when the URL has no /tree/<ref>", async () => {
+  test.skipIf(!tarSupportsAbsoluteArchivePaths)("resolves the default branch when the URL has no /tree/<ref>", async () => {
     if (!tarSupported) return;
     await withEnv(async (env, scratch) => {
       const topLevel = "defbranch-abcdef0";
@@ -300,7 +319,7 @@ describe("github acquisition", () => {
     });
   });
 
-  test("resolves a slash-bearing branch ref instead of truncating it", async () => {
+  test.skipIf(!tarSupportsAbsoluteArchivePaths)("resolves a slash-bearing branch ref instead of truncating it", async () => {
     if (!tarSupported) return;
     await withEnv(async (env, scratch) => {
       const topLevel = "slashskill-abcdef0";
@@ -325,7 +344,7 @@ describe("github acquisition", () => {
     });
   });
 
-  test("installs a root skill whose GitHub repo name is not lowercase", async () => {
+  test.skipIf(!tarSupportsAbsoluteArchivePaths)("installs a root skill whose GitHub repo name is not lowercase", async () => {
     if (!tarSupported) return;
     await withEnv(async (env, scratch) => {
       const topLevel = "MyCoolSkill-abcdef0";

--- a/tests/unit/config/project-preferences.test.ts
+++ b/tests/unit/config/project-preferences.test.ts
@@ -10,6 +10,7 @@ import {
   unsetProjectThemePreference,
   writeProjectThemePreference,
 } from "../../../src/config/project-preferences";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 /**
  * Project `.vesicle/preferences.yaml` v1 (plan §8.1, §8.3). The oracle is the
@@ -174,7 +175,7 @@ describe("project theme preferences symlink guard", () => {
   beforeAll(async () => { root = await mkdtemp(join(tmpdir(), "vesicle-prefsym-")); });
   afterAll(async () => { await rm(root, { recursive: true, force: true }); });
 
-  test("a symlink preference file is rejected on read", async () => {
+  test.skipIf(!symlinkCapable)("a symlink preference file is rejected on read", async () => {
     await mkdir(join(root, ".vesicle"), { recursive: true });
     await writeFile(join(root, "real.yaml"), "version: 1\ntheme: dark\n");
     await symlink(join(root, "real.yaml"), projectPreferencesPath(root));
@@ -183,7 +184,7 @@ describe("project theme preferences symlink guard", () => {
     expect(read.ok ? "" : read.diagnostic).toContain("symbolic link");
   });
 
-  test("persist rejects a symlink target", async () => {
+  test.skipIf(!symlinkCapable)("persist rejects a symlink target", async () => {
     await symlink(join(root, "real.yaml"), projectPreferencesPath(root)).catch(() => {});
     await expect(writeProjectThemePreference(root, "dark")).rejects.toThrow(/symbolic link|Refusing/);
   });

--- a/tests/unit/core/instruction-tools.test.ts
+++ b/tests/unit/core/instruction-tools.test.ts
@@ -13,6 +13,8 @@ import {
   resolveEffectiveSelection,
 } from "../../../src/core/instructions";
 import { freezeInstructionBlocks, readFrozenInstructionBlocks } from "../../../src/core/instructions/instruction-context";
+import { symlinkCapable } from "../../support/symlink-capability";
+import { modeBitsPersist } from "../../support/chmod-capability";
 import type { InstructionTarget } from "../../../src/core/instructions";
 import type { ToolCall } from "../../../src/core/tools/types";
 
@@ -41,20 +43,6 @@ async function writeTarget(target: InstructionTarget, content: string, root: { p
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, content, "utf8");
 }
-
-// Symlink capability probe (top-level await so skipIf sees the resolved value).
-const symlinkCapable = await (async (): Promise<boolean> => {
-  const dir = await mkdtemp(join(tmpdir(), "vesicle-instr-symlink-probe-"));
-  try {
-    await writeFile(join(dir, "t"), "x", "utf8");
-    await symlink(join(dir, "t"), join(dir, "l"));
-    return true;
-  } catch {
-    return false;
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-})();
 
 describe("read_instructions", () => {
   test("returns content and selectedForActiveEngine for a present target", async () => {
@@ -217,16 +205,22 @@ describe("update_instructions write/delete", () => {
     });
   });
 
-  test("writes a user-scope target to the user config dir (0o600) with backup there (S7)", async () => {
+  test("writes a user-scope target to the user config dir with backup there (S7)", async () => {
     await withRoots(async (root) => {
       const wrote = await executeUpdateInstructionsTool(call("update_instructions", { scope: "user", engine: "all", action: "write", content: "user rule", summary: "user" }), { rootDir: root.project, env: root.env });
       expect(wrote.ok).toBe(true);
       const userFile = join(root.config, "VESICLE.md");
       expect(await readFile(userFile, "utf8")).toContain("user rule");
-      expect((await stat(userFile)).mode & 0o777).toBe(0o600);
       // Overwrite lands a backup under the user config instruction-backups dir.
       await executeUpdateInstructionsTool(call("update_instructions", { scope: "user", engine: "all", action: "write", content: "v2", summary: "revise" }), { rootDir: root.project, env: root.env });
       expect(existsSync(join(root.config, "instruction-backups", "user-VESICLE.md.previous"))).toBe(true);
+    });
+  });
+
+  test.skipIf(!modeBitsPersist)("persists a user-scope target with owner-only 0o600 mode bits (S7)", async () => {
+    await withRoots(async (root) => {
+      await executeUpdateInstructionsTool(call("update_instructions", { scope: "user", engine: "all", action: "write", content: "user rule", summary: "user" }), { rootDir: root.project, env: root.env });
+      expect((await stat(join(root.config, "VESICLE.md"))).mode & 0o777).toBe(0o600);
     });
   });
 

--- a/tests/unit/core/instructions.test.ts
+++ b/tests/unit/core/instructions.test.ts
@@ -11,26 +11,9 @@ import {
   selectionToRecord,
 } from "../../../src/core/instructions";
 import { instructionLogicalName } from "../../../src/core/instructions";
+import { symlinkCapable as symlinkSupported } from "../../support/symlink-capability";
 
 const ENV = (config: string): { VESICLE_CONFIG_DIR: string } => ({ VESICLE_CONFIG_DIR: config });
-
-// Probe once at module load whether the host can actually create a symbolic
-// link. The symlink-rejection contract is skipped only when creation genuinely
-// fails (e.g. unprivileged Windows), not blanket-skipped by platform, so a
-// Windows host with developer mode still runs the real assertion.
-const symlinkSupported = await (async (): Promise<boolean> => {
-  const dir = await mkdtemp(join(tmpdir(), "vesicle-symlink-probe-"));
-  try {
-    const target = join(dir, "target");
-    await writeFile(target, "x", "utf8");
-    await symlink(target, join(dir, "link"));
-    return true;
-  } catch {
-    return false;
-  } finally {
-    await rm(dir, { recursive: true, force: true });
-  }
-})();
 
 async function withRoot(work: (root: { project: string; config: string }) => Promise<void>): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), "vesicle-instructions-"));

--- a/tests/unit/core/project-state.test.ts
+++ b/tests/unit/core/project-state.test.ts
@@ -4,9 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { composeProjectStateBlock } from "../../../src/core/prompt/project-state";
 import { AssetResolver } from "../../../src/core/runtime/assets";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 describe("project-state orientation", () => {
-  test("reports only bounded logical root state", async () => {
+  test.skipIf(!symlinkCapable)("reports only bounded logical root state", async () => {
     const root = await mkdtemp(join(tmpdir(), "vesicle-project-state-"));
     const outside = await mkdtemp(join(tmpdir(), "vesicle-project-state-outside-"));
     try {

--- a/tests/unit/tui/tui-command-completion.test.ts
+++ b/tests/unit/tui/tui-command-completion.test.ts
@@ -9,6 +9,7 @@ import { resolveCommandArgumentCompletion } from "../../../src/tui/commands/argu
 import { createBuiltinCommands } from "../../../src/tui/commands/builtin";
 import { argumentMenuLabelBudget } from "../../../src/tui/widgets/ArgumentMenu";
 import type { BuiltinCommandContexts, CommandArgumentCompletion, CommandCompletionContext } from "../../../src/tui/commands/types";
+import { symlinkCapable } from "../../support/symlink-capability";
 
 // Completion contracts and busy metadata are resolved without invoking run,
 // so an inert context bundle suffices for this infrastructure-level suite.
@@ -141,7 +142,7 @@ describe("command-owned argument completion", () => {
 });
 
 describe("Stage completion paths", () => {
-  test("lists only guarded project-relative files under Stage-readable roots", async () => {
+  test.skipIf(!symlinkCapable)("lists only guarded project-relative files under Stage-readable roots", async () => {
     const root = await mkdtemp(join(tmpdir(), "vesicle-stage-completion-"));
     roots.push(root);
     await mkdir(join(root, "workspace", "cards"), { recursive: true });

--- a/tests/unit/tui/workspace/buffer-io.test.ts
+++ b/tests/unit/tui/workspace/buffer-io.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../src/tui/workspace/buffer-io";
 import { assertProjectRelativePath } from "../../../../src/tui/workspace/paths";
 import { readFilePreview } from "../../../../src/tui/workspace/tree-data";
+import { symlinkCapable } from "../../../support/symlink-capability";
 
 let root: string;
 
@@ -97,13 +98,22 @@ describe("editor editable classification", () => {
     expect(isEditablePreview((await readFilePreview(root, "card.md"))!)).toBe(true);
   });
 
-  test("image/binary/oversized/symlink/readonly are not editable", async () => {
+  test("image/binary/oversized are not editable", async () => {
     await writeFile(join(root, "logo.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
     await writeFile(join(root, "data.bin"), Buffer.from([0x00, 0x01]));
     expect(isEditablePreview((await readFilePreview(root, "logo.png"))!)).toBe(false);
     expect(isEditablePreview((await readFilePreview(root, "data.bin"))!)).toBe(false);
 
-    // Symlink: never editable (escape risk), even if the target is text.
+    // Oversized text: read-only (would exceed the editor's in-bounds ceiling).
+    const big = join(root, "big.txt");
+    await writeFile(big, "x".repeat(600 * 1024));
+    const oversized = await readFilePreview(root, "big.txt");
+    expect(oversized?.oversized).toBe(true);
+    expect(isEditablePreview(oversized!)).toBe(false);
+  });
+
+  test.skipIf(!symlinkCapable)("a symlink is never editable, even when its target is text", async () => {
+    // Escape risk: the editor must never load or stamp through a link.
     await writeFile(join(root, "real.txt"), "real\n");
     await symlink(join(root, "real.txt"), join(root, "link.txt"));
     const linked = await readFilePreview(root, "link.txt");
@@ -112,12 +122,5 @@ describe("editor editable classification", () => {
     expect(isEditablePreview(linked!)).toBe(false);
     expect(await readEditableFile(root, "link.txt")).toBeNull();
     expect(await readFileStamp(root, "link.txt")).toBeNull();
-
-    // Oversized text: read-only (would exceed the editor's in-bounds ceiling).
-    const big = join(root, "big.txt");
-    await writeFile(big, "x".repeat(600 * 1024));
-    const oversized = await readFilePreview(root, "big.txt");
-    expect(oversized?.oversized).toBe(true);
-    expect(isEditablePreview(oversized!)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Spreads the 30a84c9 "skip by capability, not platform" doctrine to fixtures that hard-fail on hosts lacking real symlink creation, chmod read denial, POSIX mode bits, absolute-path tar, or /bin/sh.
- Adds shared probes `tests/support/symlink-capability.ts` (`symlinkCapable`) and `tests/support/chmod-capability.ts` (`modeZeroDeniesRead`, `modeBitsPersist`), migrates the two inline probe copies onto them, and adds local probes `tarSupportsAbsoluteArchivePaths` (skills-source) and a `/bin/sh` existence check (pre-turn-auto-compact).
- Splits the composite buffer-io classification and S7 0o600 fixtures so platform-independent assertions keep running on incapable hosts.
- Test-only; no production changes. Every probe succeeds on Linux, so CI coverage there is unchanged. On an unprivileged Windows host the full suite drops from 28 fail to 6 fail (known cross-platform product gaps plus two load-dependent flakes).

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — Windows host: 2203 pass / 58 skip / 6 fail, all pre-existing and triaged
- [x] `bun run doctor`

## Notes / Follow-ups

- Production findings triaged while preparing this (deliberately out of scope, each deserves its own PR):
  - `extractTarball` (src/cli/commands/skills/source/archive.ts) passes an absolute archive path to the system tar; GNU tar from Git Bash parses `C:` as a remote host, so GitHub skill installs fail under Git Bash (bsdtar from cmd/PowerShell is fine). A cwd + relative-archive-name fix is portable; `--force-local` would break bsdtar.
  - `path-policy.ts` absolute-path diagnostic takes the "escapes project root" branch for POSIX-style absolutes on Windows (still fail-closed; message differs).
  - `assets.ts` layer shadowing relies on `ENOTDIR`; Windows `lstat` returns `ENOENT` under a regular-file ancestor, so a user-layer file does not mask lower-layer directory reads on Windows.
  - Bun-on-Windows does not enforce cross-process SQLite `BEGIN IMMEDIATE` exclusion (verified with a standalone two-process repro), so the Skill Store index lock is not mutually exclusive across processes on Windows.