### PR TITLE
fix(runtime): stabilize Windows contracts and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Windows asset overlays and guarded-path diagnostics now match the cross-platform contracts.** A project or user asset file now shadows lower-layer descendants even when Windows reports the attempted child lookup as `ENOENT` instead of POSIX `ENOTDIR`, so direct reads and merged listings cannot disagree. Model-visible file tools also classify rooted Windows and root-relative paths through the platform path API before the existing project-boundary guard.
 - **Concurrent Skill Store writes keep cross-process exclusion without a post-publication SQLite commit.** The reported Windows lock failure was traced to a test holder becoming unreachable across an `await`; Bun then performed its documented garbage-collection close and released the SQLite transaction. The Store itself keeps its `Database` live through explicit rollback/close. A separate burst-contention case could still let the atomic index update land and then report `SQLITE_BUSY` from `COMMIT`; because SQLite carries no Store data and serves only as a mutex, successful and failed critical sections now release it with `ROLLBACK`, while lock acquisition retains the bounded retry policy.
 
 ## [1.0.0-beta.2] - 2026-08-24

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test:component": "bun test tests/component",
     "test:integration": "bun test tests/integration",
     "test:contract": "bun test tests/contract",
-    "test:deterministic": "bun test tests/unit tests/component tests/integration tests/contract",
+    "test:deterministic": "bun run test:unit && bun run test:component && bun run test:integration && bun run test:contract",
     "test:acceptance:provider": "bun test ./tests/acceptance/provider/provider-connectivity.acceptance.ts ./tests/acceptance/provider/e2e-gate.acceptance.ts",
     "test:acceptance:gemini": "bun test ./tests/acceptance/provider/gemini-image-tool-result.acceptance.ts",
     "test:acceptance:gemini:websearch": "bun test ./tests/acceptance/provider/gemini-builtin-web-search.acceptance.ts",

