### PR TITLE
fix(ci): bridge issue closing from develop PRs into the release flow

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -9,65 +9,20 @@ on:
 permissions:
   contents: read
   issues: write
+  pull_requests: read
 
 jobs:
   close-released-issues:
     if: github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
-      - name: Find and close issues referenced by closing keywords
-        uses: actions/github-script@v9
+      - uses: actions/checkout@v7
         with:
-          script: |
-            // GitHub's native auto-close only fires for keywords in PRs that
-            // target the default branch. Release PRs must therefore declare
-            // every intended closure explicitly in their own body.
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const issueRegex = /^\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\s*[.!]?\s*$/gim;
-            const candidates = new Set();
-            const collect = (text) => {
-              if (!text) return;
-              for (const match of text.matchAll(issueRegex)) {
-                candidates.add(Number(match[1]));
-              }
-            };
-            collect(pr.body);
-
-            const failures = [];
-            for (const issueNumber of candidates) {
-              try {
-                const { data: issue } = await github.rest.issues.get({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                });
-                if (issue.pull_request) {
-                  console.log(`#${issueNumber} is a pull request; skipping.`);
-                  continue;
-                }
-                if (issue.state !== "open") {
-                  console.log(`#${issueNumber} is already ${issue.state}; skipping.`);
-                  continue;
-                }
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  body: `This issue has been automatically closed as part of the release to \`main\` in #${pr.number}.`,
-                });
-                await github.rest.issues.update({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  state: "closed",
-                });
-                console.log(`Closed issue #${issueNumber}.`);
-              } catch (err) {
-                console.error(`Failed to close issue #${issueNumber}:`, err);
-                failures.push(issueNumber);
-              }
-            }
-            if (failures.length > 0) {
-              core.setFailed(`Failed to close: ${failures.map((n) => `#${n}`).join(", ")}`);
-            }
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Close issues declared by the PRs this release carried into main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun scripts/release/close-bridged-issues.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **The release close-issues workflow now bridges closing declarations from the PRs it carries into `main`.** Closing keywords in a PR body targeting `develop` no longer depend on the release PR repeating them: at release-merge time the workflow recovers the constituent PRs from the release commit range (native-merge and squash-merge forms), scans their bodies plus the release PR body with GitHub-native inline keyword semantics, and closes each still-open issue with a comment linking the originating and release PRs. Rebase-merged constituent PRs leave no PR reference in the commit history and remain unbridgeable.
+
 ## [1.0.0] - 2026-08-31
 
 ### Stable channel and known limitations

--- a/docs/dev/WORKFLOW.md
+++ b/docs/dev/WORKFLOW.md
@@ -390,12 +390,13 @@ The first version is deliberately minimal: five lenses, finder/scorer separation
 
 ## Issue Linking And Closure
 
-GitHub auto-closes an issue only when a supported closing keyword is immediately followed by the issue reference in the PR body or a commit message. Supported forms include `Closes #123`, `Fixes #123`, and `Resolves #123` (also `close`, `closed`, `fix`, `fixed`, `resolve`, `resolved`).
+GitHub auto-closes an issue only when a supported closing keyword is immediately followed by the issue reference in the PR body or a commit message. Supported forms include `Closes #123`, `Fixes #123`, and `Resolves #123` (also `close`, `closed`, `fix`, `fixed`, `resolve`, `resolved`); keywords work inline, not only on a line of their own.
 
-- A PR that resolves an issue must include one explicit line in its body: `Closes #<issue>`.
+- A PR that resolves an issue declares it in its body with a closing keyword (`Closes #<issue>`); a line of its own is the recommended, unambiguous form.
 - Use `Refs #<issue>` or plain `#<issue>` for related work that does not complete the issue.
 - `Implements #<issue>`, `Closes the follow-up in #<issue>`, and issue references in the PR title do not close issues.
 - For staged work, only the final PR uses `Closes #<issue>`; earlier PRs use `Refs #<issue>`.
+- Closing declarations in a PR merged into `develop` take effect when its commits reach `main` through a release PR: the `close-issues` workflow runs `scripts/release/close-bridged-issues.ts` at release-merge time, recovers the constituent PRs from the release commit range (native-merge and squash-merge forms; rebase merges leave no PR reference and are not bridged), scans their bodies plus the release PR body with native inline semantics, and closes each still-open issue with a comment linking both PRs. Release PR bodies no longer need to repeat closing lines — GitHub handles those natively — but repetition keeps working.
 - When an issue is resolved and merged into `develop` but has not yet reached `main`, append a tracking comment at the end of the issue: `This issue has been solved in #<pr-number>.`
 
 ## PR Body Shape

--- a/host-assets/skills/vesicle-docs/references/dev-workflow.md
+++ b/host-assets/skills/vesicle-docs/references/dev-workflow.md
@@ -392,12 +392,13 @@ The first version is deliberately minimal: five lenses, finder/scorer separation
 
 ## Issue Linking And Closure
 
-GitHub auto-closes an issue only when a supported closing keyword is immediately followed by the issue reference in the PR body or a commit message. Supported forms include `Closes #123`, `Fixes #123`, and `Resolves #123` (also `close`, `closed`, `fix`, `fixed`, `resolve`, `resolved`).
+GitHub auto-closes an issue only when a supported closing keyword is immediately followed by the issue reference in the PR body or a commit message. Supported forms include `Closes #123`, `Fixes #123`, and `Resolves #123` (also `close`, `closed`, `fix`, `fixed`, `resolve`, `resolved`); keywords work inline, not only on a line of their own.
 
-- A PR that resolves an issue must include one explicit line in its body: `Closes #<issue>`.
+- A PR that resolves an issue declares it in its body with a closing keyword (`Closes #<issue>`); a line of its own is the recommended, unambiguous form.
 - Use `Refs #<issue>` or plain `#<issue>` for related work that does not complete the issue.
 - `Implements #<issue>`, `Closes the follow-up in #<issue>`, and issue references in the PR title do not close issues.
 - For staged work, only the final PR uses `Closes #<issue>`; earlier PRs use `Refs #<issue>`.
+- Closing declarations in a PR merged into `develop` take effect when its commits reach `main` through a release PR: the `close-issues` workflow runs `scripts/release/close-bridged-issues.ts` at release-merge time, recovers the constituent PRs from the release commit range (native-merge and squash-merge forms; rebase merges leave no PR reference and are not bridged), scans their bodies plus the release PR body with native inline semantics, and closes each still-open issue with a comment linking both PRs. Release PR bodies no longer need to repeat closing lines — GitHub handles those natively — but repetition keeps working.
 - When an issue is resolved and merged into `develop` but has not yet reached `main`, append a tracking comment at the end of the issue: `This issue has been solved in #<pr-number>.`
 
 ## PR Body Shape

--- a/scripts/release/close-bridged-issues.ts
+++ b/scripts/release/close-bridged-issues.ts
@@ -1,0 +1,210 @@
+/**
+ * Cross-PR issue-closing bridge for the release flow.
+ *
+ * Invoked by `.github/workflows/close-issues.yml` after a `release/*` PR
+ * merges into `main`. GitHub's native auto-close never fires for closing
+ * keywords in PR bodies that target a non-default branch (`develop`), and it
+ * does not revisit those declarations when the commits later reach `main`
+ * through a release PR. This bridge closes that gap: it walks the commits the
+ * release carried into `main`, recovers the constituent PR numbers
+ * (native merges announce `Merge pull request #N from ...`; squash merges
+ * carry a trailing `(#N)` in the subject), scans those PR bodies plus the
+ * release PR body with GitHub-native inline keyword semantics, and closes
+ * every still-open issue with a comment linking the originating and release
+ * PRs.
+ *
+ * Commit messages are not scanned for keywords: GitHub natively closes
+ * issues from commit-message keywords once the commit reaches the default
+ * branch. Rebase-merged constituent PRs leave no PR reference in the commit
+ * history and are not bridgeable; the supported constituent merge methods
+ * are native merge and squash merge (see `docs/dev/WORKFLOW.md`).
+ *
+ * Usage (workflow): GITHUB_EVENT_PATH + GITHUB_TOKEN in the environment, then
+ * `bun scripts/release/close-bridged-issues.ts`. The extraction helpers are
+ * pure and unit-tested in `tests/unit/scripts/close-bridged-issues.test.ts`.
+ */
+import { readFileSync } from "node:fs";
+import process from "node:process";
+
+const CLOSING_KEYWORD_RE = /\b(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved)\s*:?\s+#(\d+)\b/gi;
+const MERGE_COMMIT_RE = /^Merge pull request #(\d+) from /gm;
+const SQUASH_SUBJECT_RE = /\(#(\d+)\)\s*$/;
+
+export type CommitLike = { message: string };
+
+/** Constituent PR numbers recoverable from a commit list (native-merge and squash forms). */
+export function extractPrNumbersFromCommits(commits: CommitLike[]): number[] {
+  const numbers = new Set<number>();
+  for (const commit of commits) {
+    for (const match of commit.message.matchAll(MERGE_COMMIT_RE)) {
+      numbers.add(Number(match[1]));
+    }
+    const subject = commit.message.split("\n", 1)[0] ?? "";
+    const squashed = subject.match(SQUASH_SUBJECT_RE);
+    if (squashed) numbers.add(Number(squashed[1]));
+  }
+  return [...numbers].sort((a, b) => a - b);
+}
+
+/** Issue numbers declared with GitHub-native closing keywords anywhere in the text. */
+export function extractClosingIssueNumbers(text: string | null | undefined): number[] {
+  if (!text) return [];
+  const numbers = new Set<number>();
+  for (const match of text.matchAll(CLOSING_KEYWORD_RE)) {
+    numbers.add(Number(match[1]));
+  }
+  return [...numbers].sort((a, b) => a - b);
+}
+
+export type PrBodyLike = { number: number; body: string | null | undefined };
+
+/**
+ * Map each declared issue to the PR that declared it. Constituent PRs are
+ * passed before the release PR so a constituent declaration wins the origin
+ * attribution; a release-body declaration is the fallback.
+ */
+export function collectIssueOrigins(prBodies: PrBodyLike[]): Map<number, number> {
+  const origins = new Map<number, number>();
+  for (const pr of prBodies) {
+    for (const issue of extractClosingIssueNumbers(pr.body)) {
+      if (!origins.has(issue)) origins.set(issue, pr.number);
+    }
+  }
+  return origins;
+}
+
+type WorkflowEventPullRequest = {
+  number: number;
+  merged: boolean | null;
+  body: string | null;
+  head: { ref: string; sha: string };
+  base: { ref: string; sha: string };
+  merge_commit_sha: string | null;
+};
+
+type WorkflowEvent = {
+  repository?: { full_name?: string };
+  pull_request?: WorkflowEventPullRequest;
+};
+
+function requirePullRequest(event: WorkflowEvent): { pr: WorkflowEventPullRequest; repo: string } | undefined {
+  const pr = event.pull_request;
+  if (!pr || pr.merged !== true || !pr.merge_commit_sha) return undefined;
+  if (!pr.head.ref.startsWith("release/")) return undefined;
+  const repo = event.repository?.full_name;
+  if (!repo) return undefined;
+  return { pr, repo };
+}
+
+async function main(): Promise<number> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const token = process.env.GITHUB_TOKEN;
+  if (!eventPath || !token) {
+    console.error("GITHUB_EVENT_PATH and GITHUB_TOKEN are required.");
+    return 1;
+  }
+  const gated = requirePullRequest(JSON.parse(readFileSync(eventPath, "utf8")) as WorkflowEvent);
+  if (!gated) {
+    console.log("Not a merged release PR; nothing to do.");
+    return 0;
+  }
+  const { pr, repo } = gated;
+
+  const api = async <T>(path: string, init?: { method?: string; body?: unknown }): Promise<T> => {
+    const response = await fetch(`https://api.github.com/repos/${repo}/${path}`, {
+      method: init?.method ?? "GET",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        ...(init?.body === undefined ? {} : { "Content-Type": "application/json" }),
+      },
+      body: init?.body === undefined ? undefined : JSON.stringify(init.body),
+    });
+    if (!response.ok) throw new Error(`${init?.method ?? "GET"} ${path} -> ${response.status}`);
+    return (await response.json()) as T;
+  };
+
+  // The merge commit's first parent is the pre-merge `main` tip: comparing it
+  // against the release branch head bounds exactly what this release carried
+  // in. This also works when the release PR itself was squash-merged, because
+  // the release branch retains the full constituent history.
+  const mergeCommit = await api<{ parents: { sha: string }[] }>(`commits/${pr.merge_commit_sha}`);
+  const base = mergeCommit.parents[0]?.sha ?? pr.base.sha;
+  const head = pr.head.sha;
+  // The compare endpoint caps its commits array at 250 per page; paginate so
+  // a large release range is never partially bridged. If the range is still
+  // incomplete after the page cap, fail loudly rather than skip silently.
+  const commits: CommitLike[] = [];
+  let total = 0;
+  for (let page = 1; page <= 10; page += 1) {
+    const comparison = await api<{ commits?: CommitLike[]; total_commits?: number }>(
+      `compare/${base}...${head}?per_page=250&page=${page}`,
+    );
+    total = comparison.total_commits ?? 0;
+    const batch = comparison.commits ?? [];
+    commits.push(...batch);
+    if (commits.length >= total || batch.length === 0) break;
+  }
+  if (commits.length < total) {
+    console.error(`release range carries ${total} commits but only ${commits.length} were recovered; refusing to bridge partially.`);
+    return 1;
+  }
+  console.log(`release range ${base.slice(0, 8)}...${head.slice(0, 8)} carries ${commits.length} commits`);
+
+  const candidates = extractPrNumbersFromCommits(commits);
+  console.log(`constituent PR candidates: ${candidates.map((n) => `#${n}`).join(", ") || "(none)"}`);
+
+  const constituentBodies: PrBodyLike[] = [];
+  for (const number of candidates) {
+    const pull = await api<{ number: number; merged: boolean | null; body: string | null }>(`pulls/${number}`);
+    if (pull.merged !== true) {
+      console.log(`#${number} is not a merged PR; skipping.`);
+      continue;
+    }
+    constituentBodies.push(pull);
+  }
+
+  const origins = collectIssueOrigins([...constituentBodies, { number: pr.number, body: pr.body }]);
+  if (origins.size === 0) {
+    console.log("no closing declarations found; nothing to close.");
+    return 0;
+  }
+
+  const failures: number[] = [];
+  for (const [issueNumber, originPr] of [...origins.entries()].sort((a, b) => a[0] - b[0])) {
+    try {
+      const issue = await api<{ state: string; pull_request?: unknown }>(`issues/${issueNumber}`);
+      if (issue.pull_request) {
+        console.log(`#${issueNumber} is a pull request; skipping.`);
+        continue;
+      }
+      if (issue.state !== "open") {
+        console.log(`#${issueNumber} is already ${issue.state}; skipping.`);
+        continue;
+      }
+      await api(`issues/${issueNumber}/comments`, {
+        method: "POST",
+        body: { body: `Closed via #${originPr} as part of the release to \`main\` in #${pr.number}.` },
+      });
+      await api(`issues/${issueNumber}`, { method: "PATCH", body: { state: "closed" } });
+      console.log(`Closed issue #${issueNumber} (declared by #${originPr}).`);
+    } catch (err) {
+      console.error(`Failed to close #${issueNumber}:`, err);
+      failures.push(issueNumber);
+    }
+  }
+  return failures.length > 0 ? 1 : 0;
+}
+
+if (import.meta.main) {
+  main().then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (error) => {
+      console.error(error);
+      process.exitCode = 1;
+    },
+  );
+}

