### PR TITLE
chore(repo): add issue and PR templates aligned with the graded workflows (#278)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: Bug 报告 / Bug report
+description: 报告可复现的缺陷 / Report a reproducible defect
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        提交前先搜索既有 issue;对已有 issue 点 👍 即可,不必重复开单。
+        Prefer text over screenshots / 文字优于截图。
+  - type: textarea
+    id: phenomenon
+    attributes:
+      label: 现象 / Phenomenon
+      description: 发生了什么?哪里与预期不符?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: 复现 / Reproduction
+      description: 精确的操作步骤、命令与相关配置。
+      placeholder: |
+        1.
+        2.
+    validations:
+      required: true
+  - type: dropdown
+    id: channel
+    attributes:
+      label: 渠道 / Channel
+      description: 从哪个分发渠道安装的?
+      options:
+        - npm latest (stable)
+        - npm next (prerelease)
+        - Windows 安装器 / installer
+        - 源码运行 / source checkout
+        - 其他 / other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: 版本 / Version
+      description: "`vesicle --version` 的输出。"
+  - type: input
+    id: os-terminal
+    attributes:
+      label: 系统与终端 / OS & terminal
+      placeholder: e.g. Windows 11 + Windows Terminal, Ubuntu 24.04 + zsh
+  - type: input
+    id: provider-model
+    attributes:
+      label: Provider / 模型(可选)
+      description: 请隐去密钥等敏感信息 / redact secrets.
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望 / Expected
+      description: 正确的行为应该是什么?
+  - type: textarea
+    id: notes
+    attributes:
+      label: 附注 / Notes
+      description: "`vesicle doctor` 输出(请脱敏)、相关文件与日志。"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: Bug 报告 / Bug report
 description: 报告可复现的缺陷 / Report a reproducible defect
+title: "[Bug] "
 labels: [bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: 功能提案 / Feature or enhancement
+description: 提出新能力或改进 / Propose a capability or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: motivation
+    attributes:
+      label: 动机 / Motivation
+      description: 这解决什么用户或工作流问题?来自哪类使用场景?
+    validations:
+      required: true
+  - type: textarea
+    id: design-space
+    attributes:
+      label: 方案空间 / Design space
+      description: 考虑过的方向与取舍;为何倾向其中之一(可不填)。
+  - type: textarea
+    id: boundaries
+    attributes:
+      label: 边界与非目标 / Boundaries & non-goals
+      description: 范围之外的内容;不应改变的行为。
+  - type: textarea
+    id: related
+    attributes:
+      label: 关联 / Related
+      description: 相关 issue(#N)、文档或文件锚点、外部参照。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: 功能提案 / Feature or enhancement
 description: 提出新能力或改进 / Propose a capability or improvement
+title: "[Enhancement] "
 labels: [enhancement]
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/memo.md
+++ b/.github/ISSUE_TEMPLATE/memo.md
@@ -1,0 +1,37 @@
+---
+name: 备忘 / Memo
+about: 开发备忘——调研结论、backlog、设计空间(本仓主要 issue 体例)
+title: "备忘:"
+labels: [memo]
+---
+
+<!--
+  本仓把 issue 大量用作开发备忘。章节按题材取舍:不适用的小节直接删除,
+  需要时增加题材小节(如「调研结论」「候选方向」「逐条条目」)。
+  AI 协作者经 API/CLI 创建 memo issue 时,以本文件为体例参照
+  (docs/dev/WORKFLOW.md § Issue Linking And Closure)。
+-->
+
+## 背景 / Source
+
+<!-- 什么触发了这份备忘:群测反馈、Bot Review 延后项、调研、发布观察 -->
+
+## 逐条现象与锚点 / Observations & anchors
+
+<!-- 每条一行,带 file:line 或 #issue 锚点;多条目备忘逐条编号 -->
+
+## 待厘清的设计问题 / Open design questions
+
+<!-- 推进前必须先回答什么 -->
+
+## 边界与非目标 / Boundaries & non-goals
+
+<!-- 不承诺实现 / 不冻结方案 / 不因本 issue 改动的既有合同 -->
+
+## 范围与状态 / Scope & status
+
+<!-- 定级口径:目标版本(如 1.0.1 / 1.1.0)/ 长期备忘不设截止 / 评估后再立项 -->
+
+## 关联 / Related
+
+- #<issue>、`path/to/file.ts`、外部参照

--- a/.github/ISSUE_TEMPLATE/memo.md
+++ b/.github/ISSUE_TEMPLATE/memo.md
@@ -1,7 +1,7 @@
 ---
 name: 备忘 / Memo
 about: 开发备忘——调研结论、backlog、设计空间(本仓主要 issue 体例)
-title: "备忘:"
+title: "[Memo] "
 labels: [memo]
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -1,0 +1,48 @@
+<!--
+  Release PR to `main` (docs/dev/WORKFLOW.md § Release Lifecycle; Release grade
+  of the Change Grading Workflow). GitHub offers no PR template chooser - open
+  with:
+    gh pr create --base main --title "release: prepare v<version>" \
+      --template .github/PULL_REQUEST_TEMPLATE/release.md
+  or add ?template=PULL_REQUEST_TEMPLATE/release.md to the compare URL.
+
+  Issue closing needs no lines here: the close-issues bridge recovers the
+  constituent PRs from the release commit range and reads their closing
+  declarations. Repeating closing lines also works but is unnecessary.
+-->
+
+## Summary
+
+- Channel and audience for this release (stable → npm `latest` / prerelease → `next`).
+- What this release carries since the last tag.
+- After merge: push the annotated tag `v<version>` on `main` → the pipeline publishes.
+
+## Release checklist
+
+- [ ] `package.json` version frozen to the target version
+- [ ] `CHANGELOG.md` section added for this version
+- [ ] `README.md` + `README.zh-CN.md` channel wording updated (dist-tag / install guidance)
+- [ ] README static Status badge (both languages) reflects the new channel
+- [ ] `STATUS.md` snapshot date / published version updated
+- [ ] Advanced user-manual maturity stamps updated (`docs/user/{en,zh-CN}/advanced/`)
+- [ ] Release notes disclose Windows signing status accurately (link the Code Signing Policy)
+
+## Test Plan
+
+- [ ] `bun run lint`
+- [ ] `bun run typecheck`
+- [ ] `bun test`
+- [ ] `bun run doctor`
+- [ ] `bun audit`
+- [ ] `bun run pack:check` + `bun run pack:smoke`
+- [ ] `bun run skills:docs:sync` (README/docs changed in this release)
+
+### Recorded internal acceptance (per release runbook)
+
+- [ ] `test:acceptance:provider` - record evidence
+- [ ] Other acceptance lanes as applicable - record evidence or an explicit skip decision
+- [ ] Windows acceptance per release grade
+
+## Notes / Follow-ups
+
+- ...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+<!--
+  One PR, one main intent (docs/dev/WORKFLOW.md "Hard Rules").
+
+  Grade - keep the applicable one (WORKFLOW.md § Change Grading Workflow):
+    Quick PR     Bot Review, one round
+    Standard PR  independent CR SubAgent + Bot Review (dual-track)
+    Huge PR      topic document first; Deep-CR over the whole change
+    Hot-Fix      to `main` for a blocking regression; forward-merge back to `develop`
+
+  Issue linking: "Closes #<issue>" below is the authoritative closing
+  declaration - the close-issues bridge reads this body when the commits reach
+  `main` through a release PR. Closing keywords match anywhere in the body, so
+  use "Refs #<issue>" for related work, and leave a tracking comment on the
+  issue meanwhile. Delete the Closes line when no issue applies.
+-->
+
+Grade: Quick PR
+
+Closes #<issue>
+
+## Summary
+
+- ...
+
+## Test Plan
+
+- [ ] `bun run lint`
+- [ ] `bun run typecheck`
+- [ ] `bun test`
+- [ ] `bun run doctor`
+- [ ] Targeted tests / smoke for the change class (see Verification Matrix)
+
+## Notes / Follow-ups
+
+- ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **The repository now carries issue and pull request templates** (`.github/`). Regular PRs prefill the WORKFLOW PR Body Shape — a `Grade` line naming the applicable Change Grading Workflow grade, the authoritative `Closes` closing declaration, and the verification checklist plus a targeted-tests line. Release PRs get a dedicated publication-prep checklist template opened via `gh pr create --template .github/PULL_REQUEST_TEMPLATE/release.md` (GitHub offers no PR template chooser). Issues offer structured bilingual bug / feature forms plus a memo template that fixes the repository's memo issue genre as the shape authority; blank issues are disabled. `docs/dev/WORKFLOW.md` § Release Lifecycle now lists the release-facing documentation stamps (README channel wording and Status badge, advanced user-manual maturity stamps, `STATUS.md` snapshot header) as part of the release freeze (issue #278).
+
 ### Changed
 
 - **OpenTUI fork runtime advances to `0.5.9-zv1`** (from `0.5.3-zv6`; fork baseline rejoins upstream at v0.5.9). Carries upstream byte-accurate layout rewrite (#1428) and drag-selection inclusive-end semantics (#1393): dragging across cells now includes the end cell, so the two theme-text selection expectations carry a trailing space. Pre-publish validation on a production-shaped install passed in full (unit 1242/1242, integration 883/883, contract 58/58, component with the updated expectations; issue #273).

--- a/docs/dev/WORKFLOW.md
+++ b/docs/dev/WORKFLOW.md
@@ -216,7 +216,7 @@ The empty-project smoke runs `debug markdown-runtime`, `assets status`, asset ma
 
 ### Release Lifecycle
 
-1. Freeze `package.json`, `CHANGELOG.md`, release notes, and supported user-facing scope on `release/v<version>-<topic>`. Release notes must link the public Code signing policy and state accurately whether that version's Windows artifacts are signed.
+1. Freeze `package.json`, `CHANGELOG.md`, release notes, and supported user-facing scope on `release/v<version>-<topic>`. The freeze also covers the release-facing documentation stamps: `README.md` and `README.zh-CN.md` channel wording and static Status badge, the advanced user-manual maturity stamps under `docs/user/{en,zh-CN}/advanced/`, and the `STATUS.md` snapshot header. Release notes must link the public Code signing policy and state accurately whether that version's Windows artifacts are signed.
 2. Run the standard local verification, then open a PR to `main`. PR CI executes the same reusable release build and provides short-lived Linux, Windows, assets-ZIP, and installer artifacts for review and human testing.
 3. Complete independent CR, the opt-in real-provider acceptance test, and any required small-group Windows acceptance. Merge the reviewed release PR to `main`.
 4. Update the local `main` with a fast-forward-only pull and confirm that `HEAD` is the accepted release commit.
@@ -398,10 +398,13 @@ GitHub auto-closes an issue only when a supported closing keyword is immediately
 - For staged work, only the final PR uses `Closes #<issue>`; earlier PRs use `Refs #<issue>`.
 - Closing declarations in a PR merged into `develop` take effect when its commits reach `main` through a release PR: the `close-issues` workflow runs `scripts/release/close-bridged-issues.ts` at release-merge time, recovers the constituent PRs from the release commit range (native-merge and squash-merge forms; rebase merges leave no PR reference and are not bridged), scans their bodies plus the release PR body with native inline semantics, and closes each still-open issue with a comment linking both PRs. Release PR bodies no longer need to repeat closing lines — GitHub handles those natively — but repetition keeps working.
 - When an issue is resolved and merged into `develop` but has not yet reached `main`, append a tracking comment at the end of the issue: `This issue has been solved in #<pr-number>.`
+- Issue bodies follow the repository issue templates under `.github/ISSUE_TEMPLATE/`; the memo template is the shape authority for memo issues, and collaborators creating issues through the API or CLI copy that skeleton.
 
 ## PR Body Shape
 
 ```markdown
+Grade: Quick PR
+
 Closes #<issue>
 
 ## Summary
@@ -414,11 +417,14 @@ Closes #<issue>
 - [ ] `bun run typecheck`
 - [ ] `bun test`
 - [ ] `bun run doctor`
+- [ ] Targeted tests / smoke for the change class (see Verification Matrix)
 
 ## Notes / Follow-ups
 
 - ...
 ```
+
+The `Grade` line keeps the applicable grade of the Change Grading Workflow (Quick PR / Standard PR / Huge PR / Hot-Fix) so the review bar is visible on the PR; Release PRs carry their own template instead of the grade line. The default PR template `.github/pull_request_template.md` carries this shape. Release PRs use `.github/PULL_REQUEST_TEMPLATE/release.md`; GitHub offers no PR template chooser, so select it explicitly with `gh pr create --template .github/PULL_REQUEST_TEMPLATE/release.md` or the `?template=` compare-URL parameter.
 
 ## Documentation Sweep
 

--- a/host-assets/skills/vesicle-docs/references/dev-workflow.md
+++ b/host-assets/skills/vesicle-docs/references/dev-workflow.md
@@ -218,7 +218,7 @@ The empty-project smoke runs `debug markdown-runtime`, `assets status`, asset ma
 
 ### Release Lifecycle
 
-1. Freeze `package.json`, `CHANGELOG.md`, release notes, and supported user-facing scope on `release/v<version>-<topic>`. Release notes must link the public Code signing policy and state accurately whether that version's Windows artifacts are signed.
+1. Freeze `package.json`, `CHANGELOG.md`, release notes, and supported user-facing scope on `release/v<version>-<topic>`. The freeze also covers the release-facing documentation stamps: `README.md` and `README.zh-CN.md` channel wording and static Status badge, the advanced user-manual maturity stamps under `docs/user/{en,zh-CN}/advanced/`, and the `STATUS.md` snapshot header. Release notes must link the public Code signing policy and state accurately whether that version's Windows artifacts are signed.
 2. Run the standard local verification, then open a PR to `main`. PR CI executes the same reusable release build and provides short-lived Linux, Windows, assets-ZIP, and installer artifacts for review and human testing.
 3. Complete independent CR, the opt-in real-provider acceptance test, and any required small-group Windows acceptance. Merge the reviewed release PR to `main`.
 4. Update the local `main` with a fast-forward-only pull and confirm that `HEAD` is the accepted release commit.
@@ -400,10 +400,13 @@ GitHub auto-closes an issue only when a supported closing keyword is immediately
 - For staged work, only the final PR uses `Closes #<issue>`; earlier PRs use `Refs #<issue>`.
 - Closing declarations in a PR merged into `develop` take effect when its commits reach `main` through a release PR: the `close-issues` workflow runs `scripts/release/close-bridged-issues.ts` at release-merge time, recovers the constituent PRs from the release commit range (native-merge and squash-merge forms; rebase merges leave no PR reference and are not bridged), scans their bodies plus the release PR body with native inline semantics, and closes each still-open issue with a comment linking both PRs. Release PR bodies no longer need to repeat closing lines — GitHub handles those natively — but repetition keeps working.
 - When an issue is resolved and merged into `develop` but has not yet reached `main`, append a tracking comment at the end of the issue: `This issue has been solved in #<pr-number>.`
+- Issue bodies follow the repository issue templates under `.github/ISSUE_TEMPLATE/`; the memo template is the shape authority for memo issues, and collaborators creating issues through the API or CLI copy that skeleton.
 
 ## PR Body Shape
 
 ```markdown
+Grade: Quick PR
+
 Closes #<issue>
 
 ## Summary
@@ -416,11 +419,14 @@ Closes #<issue>
 - [ ] `bun run typecheck`
 - [ ] `bun test`
 - [ ] `bun run doctor`
+- [ ] Targeted tests / smoke for the change class (see Verification Matrix)
 
 ## Notes / Follow-ups
 
 - ...
 ```
+
+The `Grade` line keeps the applicable grade of the Change Grading Workflow (Quick PR / Standard PR / Huge PR / Hot-Fix) so the review bar is visible on the PR; Release PRs carry their own template instead of the grade line. The default PR template `.github/pull_request_template.md` carries this shape. Release PRs use `.github/PULL_REQUEST_TEMPLATE/release.md`; GitHub offers no PR template chooser, so select it explicitly with `gh pr create --template .github/PULL_REQUEST_TEMPLATE/release.md` or the `?template=` compare-URL parameter.
 
 ## Documentation Sweep
 


### PR DESCRIPTION
Grade: Quick PR

Closes #278

## Summary

- **PR templates.** `.github/pull_request_template.md` prefills the WORKFLOW PR Body Shape with a new `Grade:` line (Quick / Standard / Huge / Hot-Fix) so the review bar is visible on every PR, plus a targeted-tests line tied to the Verification Matrix. `.github/PULL_REQUEST_TEMPLATE/release.md` carries the publication-prep checklist modeled on the actual v1.0.0 release PR body (#269): freeze items, full test plan, recorded-acceptance lanes with explicit-skip allowance.
- **Release template carries no `Closes` block.** After #272 the close-issues bridge recovers constituent PRs from the release commit range and reads *their* bodies (`collectIssueOrigins`: constituent declarations win, release-body is the fallback), so release bodies no longer need closing lines — the template comment states "not needed; repetition also works but is unnecessary".
- **Issue templates (mixed forms).** Structured bilingual bug / feature forms (`bug_report.yml`, `feature_request.yml`) with a channel dropdown for group-test users, plus a classic `memo.md` that fixes the repository's dominant issue genre as the shape authority — sections follow the real memo practice (#268/#275–#279), and API/CLI collaborators copy its skeleton. `config.yml` disables blank issues. Issue titles prefill bracketed type prefixes (`[Bug] ` / `[Enhancement] ` / `[Memo] `) following the prts-mcp house convention; PRs keep Conventional-Commit titles without brackets.
- **WORKFLOW.md sync (zero-conflict).** § PR Body Shape gains the Grade + targeted-tests lines and documents the template selection mechanism (GitHub has no PR template chooser; release template via `gh pr create --template` or `?template=`); § Release Lifecycle step 1 now lists the release-facing documentation stamps (README channel wording + Status badge, advanced maturity stamps, STATUS snapshot header) as part of the freeze — the release checklist's rule basis; § Issue Linking And Closure names `memo.md` as the memo shape authority.
- **Design was independently researched** (platform facts + reference projects) and diverges from the initial bot draft on the two points above (no chooser exists; no Closes bridge list). Reference consensus (codex / opencode / DeepSeek-Reasonix) informed the mixed forms decision.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — 2317 pass / 10 skip / 0 fail
- [x] `bun run doctor` — `Missing: none`
- [x] Targeted: `bun run skills:docs:sync` — 95 references regenerated (`dev-workflow.md` mirror updated); bundled-skill-references contract covered by the suite

## Notes / Follow-ups

- **Bot-review NIT resolved with API-level evidence** (no throwaway PR needed): GitHub's `pullRequestTemplates` GraphQL field — the same list the web UI and `gh` consume — does not let the folder shadow the single-file default. A repo with both layouts (dotnet/msbuild) returns `[pull_request_template.md, shiproom.md]`: one alphabetically-ordered list, single file first; folder-only (pytorch/pytorch) returns only folder files; single-file-only (sst/opencode) returns only the single file. gh 2.98's interactive `pr create` prompts with that list (single file first); `-T` remains the explicit release-template path. End-to-end web pre-fill confirms on the first PR opened after this merges to `develop`.
- Issue forms / chooser activate from the default branch, i.e. when this change reaches `main` through the next release PR.
- `memo` label created (d876e7) so the memo template's `labels: [memo]` applies.
