### PR TITLE
fix(compact): materialize image attachments before provider serialization (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
+- **`/compact` no longer fails for sessions whose history contains durable image attachments (issue #281, P1).** All compaction summary requests now materialize content-addressed image references into the in-memory request copy before provider serialization — manual `/compact`, opt-in automatic compaction, model-switch compaction, `/rewind` from-point summaries, and the optional remote Responses compact request. A missing or corrupted attachment fails closed with an explicit attachment error and leaves the session head unchanged; the durable JSONL transcript keeps storing reference-only attachments, never base64.
+- **OpenAI Responses requests no longer silently drop tool-result images.** `function_call_output` Items cannot carry media, so accepted MCP/tool images attached to a tool result are now held and flushed as a synthesized user input item after the complete tool batch, mirroring the OpenAI-compatible chat serializer; an unmaterialized reference still fails closed with the standard serialization guard.
 - **The release close-issues workflow now bridges closing declarations from the PRs it carries into `main`.** Closing keywords in a PR body targeting `develop` no longer depend on the release PR repeating them: at release-merge time the workflow recovers the constituent PRs from the release commit range (native-merge and squash-merge forms), scans their bodies plus the release PR body with GitHub-native inline keyword semantics, and closes each still-open issue with a comment linking the originating and release PRs. Rebase-merged constituent PRs leave no PR reference in the commit history and remain unbridgeable.
 
 ## [1.0.0] - 2026-08-31

--- a/src/core/compact/service.ts
+++ b/src/core/compact/service.ts
@@ -3,6 +3,7 @@ import { loadConfigForSelection } from "../../config/providers";
 import { createProvider, resolveProviderProxyPolicy } from "../../providers";
 import type { ProviderAdapter, ProviderCompactResult, ProviderRetryInfo, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
 import { loadEngineProfile, type EngineId } from "../engine/profile";
+import { prepareProviderMessages } from "../attachments/store";
 import { composeSystemPromptWithInstructions } from "../instructions";
 import { composeSystemPrompt, loadPromptBundle } from "../prompt/loader";
 import { createSessionStore, loadSessionSnapshot, type ResumedMessage, type SessionSnapshot } from "../session/store";
@@ -158,7 +159,14 @@ export async function runPortableCompaction(options: RunPortableCompactionOption
         const compacted = await provider.compact({
           id: `${options.sessionId}:compact:${selection.sourceHeadUuid}`,
           model: { provider: config.providerId, model: config.model },
-          messages: full.messages.map(toVesicleMessage),
+          // Remote compact serializes directly through the adapter, so durable
+          // image references materialize here too. A materialization failure
+          // falls into the same optional-optimization degrade below.
+          messages: await prepareProviderMessages(
+            options.rootDir,
+            full.messages.map(toVesicleMessage),
+            config.capabilities?.vision === true,
+          ),
           signal: options.signal,
           onRetry: options.onRetry,
         });
@@ -383,12 +391,19 @@ async function generateSummary(options: {
   const systemPrompt = (
     await composeSystemPromptWithInstructions(options.engine, enginePrompt, options.rootDir)
   ).systemPrompt;
+  // Like the portable summary, this from-point request bypasses
+  // completeProviderRound and materializes durable image references itself.
+  const summaryMessages = await prepareProviderMessages(
+    options.rootDir,
+    options.messages.map(toVesicleMessage),
+    config.capabilities?.vision === true,
+  );
   const request: VesicleRequest = {
     id: options.sessionId,
     model: { provider: config.providerId, model: config.model },
     system: [systemPrompt],
     messages: [
-      ...options.messages.map(toVesicleMessage),
+      ...summaryMessages,
       { role: "user", content: `${NO_TOOLS_COMPACT_PREAMBLE}\n\n${options.prompt}` },
     ],
     generation: options.generation,

--- a/src/core/compact/summary-generator.ts
+++ b/src/core/compact/summary-generator.ts
@@ -2,6 +2,7 @@ import type { ProviderSelection } from "../../config/providers";
 import { loadConfigForSelection } from "../../config/providers";
 import { createProvider, resolveProviderProxyPolicy } from "../../providers";
 import type { ProviderRetryInfo, VesicleMessage, VesicleRequest, VesicleResponse } from "../../providers/shared/types";
+import { prepareProviderMessages } from "../attachments/store";
 import { loadEngineProfile, type EngineId } from "../engine/profile";
 import { composeSystemPromptWithInstructions } from "../instructions";
 import { composeSystemPrompt, loadPromptBundle } from "../prompt/loader";
@@ -57,12 +58,19 @@ export async function generatePortableSummary(options: GenerateSummaryOptions): 
   const profile = await loadEngineProfile(options.engine, options.rootDir);
   const enginePrompt = composeSystemPrompt(await loadPromptBundle(profile, options.rootDir));
   const systemPrompt = (await composeSystemPromptWithInstructions(options.engine, enginePrompt, options.rootDir)).systemPrompt;
+  // This request bypasses completeProviderRound, so durable image references
+  // must materialize here with the same vision gate as an ordinary round.
+  const summaryMessages = await prepareProviderMessages(
+    options.rootDir,
+    messages.map(toVesicleMessage),
+    config.capabilities?.vision === true,
+  );
   const request: VesicleRequest = {
     id: options.sessionId,
     model: { provider: config.providerId, model: config.model },
     system: [systemPrompt],
     messages: [
-      ...messages.map(toVesicleMessage),
+      ...summaryMessages,
       { role: "user", content: `${NO_TOOLS_COMPACT_PREAMBLE}\n\n${prompt}` },
     ],
     generation: options.generation,

--- a/src/providers/openai-responses/request.ts
+++ b/src/providers/openai-responses/request.ts
@@ -150,6 +150,15 @@ function serializeResponsesInput(
   const input: unknown[] = [];
   const declaredCallIds = new Set(initialCallIds);
   const answeredCallIds = new Set<string>();
+  // function_call_output Items cannot carry images. Tool-result images are
+  // held and flushed as one synthesized user input item after the complete
+  // tool batch, mirroring the OpenAI-compatible chat serializer.
+  let pendingToolImages: NonNullable<VesicleMessage["images"]> = [];
+  const flushToolImages = () => {
+    if (pendingToolImages.length === 0) return;
+    input.push({ role: "user", content: userContent({ role: "user", content: "", images: pendingToolImages }) });
+    pendingToolImages = [];
+  };
   for (const message of messages) {
     if (message.kind === PROVIDER_NATIVE_CHECKPOINT_KIND) {
       const compacted = nativeCompactInput(message.providerState, model, context);
@@ -157,6 +166,7 @@ function serializeResponsesInput(
         input.length = 0;
         declaredCallIds.clear();
         answeredCallIds.clear();
+        pendingToolImages = [];
         for (const item of compacted) {
           if (item.type === "function_call" && typeof item.call_id === "string") declaredCallIds.add(item.call_id);
           if (item.type === "function_call_output" && typeof item.call_id === "string") answeredCallIds.add(item.call_id);
@@ -165,6 +175,7 @@ function serializeResponsesInput(
       }
       continue;
     }
+    if (message.role !== "tool") flushToolImages();
     if (message.role === "assistant" && message.providerState) {
       const native = nativeOutputItems(message.providerState, model, context);
       const nativeCarriesSearch = native?.some((item) =>
@@ -190,6 +201,7 @@ function serializeResponsesInput(
       if (answeredCallIds.has(message.toolCallId)) throw new Error(`OpenAI Responses call_id ${message.toolCallId} was answered more than once.`);
       answeredCallIds.add(message.toolCallId);
       input.push({ type: "function_call_output", call_id: message.toolCallId, output: message.content });
+      pendingToolImages.push(...(message.images ?? []));
       continue;
     }
     if (message.role === "assistant" && message.toolCalls?.length) {
@@ -209,6 +221,7 @@ function serializeResponsesInput(
         : message.content,
     });
   }
+  flushToolImages();
   const unanswered = [...declaredCallIds].find((callId) => !answeredCallIds.has(callId));
   if (unanswered) throw new Error(`OpenAI Responses function call_id ${unanswered} has no result.`);
   return input;

--- a/tests/integration/providers/openai-responses-provider.test.ts
+++ b/tests/integration/providers/openai-responses-provider.test.ts
@@ -78,6 +78,46 @@ describe("OpenAI Responses request codec", () => {
     }, context(), false, "openai-public")).toThrow("Unsupported reasoning tier: invalid");
   });
 
+  test("flushes materialized tool-result images as a user input item after the tool batch", () => {
+    const imageData = Buffer.from("png").toString("base64");
+    const attachment = {
+      id: "img_flush",
+      path: ".vesicle/attachments/flush.png",
+      mediaType: "image/png",
+      bytes: 3,
+      sha256: "0".repeat(64),
+      source: "project",
+      data: imageData,
+    } as const;
+    const body = toResponsesBody({
+      ...request(),
+      messages: [
+        { role: "user", content: "inspect the capture" },
+        { role: "assistant", content: "", toolCalls: [{ id: "call_view", name: "view_image", arguments: "{\"path\":\"a.png\"}" }] },
+        { role: "tool", toolCallId: "call_view", content: "{\"ok\":true}", images: [attachment] },
+        { role: "assistant", content: "done" },
+      ],
+    }, context(), false, "openai-public");
+
+    expect(body.input).toEqual([
+      { role: "user", content: "inspect the capture" },
+      { type: "function_call", call_id: "call_view", name: "view_image", arguments: "{\"path\":\"a.png\"}" },
+      { type: "function_call_output", call_id: "call_view", output: "{\"ok\":true}" },
+      { role: "user", content: [{ type: "input_image", image_url: `data:image/png;base64,${imageData}` }] },
+      { role: "assistant", content: "done" },
+    ]);
+    // An unmaterialized durable reference still fails closed instead of being
+    // silently dropped with the function_call_output Item.
+    expect(() => toResponsesBody({
+      ...request(),
+      messages: [
+        { role: "assistant", content: "", toolCalls: [{ id: "call_view", name: "view_image", arguments: "{}" }] },
+        { role: "tool", toolCallId: "call_view", content: "{\"ok\":true}", images: [{ ...attachment, data: undefined }] },
+        { role: "assistant", content: "done" },
+      ],
+    }, context(), false, "openai-public")).toThrow("Image attachment was not materialized before provider serialization: img_flush.");
+  });
+
   test("omits service_tier from the codex-http-relay compatibility-tier request", () => {
     const body = toResponsesBody({
       ...request(),

--- a/tests/integration/session/compact.test.ts
+++ b/tests/integration/session/compact.test.ts
@@ -1,11 +1,13 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, rm, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   ERROR_PENDING_INTERACTION,
   compactConversation,
+  compactConversationFromPoint,
 } from "../../../src/core/compact/service";
+import { ingestImageBytes } from "../../../src/core/attachments/store";
 import {
   COMPACT_CHECKPOINT_KIND,
   createSessionStore,
@@ -14,6 +16,11 @@ import {
   parseCompactCheckpoint,
 } from "../../../src/core/session/store";
 import { closeResponsesWebSocketSession, responsesWebSocketSession } from "../../../src/providers/openai-responses/websocket";
+
+const png = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x00,
+]);
 
 const originalFetch = globalThis.fetch;
 const originalEnv = { ...process.env };
@@ -211,6 +218,157 @@ describe("conversation compact", () => {
     expect(retries).toHaveLength(1);
     expect(retries[0]!.attempt).toBe(1);
     expect(retries[0]!.status).toBe(429);
+  });
+
+  test("materializes evicted image attachments into the summary request without persisting base64 (#281)", async () => {
+    await writeFile(join(configDir!, "providers.yaml"), [
+      "default:", "  provider: test", "  model: test-model", "providers:",
+      "  test:", "    protocol: openai-chat-compatible", "    baseUrl: https://provider.test/v1",
+      "    apiKeyEnv: TEST_PROVIDER_API_KEY", "    models:", "      - id: test-model",
+      "        capabilities:", "          vision: true", "",
+    ].join("\n"), "utf8");
+    const rootDir = await createPromptRoot();
+    const store = await createSessionStore(rootDir, "compact-image");
+    const image = await ingestImageBytes(rootDir, png, { source: "clipboard" });
+    await store.append({ role: "system", content: "base\n\netl", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "first", metadata: { images: [image] } });
+    await store.append({ role: "assistant", content: "answer one" });
+    await store.append({ role: "user", content: "second" });
+    await store.append({ role: "assistant", content: "answer two" });
+
+    let requestBody: { messages?: Array<{ content?: unknown }> } = {};
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body));
+      return Response.json({
+        id: "compact",
+        choices: [{ message: { content: "<summary>Image session summary.</summary>" } }],
+      });
+    }) as typeof fetch;
+
+    const result = await compactConversation({ rootDir, sessionId: store.sessionId, engine: "etl" });
+
+    expect(result.summary).toBe("Image session summary.");
+    const expectedUrl = `data:image/png;base64,${Buffer.from(png).toString("base64")}`;
+    expect(imagePartFromMessages(requestBody.messages)).toMatchObject({ image_url: { url: expectedUrl } });
+    // The durable transcript keeps the content-addressed reference only.
+    const jsonl = await readFile(store.sessionPath, "utf8");
+    expect(jsonl).not.toContain(Buffer.from(png).toString("base64"));
+    expect(jsonl).toContain(image.id);
+  });
+
+  test("fails closed on a changed attachment and keeps the session head (#281)", async () => {
+    await writeFile(join(configDir!, "providers.yaml"), [
+      "default:", "  provider: test", "  model: test-model", "providers:",
+      "  test:", "    protocol: openai-chat-compatible", "    baseUrl: https://provider.test/v1",
+      "    apiKeyEnv: TEST_PROVIDER_API_KEY", "    models:", "      - id: test-model",
+      "        capabilities:", "          vision: true", "",
+    ].join("\n"), "utf8");
+    const rootDir = await createPromptRoot();
+    const store = await createSessionStore(rootDir, "compact-image-tampered");
+    const image = await ingestImageBytes(rootDir, png, { source: "clipboard" });
+    await store.append({ role: "system", content: "base\n\netl", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "first", metadata: { images: [image] } });
+    await store.append({ role: "assistant", content: "answer one" });
+    await store.append({ role: "user", content: "second" });
+    await store.append({ role: "assistant", content: "answer two" });
+    await writeFile(join(rootDir, image.path), "tampered bytes", "utf8");
+
+    globalThis.fetch = (async () => {
+      throw new Error("The summary request must not be sent after a materialization failure.");
+    }) as unknown as typeof fetch;
+
+    await expect(compactConversation({ rootDir, sessionId: store.sessionId, engine: "etl" }))
+      .rejects.toThrow(/changed on disk: img_/);
+    const records = await loadSessionRecords(rootDir, store.sessionId);
+    expect(records.at(-1)?.metadata?.kind).not.toBe(COMPACT_CHECKPOINT_KIND);
+    expect(records.at(-1)?.role).toBe("assistant");
+    expect(records.at(-1)?.content).toBe("answer two");
+  });
+
+  test("materializes image attachments for a from-point summary (#281)", async () => {
+    await writeFile(join(configDir!, "providers.yaml"), [
+      "default:", "  provider: test", "  model: test-model", "providers:",
+      "  test:", "    protocol: openai-chat-compatible", "    baseUrl: https://provider.test/v1",
+      "    apiKeyEnv: TEST_PROVIDER_API_KEY", "    models:", "      - id: test-model",
+      "        capabilities:", "          vision: true", "",
+    ].join("\n"), "utf8");
+    const rootDir = await createPromptRoot();
+    const store = await createSessionStore(rootDir, "compact-image-point");
+    const image = await ingestImageBytes(rootDir, png, { source: "clipboard" });
+    await store.append({ role: "system", content: "base\n\netl", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "first", metadata: { images: [image] } });
+    await store.append({ role: "assistant", content: "answer one" });
+    const point = await store.append({ role: "user", content: "second" });
+    await store.append({ role: "assistant", content: "answer two" });
+
+    let requestBody: { messages?: Array<{ content?: unknown }> } = {};
+    globalThis.fetch = (async (_input: unknown, init?: RequestInit) => {
+      requestBody = JSON.parse(String(init?.body));
+      return Response.json({
+        id: "compact",
+        choices: [{ message: { content: "<summary>Point summary.</summary>" } }],
+      });
+    }) as typeof fetch;
+
+    const result = await compactConversationFromPoint({
+      rootDir,
+      sessionId: store.sessionId,
+      point: { uuid: point.uuid, parentUuid: point.parentUuid, content: point.content },
+      engine: "etl",
+    });
+
+    expect(result.summary).toBe("Point summary.");
+    const expectedUrl = `data:image/png;base64,${Buffer.from(png).toString("base64")}`;
+    expect(imagePartFromMessages(requestBody.messages)).toMatchObject({ image_url: { url: expectedUrl } });
+  });
+
+  test("materializes history images for the remote Responses compact request (#281)", async () => {
+    await writeFile(join(configDir!, "providers.yaml"), [
+      "default:", "  provider: openai", "  model: gpt-5.6", "providers:",
+      "  openai:", "    protocol: openai-responses", "    baseUrl: https://api.openai.com/v1",
+      "    apiKeyEnv: TEST_PROVIDER_API_KEY", "    responsesProfile: openai-public", "    responsesTransport: http",
+      "    models:", "      - id: gpt-5.6", "        capabilities:", "          remoteCompact: true",
+      "          vision: true", "",
+    ].join("\n"), "utf8");
+    const rootDir = await createPromptRoot();
+    const store = await createSessionStore(rootDir, "compact-image-native");
+    const image = await ingestImageBytes(rootDir, png, { source: "clipboard" });
+    await store.append({ role: "system", content: "base\n\netl", metadata: { engine: "etl" } });
+    await store.append({ role: "user", content: "first", metadata: { images: [image] } });
+    await store.append({ role: "assistant", content: "answer one" });
+    await store.append({ role: "user", content: "second" });
+    await store.append({ role: "assistant", content: "answer two" });
+
+    let compactBody: { input?: unknown[] } = {};
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      if (new URL(String(input)).pathname.endsWith("/responses/compact")) {
+        compactBody = JSON.parse(String(init?.body));
+        return Response.json({
+          id: "compact-native",
+          object: "response.compaction",
+          output: [
+            { id: "msg_compact", type: "message", role: "user", content: [{ type: "input_text", text: "canonical context" }] },
+            { id: "cmp_1", type: "compaction", encrypted_content: "opaque-compact" },
+          ],
+        });
+      }
+      return Response.json({
+        id: "summary-response",
+        status: "completed",
+        output: [{ type: "message", role: "assistant", content: [{ type: "output_text", text: "<summary>Native with image.</summary>" }] }],
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await compactConversation({ rootDir, sessionId: store.sessionId, engine: "etl" });
+
+    expect(result.summary).toBe("Native with image.");
+    const expectedUrl = `data:image/png;base64,${Buffer.from(png).toString("base64")}`;
+    const imageItem = compactBody.input?.find((item) =>
+      item !== null && typeof item === "object" && Array.isArray((item as { content?: unknown }).content));
+    expect(imageItem).toMatchObject({ role: "user", content: [
+      { type: "input_text", text: "first" },
+      { type: "input_image", image_url: expectedUrl },
+    ] });
   });
 
   test("refuses to compact while an interactive request is pending", async () => {
@@ -529,6 +687,14 @@ describe("conversation compact", () => {
     expect(compacted.parentUuid).toBeDefined();
   });
 });
+
+function imagePartFromMessages(
+  messages: Array<{ content?: unknown }> | undefined,
+): Record<string, unknown> | undefined {
+  const imageUser = messages?.find((message) => Array.isArray(message.content));
+  const content = imageUser?.content as Array<Record<string, unknown>> | undefined;
+  return content?.find((part) => part.type === "image_url");
+}
 
 async function createPromptRoot(): Promise<string> {
   const rootDir = await mkdtemp(join(tmpdir(), "vesicle-compact-"));


### PR DESCRIPTION
Grade: Standard PR

Closes #281

## Summary

- **Compact materialize fix (the #281 P1).** Compaction summary requests bypass `completeProviderRound` and serialized durable image references directly, so `/compact` crashed with `Image attachment was not materialized before provider serialization` whenever the compactable history contained an image attachment. All three direct-send sites now run `prepareProviderMessages` (vision gate + read + SHA-256/MIME verification + request-only base64): the portable summary (manual `/compact`, opt-in automatic compaction, model-switch compaction), the `/rewind` from-point summary, and the optional remote Responses compact request. A missing/corrupted attachment fails closed with an explicit error and leaves the session head unchanged (existing transaction boundary); the JSONL transcript still stores reference-only attachments, never base64.
- **Adjacent defect found in the #281 adapter sweep, fixed in the same change.** `serializeResponsesInput` dropped `message.images` on `function_call_output` items, so accepted MCP tool-result images were silently lost from every OpenAI Responses request — contradicting `docs/dev/TOOLS.md` § tool-result images. Tool-batch images are now held and flushed as one synthesized user input item after the batch, mirroring the OpenAI-compatible chat serializer; a native checkpoint window reset drops pending images from the replaced segment; an unmaterialized reference still fails closed. This also restores the native projection for image-carrying sessions compacting on a remote-compact profile (previously degraded silently on the same unmaterialized throw).
- The other adapters were swept and are symmetric: anthropic inline `tool_result` image blocks, openai-chat synthesized-user flush, gemini separate ordinary user Content (#226 shape) — all guarded, all transports share the guarded builders.
- No schema, adapter-file-access, or persistence change: materialization stays host-side (`PROVIDERS.md` § "Core materializes durable image references before invoking an adapter" — this change brings the compact paths into compliance with the existing contract).

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — 2322 pass · 10 skip · 0 fail
- [x] `bun run doctor` — `Missing: none`
- [x] Targeted tests for the change class (see Verification Matrix): `tests/integration/session/compact.test.ts` gains four regressions — evicted-image summary materializes base64 with no base64 in the JSONL; tampered attachment fails closed with head unchanged; from-point summary materializes; remote Responses compact receives materialized `input_image`. `tests/integration/providers/openai-responses-provider.test.ts` pins the tool-batch image flush shape plus the fail-closed unmaterialized guard.

## Notes

- Vision-off semantics stay uniform with ordinary rounds: a session whose history carries images compacted under a non-vision model fails with the standard vision error, exactly as its next normal round would. No new stripping rule was introduced.
- CHANGELOG carries two Fixed entries (compact materialization; Responses tool-image flush). No `docs/dev` or `docs/user` page changed, so `skills:docs:sync` was not triggered (pre-commit confirms references in sync).
