### PR TITLE
fix(session): stabilize title generation ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **Session-title generation keeps project and configuration ownership stable.** The auxiliary request now resolves `settings.yaml` from an explicit host-environment input instead of rereading mutable process-global test state, and active cancellation ownership is keyed by project root plus session id. Resetting a same-named session in another project can no longer abort the wrong request, while a stale cancelled request cannot detach the controller that replaced it.
+
 - **Built-in command argument completion now covers the recent command surface.** `/websearch`, `/title`, `/init`, `/workspace`, and the `/skill --context-only` continuation now expose their finite or guarded runtime candidates through the shared ↑/↓/Tab/Enter popup. Every built-in command explicitly declares whether it owns completion, preventing new commands from silently omitting the contract.
 
 - **Windows system surfaces now use the full-size canonical ICO.** The installer places `prism-vesicle.ico` beside `vesicle.exe` and points Apps & Features, Start Menu, and Explorer integration at that multi-size file, preventing Windows Settings from enlarging a low-resolution executable frame into a blurred icon.

--- a/src/core/session/title.ts
+++ b/src/core/session/title.ts
@@ -5,7 +5,7 @@ import type { SessionRecord } from "./record-model";
 import type { SessionStore } from "./append-store";
 import { createSessionStore } from "./append-store";
 import { readFile } from "node:fs/promises";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { normalizeSessionRecords } from "./record-model";
 
 async function readRecords(rootDir: string, sessionId: string): Promise<SessionRecord[]> {
@@ -28,6 +28,12 @@ export type SessionTitleGenerationState = {
   settled?: boolean;
   claimUntil?: string;
 };
+
+function titleControllerKey(rootDir: string, sessionId: string): string {
+  // NUL cannot occur in a path or session id, so it safely separates the
+  // components; resolve() keeps equivalent relative and absolute paths aligned.
+  return `${resolve(rootDir)}\0${sessionId}`;
+}
 
 function metadataRecords(records: SessionRecord[], kind: string): Record<string, unknown>[] {
   return records.flatMap((record) => {
@@ -182,14 +188,16 @@ export async function maybeGenerateSessionTitle(options: {
   session: SessionStore;
   provider: ProviderAdapter;
   config: VesicleConfig;
+  env?: NodeJS.ProcessEnv;
   signal?: AbortSignal;
   onTitleChanged?: (title: string, sessionId: string) => void;
 }): Promise<void> {
-  const settings = await loadSettings();
+  const env = options.env ?? process.env;
+  const settings = await loadSettings(env);
   // Existing provider fixtures intentionally omit host settings; keeping the
   // implicit default side-effect-free there avoids an auxiliary request racing
   // tests that replace the process transport. Production defaults remain auto.
-  if (process.env.NODE_ENV === "test" && !settings.exists) return;
+  if (env.NODE_ENV === "test" && !settings.exists) return;
   if ((settings.sessionTitle ?? "auto") !== "auto") return;
   const records = await readRecords(options.rootDir, options.session.sessionId);
   if (projectSessionTitle(records)?.source === "user") return;
@@ -207,11 +215,12 @@ export async function maybeGenerateSessionTitle(options: {
     return;
   }
   const controller = new AbortController();
-  activeTitleControllers.set(options.session.sessionId, controller);
+  const controllerKey = titleControllerKey(options.rootDir, options.session.sessionId);
+  activeTitleControllers.set(controllerKey, controller);
   if (options.signal?.aborted) controller.abort(options.signal.reason);
   else options.signal?.addEventListener("abort", () => controller.abort(options.signal?.reason), { once: true });
   const result = await generateSessionTitle({ provider: options.provider, config: options.config, userContent: turn.user.content, assistantContent: turn.assistant.content, signal: controller.signal });
-  activeTitleControllers.delete(options.session.sessionId);
+  if (activeTitleControllers.get(controllerKey) === controller) activeTitleControllers.delete(controllerKey);
   const latest = await readRecords(options.rootDir, options.session.sessionId);
   if (projectSessionTitle(latest)?.source === "user") return;
   const latestState = projectSessionTitleGeneration(latest);
@@ -256,8 +265,9 @@ export async function appendSessionTitle(rootDir: string, sessionId: string, tit
 }
 
 export async function resetSessionTitleGeneration(rootDir: string, sessionId: string): Promise<void> {
-  activeTitleControllers.get(sessionId)?.abort();
-  activeTitleControllers.delete(sessionId);
+  const controllerKey = titleControllerKey(rootDir, sessionId);
+  activeTitleControllers.get(controllerKey)?.abort();
+  activeTitleControllers.delete(controllerKey);
   const session = await createSessionStore(rootDir, sessionId);
   await session.append({ role: "system", content: "", metadata: { kind: SESSION_TITLE_GENERATION_KIND, version: 1, attempts: 0, settled: false } });
 }

--- a/tests/integration/session/title.test.ts
+++ b/tests/integration/session/title.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -16,25 +16,18 @@ import {
   resetSessionTitleGeneration,
 } from "../../../src/core/session/store";
 
-const originalConfigDir = process.env.VESICLE_CONFIG_DIR;
-
-afterEach(() => {
-  if (originalConfigDir === undefined) delete process.env.VESICLE_CONFIG_DIR;
-  else process.env.VESICLE_CONFIG_DIR = originalConfigDir;
-});
-
 async function fixture() {
   const rootDir = await mkdtemp(join(tmpdir(), "vesicle-session-title-"));
   const configDir = join(rootDir, "config");
   await mkdir(configDir, { recursive: true });
   await writeFile(join(configDir, "settings.yaml"), "version: 1\nsessionTitle: auto\n", "utf8");
-  process.env.VESICLE_CONFIG_DIR = configDir;
   const session = await createSessionStore(rootDir, "title-test");
   await session.append({ role: "system", content: "system" });
   const user = await session.append({ role: "user", content: "Plan a terminal title feature" });
   const assistant = await session.append({ role: "assistant", content: "Implemented the durable title behavior." });
   const config = { providerId: "test", model: "fixture-model" } as VesicleConfig;
-  return { rootDir, session, user, assistant, config };
+  const env = { NODE_ENV: "test", VESICLE_CONFIG_DIR: configDir };
+  return { rootDir, session, user, assistant, config, env };
 }
 
 describe("durable session title lifecycle", () => {
@@ -87,5 +80,87 @@ describe("durable session title lifecycle", () => {
     await pending;
     expect(projectSessionTitleGeneration(await loadSessionRecords(f.rootDir, f.session.sessionId))).toEqual({ attempts: 0, settled: false });
   });
-});
 
+  test("reset scopes active requests by project root when session ids match", async () => {
+    const first = await fixture();
+    const second = await fixture();
+    let firstStarted!: () => void;
+    let secondStarted!: () => void;
+    let firstAborted = false;
+    let secondAborted = false;
+    const firstReady = new Promise<void>((resolve) => { firstStarted = resolve; });
+    const secondReady = new Promise<void>((resolve) => { secondStarted = resolve; });
+    const provider = (started: () => void, markAborted: () => void): ProviderAdapter => ({
+      id: "fixture",
+      complete: async (request) => {
+        started();
+        return new Promise((_resolve, reject) => request.signal?.addEventListener("abort", () => {
+          markAborted();
+          reject(new DOMException("Aborted", "AbortError"));
+        }, { once: true }));
+      },
+    });
+
+    const firstPending = maybeGenerateSessionTitle({
+      ...first,
+      provider: provider(firstStarted, () => { firstAborted = true; }),
+    });
+    await firstReady;
+    const secondPending = maybeGenerateSessionTitle({
+      ...second,
+      provider: provider(secondStarted, () => { secondAborted = true; }),
+    });
+    await secondReady;
+
+    await resetSessionTitleGeneration(first.rootDir, first.session.sessionId);
+    await firstPending;
+    expect(firstAborted).toBe(true);
+    expect(secondAborted).toBe(false);
+
+    await resetSessionTitleGeneration(second.rootDir, second.session.sessionId);
+    await secondPending;
+    expect(secondAborted).toBe(true);
+  });
+
+  test("a stale completion cannot detach its replacement controller", async () => {
+    const f = await fixture();
+    let firstStarted!: () => void;
+    let secondStarted!: () => void;
+    let releaseFirst!: () => void;
+    let secondAborted = false;
+    const firstReady = new Promise<void>((resolve) => { firstStarted = resolve; });
+    const secondReady = new Promise<void>((resolve) => { secondStarted = resolve; });
+    const firstProvider: ProviderAdapter = {
+      id: "fixture",
+      complete: async (request) => {
+        firstStarted();
+        return new Promise((_resolve, reject) => request.signal?.addEventListener("abort", () => {
+          releaseFirst = () => reject(new DOMException("Aborted", "AbortError"));
+        }, { once: true }));
+      },
+    };
+    const secondProvider: ProviderAdapter = {
+      id: "fixture",
+      complete: async (request) => {
+        secondStarted();
+        return new Promise((_resolve, reject) => request.signal?.addEventListener("abort", () => {
+          secondAborted = true;
+          reject(new DOMException("Aborted", "AbortError"));
+        }, { once: true }));
+      },
+    };
+
+    const firstPending = maybeGenerateSessionTitle({ ...f, provider: firstProvider });
+    await firstReady;
+    await resetSessionTitleGeneration(f.rootDir, f.session.sessionId);
+
+    const secondPending = maybeGenerateSessionTitle({ ...f, provider: secondProvider });
+    await secondReady;
+    releaseFirst();
+    await firstPending;
+
+    await resetSessionTitleGeneration(f.rootDir, f.session.sessionId);
+    await secondPending;
+    expect(secondAborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- make session-title settings reads use explicit environment ownership
- scope cancellation controllers by normalized project root and session id
- prevent stale requests from deleting replacement controllers
- add cross-project and stale-completion regressions

Closes #257

## Verification

- `bun test tests/integration/session/title.test.ts`
- `bun test tests/integration`
- `bun test`
- `bun run lint`
- `bun run typecheck`
- `bun run doctor`
- `git diff --check`

Full suite: 2284 pass, 10 skip, 0 fail.