--- a/tests/contract/release/release-workflow.test.ts
+++ b/tests/contract/release/release-workflow.test.ts
@@ -21,6 +21,7 @@ type WorkflowJob = {
 
 type Workflow = {
   on: Record<string, unknown>;
+  permissions?: Record<string, string>;
   jobs: Record<string, WorkflowJob>;
 };
 
@@ -141,7 +142,6 @@ describe("release workflow contract", () => {
       "actions/setup-node@": "actions/setup-node@v7",
       "oven-sh/setup-bun@": "oven-sh/setup-bun@v2",
       "softprops/action-gh-release@": "softprops/action-gh-release@v3",
-      "actions/github-script@": "actions/github-script@v9",
     };
     for (const [prefix, required] of Object.entries(requiredActions)) {
       const matched = uses.filter((action) => action.startsWith(prefix));
@@ -161,20 +161,30 @@ describe("release workflow contract", () => {
     expect(setupNode?.with?.["node-version"]).toBe("24");
   });
 
-  test("closes only issues explicitly declared by a merged release PR", async () => {
+  test("closes issues through the cross-PR bridge script", async () => {
     const workflow = await loadWorkflow("close-issues.yml");
     const job = workflow.jobs["close-released-issues"];
-    const script = job?.steps?.find((step) => step.uses === "actions/github-script@v9")?.with?.script;
+    const steps = job?.steps ?? [];
 
     expect(job?.if).toContain("github.event.pull_request.merged == true");
     expect(job?.if).toContain("startsWith(github.head_ref, 'release/')");
-    expect(script).toContain("collect(pr.body)");
-    expect(script).not.toContain("compareCommits");
-
-    const explicitClosingLine = /^\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)\s*[.!]?\s*$/gim;
-    const candidates = (text: string) => [...text.matchAll(explicitClosingLine)].map((match) => Number(match[1]));
-    expect(candidates("Closes #225\nFixes #226.")).toEqual([225, 226]);
-    expect(candidates("Should-fix #123\nbugfix #124\nMention fixes #125 in prose.")).toEqual([]);
+    // The bridge validates constituent PRs via GET /pulls/{n}; without an
+    // explicit read grant the restricted permissions block defaults it to
+    // none and every release merge fails with 403 (Bot Review finding).
+    expect(workflow.permissions?.["pull_requests"]).toBe("read");
+    expect(workflow.permissions?.["issues"]).toBe("write");
+    // The bridge script must run at the exact merged release state, under the
+    // pinned Bun runtime. Keyword semantics live with the script's unit tests
+    // (tests/unit/scripts/close-bridged-issues.test.ts).
+    expect(
+      steps.some(
+        (step) =>
+          step.uses === "actions/checkout@v7" && step.with?.["ref"] === "${{ github.event.pull_request.merge_commit_sha }}",
+      ),
+    ).toBe(true);
+    expect(steps.some((step) => step.uses === "oven-sh/setup-bun@v2")).toBe(true);
+    expect(steps.some((step) => step.run?.includes("bun scripts/release/close-bridged-issues.ts"))).toBe(true);
+    expect(steps.some((step) => step.uses?.startsWith("actions/github-script"))).toBe(false);
   });
 
   test("keeps every release gate in the reusable workflow", async () => {

--- a/tests/unit/scripts/close-bridged-issues.test.ts
+++ b/tests/unit/scripts/close-bridged-issues.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import {
+  collectIssueOrigins,
+  extractClosingIssueNumbers,
+  extractPrNumbersFromCommits,
+} from "../../../scripts/release/close-bridged-issues";
+
+describe("constituent PR extraction", () => {
+  test("recovers native-merge PR numbers from merge-commit messages", () => {
+    expect(
+      extractPrNumbersFromCommits([
+        { message: "Merge pull request #267 from 3aKHP/fix/working-title-quadrant-frames\n\nfix(tui): replace jittering working-title frames" },
+        { message: "Merge pull request #266 from 3aKHP/chore/forward-sync-v1.0.0-rc.1" },
+      ]),
+    ).toEqual([266, 267]);
+  });
+
+  test("recovers squash-merged PR numbers from the trailing subject reference", () => {
+    expect(
+      extractPrNumbersFromCommits([
+        { message: "fix(tui): replace jittering working-title frames with quadrant squares (#267)\n\nbody text mentioning #263 elsewhere" },
+      ]),
+    ).toEqual([267]);
+  });
+
+  test("ignores references that are neither merge announcements nor subject-trailing", () => {
+    expect(
+      extractPrNumbersFromCommits([
+        { message: "fix: see (#123) mid-sentence\n\nbody references (#456) too" },
+        { message: "chore(release): stamp 1.0.0-rc.2 for group-test installers" },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("deduplicates numbers found through both patterns", () => {
+    expect(
+      extractPrNumbersFromCommits([
+        { message: "Merge pull request #267 from 3aKHP/fix/x" },
+        { message: "docs(readme): mark the project status badge stable for 1.0.0 (#267)" },
+      ]),
+    ).toEqual([267]);
+  });
+});
+
+describe("closing keyword extraction (GitHub-native inline semantics)", () => {
+  test("matches inline, past-tense, colonated, and case variants", () => {
+    expect(extractClosingIssueNumbers("This closes #1, fixes #2, and Resolves: #3 in one sentence.")).toEqual([1, 2, 3]);
+  });
+
+  test("does not match keywords embedded inside larger words or bare references", () => {
+    expect(extractClosingIssueNumbers("hotfix #1, prefix #2, and plain #3 do not close anything")).toEqual([]);
+  });
+
+  test("matches prose-style references exactly as GitHub native does", () => {
+    expect(extractClosingIssueNumbers("Back in July we closed #177 after the audit.")).toEqual([177]);
+  });
+
+  test("returns empty for missing bodies and deduplicates repeats", () => {
+    expect(extractClosingIssueNumbers(undefined)).toEqual([]);
+    expect(extractClosingIssueNumbers("Closes #9 and closes #9")).toEqual([9]);
+  });
+});
+
+describe("issue origin attribution", () => {
+  test("attributes to the first declaring PR, keeping release-body declarations as fallback", () => {
+    const origins = collectIssueOrigins([
+      { number: 267, body: "Closes #263" },
+      { number: 269, body: "Closes #263\n\nAlso fixes #264" },
+    ]);
+    expect(origins.get(263)).toBe(267);
+    expect(origins.get(264)).toBe(269);
+  });
+
+  test("handles missing constituent bodies", () => {
+    const origins = collectIssueOrigins([
+      { number: 270, body: null },
+      { number: 271, body: "resolves #84" },
+    ]);
+    expect(origins.get(84)).toBe(271);
+    expect(origins.size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Implements the cross-PR issue-closing bridge that the close-issues workflow was originally designed for: closing keywords in a PR body targeting `develop` now take effect when its commits reach `main` through a release PR, instead of depending on the release PR repeating them (which duplicated GitHub's native default-branch behavior and silently no-oped when forgotten — the 1.0.0/#263 incident).
- New `scripts/release/close-bridged-issues.ts` (pinned-bun workflow shell, logic unit-tested): bounds the release range by the merge commit's first parent (works for both merge- and squash-merged release PRs), recovers constituent PR numbers from `Merge pull request #N` announcements and squash `(#N)` subject suffixes, validates candidates as merged PRs, scans constituent bodies plus the release PR body with GitHub-native **inline** keyword semantics, and closes each still-open issue with a `Closed via #N as part of the release to main in #M.` comment. Idempotent (already-closed/PR targets skipped).
- Explicit non-goals recorded: commit-message keywords are not scanned (GitHub closes those natively once commits reach `main`); rebase-merged constituents are unrecoverable and documented unsupported.
- `docs/dev/WORKFLOW.md` § Issue Linking And Closure updated to the new rules; release-workflow contract tests updated to the new shape (github-script family retired); `CHANGELOG.md` `[Unreleased]` entry added.

## Test Plan

- [x] `bun run lint` / `bun run typecheck`
- [x] `bun test` — 2327 pass / 0 fail / 10 skip
- [x] `tests/unit/scripts/close-bridged-issues.test.ts` — 10 tests: both extraction patterns, false-positive guards, native-inline keyword semantics, origin attribution
- [x] **Real-range validation**: the extractor run against the actual 1.0.0 release range (`4059b1a..70cf08c`, 9 commits) recovers exactly `[#266, #267]` — this is how the missing `g` regex flag was caught before CI

## Notes / Follow-ups

- First live verification window: the 1.0.1 release PR. Design study: `dev/docs/working/CLOSE_ISSUES_CROSS_PR_BRIDGE_DESIGN.md` (owner decisions recorded: close at release-merge time; native inline semantics; externalized TS script).
- The `(#N)` squash suffix depends on GitHub's squash-message convention; the merged-PR validation gate is the guard against edited subjects pointing at non-PR numbers.