### PR TITLE
docs(readme): mark the project status badge stable for 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm](https://img.shields.io/npm/v/prism-vesicle?logo=npm&label=npm)](https://www.npmjs.com/package/prism-vesicle)
 [![Release](https://img.shields.io/github/v/release/3aKHP/prism-vesicle?include_prereleases&label=release)](https://github.com/3aKHP/prism-vesicle/releases)
 [![CI](https://github.com/3aKHP/prism-vesicle/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/3aKHP/prism-vesicle/actions/workflows/ci.yml)
-[![Status](https://img.shields.io/badge/status-public_beta-f59e0b)](#scope-and-lineage)
+[![Status](https://img.shields.io/badge/status-stable-brightgreen)](#scope-and-lineage)
 [![License](https://img.shields.io/github/license/3aKHP/prism-vesicle)](./LICENSE)
 
 [![Agent Harness](https://img.shields.io/badge/Agent_Harness-Prism_Engine-059669)](#what-vesicle-supports)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 [![npm](https://img.shields.io/npm/v/prism-vesicle?logo=npm&label=npm)](https://www.npmjs.com/package/prism-vesicle)
 [![Release](https://img.shields.io/github/v/release/3aKHP/prism-vesicle?include_prereleases&label=release)](https://github.com/3aKHP/prism-vesicle/releases)
 [![CI](https://github.com/3aKHP/prism-vesicle/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/3aKHP/prism-vesicle/actions/workflows/ci.yml)
-[![Status](https://img.shields.io/badge/status-public_beta-f59e0b)](#范围与来源)
+[![Status](https://img.shields.io/badge/status-stable-brightgreen)](#范围与来源)
 [![License](https://img.shields.io/github/license/3aKHP/prism-vesicle)](./LICENSE)
 
 [![Agent Harness](https://img.shields.io/badge/Agent_Harness-Prism_Engine-059669)](#vesicle-当前支持的能力)

--- a/host-assets/skills/vesicle-docs/references/root-readme.md
+++ b/host-assets/skills/vesicle-docs/references/root-readme.md
@@ -9,7 +9,7 @@
 [![npm](https://img.shields.io/npm/v/prism-vesicle?logo=npm&label=npm)](https://www.npmjs.com/package/prism-vesicle)
 [![Release](https://img.shields.io/github/v/release/3aKHP/prism-vesicle?include_prereleases&label=release)](https://github.com/3aKHP/prism-vesicle/releases)
 [![CI](https://github.com/3aKHP/prism-vesicle/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/3aKHP/prism-vesicle/actions/workflows/ci.yml)
-[![Status](https://img.shields.io/badge/status-public_beta-f59e0b)](#scope-and-lineage)
+[![Status](https://img.shields.io/badge/status-stable-brightgreen)](#scope-and-lineage)
 [![License](https://img.shields.io/github/license/3aKHP/prism-vesicle)](./LICENSE)
 
 [![Agent Harness](https://img.shields.io/badge/Agent_Harness-Prism_Engine-059669)](#what-vesicle-supports)


### PR DESCRIPTION
## Summary

- The Status badge in both language READMEs is a hardcoded static shields badge (`status-public_beta`); the stable-channel flip missed it, so the main-page badge still reads "public beta" after the 1.0.0 release.
- Points it at `status-stable-brightgreen` (same one-line change in both READMEs, bundled references regenerated). Identical fix already landed on develop (`b4064ac`).
- The npm and Release badges already resolve to `v1.0.0` server-side; those were only cache lag. The CI badge is pinned to `develop` by design.

## Test Plan

- [x] `bun run skills:docs:sync` — 95 references regenerated; sync check passes
- [x] Badge URL verified live (`shields.io/badge/status-stable-brightgreen` renders "status | stable")