--- a/src/core/runtime/assets.ts
+++ b/src/core/runtime/assets.ts
@@ -474,11 +474,15 @@ async function hasFileAncestor(
   suffixParts: readonly string[],
 ): Promise<boolean> {
   let current = layer.directory;
+  const ancestors = [current];
   for (const part of suffixParts.slice(0, -1)) {
     current = join(current, part);
+    ancestors.push(current);
+  }
+  for (const ancestor of ancestors) {
     let info: Stats;
     try {
-      info = await lstat(current);
+      info = await lstat(ancestor);
     } catch (error) {
       if (isMissing(error) || errorCode(error) === "ENOTDIR") return false;
       throw assetAccessError(logicalPath, error);

--- a/src/core/runtime/assets.ts
+++ b/src/core/runtime/assets.ts
@@ -432,15 +432,17 @@ async function resolveLayerEntry(
 ): Promise<{ absolutePath: string; info: Stats } | undefined> {
   if (!layerAllowsPath(layer, logicalPath)) return undefined;
   const suffix = logicalPath === "assets" ? "" : logicalPath.slice("assets/".length);
-  const candidate = join(layer.directory, ...suffix.split("/").filter(Boolean));
-  const entry = await lstat(candidate).catch((error: unknown) => {
-    if (isMissing(error)) return undefined;
-    if (errorCode(error) === "ENOTDIR") {
+  const suffixParts = suffix.split("/").filter(Boolean);
+  const candidate = join(layer.directory, ...suffixParts);
+  try {
+    await lstat(candidate);
+  } catch (error) {
+    if (errorCode(error) === "ENOTDIR" || (isMissing(error) && await hasFileAncestor(layer, logicalPath, suffixParts))) {
       throw new AssetPathShadowError(logicalPath);
     }
+    if (isMissing(error)) return undefined;
     throw assetAccessError(logicalPath, error);
-  });
-  if (!entry) return undefined;
+  }
 
   const [rootPath, absolutePath] = await Promise.all([realpath(layer.directory), realpath(candidate)]).catch((error: unknown) => {
     throw assetAccessError(logicalPath, error);
@@ -463,6 +465,28 @@ async function resolveLayerEntry(
     throw assetAccessError(logicalPath, error);
   });
   return { absolutePath, info };
+}
+
+/** Windows reports a descendant below a regular file as ENOENT, not ENOTDIR. */
+async function hasFileAncestor(
+  layer: AssetLayer,
+  logicalPath: string,
+  suffixParts: readonly string[],
+): Promise<boolean> {
+  let current = layer.directory;
+  for (const part of suffixParts.slice(0, -1)) {
+    current = join(current, part);
+    let info: Stats;
+    try {
+      info = await lstat(current);
+    } catch (error) {
+      if (isMissing(error) || errorCode(error) === "ENOTDIR") return false;
+      throw assetAccessError(logicalPath, error);
+    }
+    if (info.isSymbolicLink()) throw new Error(`Asset symlinks are not supported: ${logicalPath}.`);
+    if (info.isFile()) return true;
+  }
+  return false;
 }
 
 class AssetPathShadowError extends Error {

--- a/src/core/tools/file/path-policy.ts
+++ b/src/core/tools/file/path-policy.ts
@@ -1,5 +1,5 @@
 import { lstat, realpath } from "node:fs/promises";
-import { relative, resolve, sep } from "node:path";
+import { isAbsolute, relative, resolve, sep } from "node:path";
 import { modelReadableRoots, modelWritableRoots } from "../../project/roots";
 
 export const readableFileRoots = modelReadableRoots;
@@ -8,7 +8,7 @@ export const writableFileRoots = [...modelWritableRoots] as const;
 /** The single project-relative path policy for model-visible file tools. */
 export async function resolveAllowedPath(rootDir: string, requestedPath: string, roots: readonly string[]): Promise<string> {
   if (!requestedPath || requestedPath.includes("\0")) throw new Error("Path is required.");
-  if (resolve(requestedPath) === requestedPath) throw new Error("Only project-relative paths are allowed.");
+  if (isAbsolute(requestedPath)) throw new Error("Only project-relative paths are allowed.");
 
   const root = resolve(rootDir);
   const resolved = resolve(root, requestedPath);

--- a/tests/integration/agent-loop/fixtures/agent-loop.ts
+++ b/tests/integration/agent-loop/fixtures/agent-loop.ts
@@ -99,6 +99,9 @@ export async function configureTestProviderEnv(options: { models?: string[]; vis
   ].join("\n"), "utf8");
   await writeFile(join(configDir, ".env"), "TEST_PROVIDER_API_KEY=test-key\n", "utf8");
   process.env.VESICLE_PROVIDERS_FILE = configPath;
+  // Keep Agent Loop tests hermetic from a developer's user-level MCP registry.
+  // MCP-specific fixtures write this sibling path explicitly when needed.
+  process.env.VESICLE_MCP_FILE = join(configDir, "mcp.yaml");
   delete process.env.TEST_PROVIDER_API_KEY;
   delete process.env.VESICLE_API_KEY;
   delete process.env.VESICLE_PROVIDER;

--- a/tests/integration/agent-loop/subagent-foreground.test.ts
+++ b/tests/integration/agent-loop/subagent-foreground.test.ts
@@ -115,7 +115,7 @@ describe("agent loop: subagent foreground", () => {
     }) as typeof fetch;
 
     const turn = runPrompt({ input: "delegate", rootDir });
-    await eventually(() => expect(childResolvers).toHaveLength(2));
+    await eventually(() => expect(childResolvers).toHaveLength(2), { timeoutMs: 3_000 });
     expect(parentRequests).toBe(1);
     childResolvers[0]!(Response.json({ id: "child-a", choices: [{ message: { content: "source map" } }] }));
     childResolvers[1]!(Response.json({ id: "child-b", choices: [{ message: { content: "review" } }] }));
@@ -196,7 +196,7 @@ describe("agent loop: subagent foreground", () => {
       permission: { mode: "MANUAL" },
       agentManager: manager,
     });
-    await eventually(() => expect(childResolvers).toHaveLength(2));
+    await eventually(() => expect(childResolvers).toHaveLength(2), { timeoutMs: 3_000 });
     childResolvers[0]!({ content: "A" });
     childResolvers[1]!({ content: "B" });
     expect((await completion).kind).toBe("complete");
@@ -242,7 +242,7 @@ describe("agent loop: subagent foreground", () => {
 
     let turnSettled = false;
     const observedTurn = turn.finally(() => { turnSettled = true; });
-    await eventually(() => expect(childResolvers).toHaveLength(2));
+    await eventually(() => expect(childResolvers).toHaveLength(2), { timeoutMs: 3_000 });
     childResolvers[0]!({ content: "child result A" });
     await Bun.sleep(0);
     expect(turnSettled).toBe(false);

--- a/tests/integration/assets/assets-runtime.test.ts
+++ b/tests/integration/assets/assets-runtime.test.ts
@@ -177,6 +177,34 @@ describe("runtime assets", () => {
     }
   });
 
+  test("project and user asset-root files shadow lower-layer descendants", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vesicle-asset-root-shadow-"));
+    const project = join(root, "project");
+    const config = join(root, "config");
+    const bundled = join(root, "bundled-assets");
+    try {
+      await mkdir(project, { recursive: true });
+      await writeFile(join(project, "assets"), "project root blocker", "utf8");
+      await write(join(bundled, "specs", "lower.md"), "must stay hidden");
+      const resolver = new AssetResolver(project, {
+        env: { VESICLE_CONFIG_DIR: config },
+        bundledDirectory: bundled,
+        executablePath: join(root, "missing", "vesicle"),
+      });
+
+      await expect(resolver.readText("assets/specs/lower.md")).rejects.toThrow("shadowed by a file");
+      await expect(resolver.listDirectory("assets")).rejects.toThrow("not a directory");
+
+      await rm(join(project, "assets"));
+      await mkdir(config, { recursive: true });
+      await writeFile(join(config, "assets"), "user root blocker", "utf8");
+      await expect(resolver.readText("assets/specs/lower.md")).rejects.toThrow("shadowed by a file");
+      await expect(resolver.listDirectory("assets")).rejects.toThrow("not a directory");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("uses one managed baseline without falling through to bundled legacy files", async () => {
     const root = await mkdtemp(join(tmpdir(), "vesicle-managed-assets-"));
     const project = join(root, "project");

--- a/tests/support/async/eventually.ts
+++ b/tests/support/async/eventually.ts
@@ -6,15 +6,22 @@
  * error is re-thrown so failures surface a meaningful message instead of a
  * generic timeout.
  */
-export async function eventually(assertion: () => void | Promise<void>): Promise<void> {
+export async function eventually(
+  assertion: () => void | Promise<void>,
+  options: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 500;
+  const intervalMs = options.intervalMs ?? 5;
+  const startedAt = performance.now();
   let lastError: unknown;
-  for (let attempt = 0; attempt < 100; attempt++) {
+  while (true) {
     try {
       await assertion();
       return;
     } catch (error) {
       lastError = error;
-      await Bun.sleep(5);
+      if (performance.now() - startedAt >= timeoutMs) break;
+      await Bun.sleep(intervalMs);
     }
   }
   throw lastError;

--- a/tests/unit/config/project-preferences.test.ts
+++ b/tests/unit/config/project-preferences.test.ts
@@ -81,19 +81,12 @@ describe("project theme preferences read", () => {
   });
 
   test("a non-ENOENT stat error on the preference path is a bounded diagnostic, not a thrown crash", async () => {
-    // A rootDir that is a regular file makes lstat of <rootDir>/.vesicle/preferences.yaml
-    // reject with ENOTDIR (non-ENOENT). Plan §6.3: project config is optional and
-    // recoverable — the read must surface a diagnostic, never throw.
-    const container = await mkdtemp(join(tmpdir(), "vesicle-prefs-notdir-"));
-    try {
-      const fileRoot = join(container, "not-a-dir");
-      await writeFile(fileRoot, "blocker");
-      const read = await readProjectThemePreference(fileRoot);
-      expect(read.ok).toBe(false);
-      expect(read.ok ? "" : read.diagnostic).toContain("Could not stat");
-    } finally {
-      await rm(container, { recursive: true, force: true });
-    }
+    // A NUL-bearing root is rejected by lstat on every supported platform.
+    // Plan §6.3: project config is optional and recoverable — the read must
+    // surface a diagnostic, never throw.
+    const read = await readProjectThemePreference("invalid\0project-root");
+    expect(read.ok).toBe(false);
+    expect(read.ok ? "" : read.diagnostic).toContain("Could not stat");
   });
 });
 

--- a/tests/unit/skills-runtime/script.test.ts
+++ b/tests/unit/skills-runtime/script.test.ts
@@ -189,8 +189,8 @@ describe("run_skill_script: self-invocation", () => {
   test("works without configured self-invocation (no env injected, script still runs)", async () => {
     clearSelfInvocation();
     // The child simply does not see the env vars; execution is unaffected.
-    const catalog = await activeCatalog({ "scripts/echo-missing.sh": "#!/bin/sh\ntest -z \"$VESICLE_SELF_EXECUTABLE\" && echo absent || echo present\n" });
-    const result = await executeRunSkillScriptTool(scratch, call("run_skill_script", { skill: "alpha", path: "scripts/echo-missing.sh" }), { catalog, sessionId });
+    const catalog = await activeCatalog({ "scripts/echo-missing.ts": "console.log(process.env.VESICLE_SELF_EXECUTABLE ? 'present' : 'absent');\n" });
+    const result = await executeRunSkillScriptTool(scratch, call("run_skill_script", { skill: "alpha", path: "scripts/echo-missing.ts" }), { catalog, sessionId });
     expect(result.ok).toBe(true);
     expect(result.content).toContain("absent");
   });


### PR DESCRIPTION
## Summary

- make asset shadowing honor regular-file ancestors when Windows reports descendant lookup as `ENOENT`
- classify rooted model-visible paths with the platform path API and make Windows-only test fixtures hermetic
- isolate Agent Loop MCP configuration, allow realistic SubAgent startup latency, and run deterministic test groups in separate processes to avoid the Bun/OpenTUI FFI crash

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` — 2236 pass, 30 skip, 0 fail
- [x] `bun run doctor` — `Missing: none` with MCP discovery isolated
- [x] `bun run skills:docs:check`
- [x] `git diff --check`

## Notes / Follow-ups

- Related investigation: oven-sh/bun#40659.
- Independent Tier 1 CR completed after the follow-up commit: 0 Blocking, 0 Should-fix, 0 Nits.
- `bun test --isolate` is intentionally not used because parallel OpenTUI FFI initialization fails; the standard runner instead preserves each group’s existing semantics in four sequential processes.
- The developer’s real MCP registry was left untouched.