### PR TITLE
test: worker-barrier harness dedup + path-index test relocation (#265 items 5+6)

### DIFF
--- a/tests/support/worker-barrier.ts
+++ b/tests/support/worker-barrier.ts
@@ -1,0 +1,85 @@
+import { lstat, mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+/**
+ * Cross-process readiness barrier for burst-contention tests: each worker
+ * signals readiness with a per-index file, blocks until the shared "go" file
+ * appears, then runs its payload. The barrier owns the ready directory, the
+ * worker-script prelude, and the release/collect/shutdown contract; the test
+ * owns the worker count, payload, and domain assertions. Shutdown only kills
+ * workers that are still running and never masks the test's own failure.
+ */
+export type BarrierWorker = {
+  readonly exited: Promise<number>;
+  readonly exitCode: number | null;
+  readonly stderr: ReadableStream;
+  kill(signal?: string | number): void;
+};
+
+export type WorkerBarrier = {
+  readonly barrierPath: string;
+  workerEnv(index: number): Record<string, string>;
+  workerScript(options: { imports?: string[]; payload: string[] }): string;
+  releaseWhenReady(workerCount: number): Promise<void>;
+  collect(workers: readonly BarrierWorker[]): Promise<{ exitCode: number; stderr: string }[]>;
+  shutdown(workers: readonly BarrierWorker[]): Promise<void>;
+};
+
+export async function startWorkerBarrier(dir: string): Promise<WorkerBarrier> {
+  const readyRoot = join(dir, "workers-ready");
+  const barrierPath = join(dir, "workers-go");
+  await mkdir(readyRoot, { recursive: true });
+
+  const readyPath = (index: number) => join(readyRoot, `${index}.ready`);
+
+  return {
+    barrierPath,
+    workerEnv(index) {
+      return { BARRIER_PATH: barrierPath, READY_PATH: readyPath(index) };
+    },
+    workerScript({ imports = [], payload }) {
+      return [
+        'import { lstat, writeFile } from "node:fs/promises";',
+        ...imports,
+        'await writeFile(process.env.READY_PATH!, "ready");',
+        "while (true) {",
+        "  try { await lstat(process.env.BARRIER_PATH!); break; } catch (error) {",
+        // A missing barrier file is the normal pre-release state; any other
+        // lstat error is a real filesystem problem and must fail the worker.
+        '    if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) throw error;',
+        "    await Bun.sleep(5);",
+        "  }",
+        "}",
+        ...payload,
+      ].join("\n");
+    },
+    async releaseWhenReady(workerCount) {
+      let readyCount = 0;
+      for (let attempt = 0; attempt < 1_000; attempt++) {
+        const ready = await Promise.all(
+          Array.from({ length: workerCount }, (_, index) => readyPath(index))
+            .map((path) => lstat(path).then(() => true, () => false)),
+        );
+        readyCount = ready.filter(Boolean).length;
+        if (readyCount === workerCount) break;
+        await Bun.sleep(10);
+      }
+      if (readyCount !== workerCount) {
+        throw new Error(`worker barrier: ${readyCount}/${workerCount} workers ready`);
+      }
+      await writeFile(barrierPath, "go");
+    },
+    async collect(workers) {
+      return Promise.all(workers.map(async (worker) => ({
+        exitCode: await worker.exited,
+        stderr: await new Response(worker.stderr).text(),
+      })));
+    },
+    async shutdown(workers) {
+      for (const worker of workers) {
+        if (worker.exitCode === null) worker.kill("SIGKILL");
+      }
+      await Promise.all(workers.map((worker) => worker.exited.catch(() => undefined)));
+    },
+  };
+}

--- a/tests/unit/core/project/path-index.test.ts
+++ b/tests/unit/core/project/path-index.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildProjectPathIndex } from "../../../../src/core/project/path-index";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "vesicle-path-index-"));
+  await mkdir(join(root, "workspace/cards"), { recursive: true });
+  await mkdir(join(root, "novels"), { recursive: true });
+  await mkdir(join(root, "node_modules/pkg"), { recursive: true });
+  await writeFile(join(root, "workspace/cards/mira.md"), "# Mira\n\nA card.\n");
+  await writeFile(join(root, "workspace/notes.txt"), "line one\nline two\n");
+  await writeFile(join(root, "novels/draft.md"), "draft\n");
+  await writeFile(join(root, "logo.png"), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+  await writeFile(join(root, "data.bin"), Buffer.from([0x00, 0x01, 0x02]));
+  await writeFile(join(root, "fake.txt"), Buffer.from([0x41, 0x00, 0x42])); // NUL inside
+  await writeFile(join(root, ".hidden.md"), "secret\n");
+  await writeFile(join(root, "node_modules/pkg/index.js"), "module.exports = 1;\n");
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("project path index", () => {
+  test("indexes visible files and directories without following symlinks", async () => {
+    await symlink(join(root, "novels"), join(root, "linked-novels"));
+    await writeFile(join(root, "foo\\..\\bar.md"), "unsafe-name\n");
+    const index = await buildProjectPathIndex(root, { showHidden: false });
+    expect(index).toContainEqual({ path: "workspace", kind: "dir" });
+    expect(index).toContainEqual({ path: "workspace/cards/mira.md", kind: "file" });
+    expect(index.some((entry) => entry.path.startsWith("linked-novels"))).toBe(false);
+    expect(index.some((entry) => entry.path.startsWith(".hidden"))).toBe(false);
+    expect(index.some((entry) => entry.path.includes(".."))).toBe(false);
+  });
+});

--- a/tests/unit/skills/disabled.test.ts
+++ b/tests/unit/skills/disabled.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { disabledPathForScope, readDisabledNames, setDisabled, userDisabledPath } from "../../../src/skills";
+import { startWorkerBarrier } from "../../support/worker-barrier";
 
 async function withTemp<T>(work: (dir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), "vesicle-skill-disabled-"));
@@ -62,55 +63,30 @@ describe("skill disabled state", () => {
     await withTemp(async (dir) => {
       const path = join(dir, "missing", ".disabled");
       const disabledModule = join(import.meta.dir, "../../../src/skills/disabled.ts");
-      const readyRoot = join(dir, "workers-ready");
-      const barrier = join(dir, "workers-go");
-      await mkdir(readyRoot, { recursive: true });
-      const workerScript = [
-        'import { lstat, writeFile } from "node:fs/promises";',
-        `import { setDisabled } from ${JSON.stringify(disabledModule)};`,
-        'await writeFile(process.env.READY_PATH!, "ready");',
-        "while (true) {",
-        "  try { await lstat(process.env.BARRIER_PATH!); break; } catch (error) {",
-        '    if (!(error && typeof error === "object" && "code" in error && error.code === "ENOENT")) throw error;',
-        "    await Bun.sleep(5);",
-        "  }",
-        "}",
-        "await setDisabled(process.env.DISABLED_PATH!, process.env.SKILL_NAME!, true);",
-      ].join("\n");
+      const barrier = await startWorkerBarrier(dir);
+      const workerScript = barrier.workerScript({
+        imports: [`import { setDisabled } from ${JSON.stringify(disabledModule)};`],
+        payload: ["await setDisabled(process.env.DISABLED_PATH!, process.env.SKILL_NAME!, true);"],
+      });
       const expected = Array.from({ length: 16 }, (_, index) => `skill-${index}`);
       const workers = expected.map((name, index) => Bun.spawn({
         cmd: [process.execPath, "-e", workerScript],
         env: {
           ...process.env,
-          BARRIER_PATH: barrier,
+          ...barrier.workerEnv(index),
           DISABLED_PATH: path,
-          READY_PATH: join(readyRoot, `${index}.ready`),
           SKILL_NAME: name,
         },
         stdout: "pipe",
         stderr: "pipe",
       }));
       try {
-        let readyCount = 0;
-        for (let attempt = 0; attempt < 1_000; attempt++) {
-          const ready = await Promise.all(expected.map((_, index) => lstat(join(readyRoot, `${index}.ready`)).then(() => true, () => false)));
-          readyCount = ready.filter(Boolean).length;
-          if (readyCount === expected.length) break;
-          await Bun.sleep(10);
-        }
-        expect(readyCount).toBe(expected.length);
-        await writeFile(barrier, "go");
-        const results = await Promise.all(workers.map(async (worker) => ({
-          exitCode: await worker.exited,
-          stderr: await new Response(worker.stderr).text(),
-        })));
+        await barrier.releaseWhenReady(expected.length);
+        const results = await barrier.collect(workers);
         expect(results).toEqual(expected.map(() => ({ exitCode: 0, stderr: "" })));
         expect(await readDisabledNames(path)).toEqual(new Set(expected));
       } finally {
-        for (const worker of workers) {
-          if (worker.exitCode === null) worker.kill("SIGKILL");
-        }
-        await Promise.all(workers.map((worker) => worker.exited.catch(() => undefined)));
+        await barrier.shutdown(workers);
       }
     });
   }, 15_000);

--- a/tests/unit/skills/store.test.ts
+++ b/tests/unit/skills/store.test.ts
@@ -15,6 +15,7 @@ import {
   uninstallSkill,
 } from "../../../src/skills";
 import { SkillStoreError } from "../../../src/skills/store";
+import { startWorkerBarrier } from "../../support/worker-barrier";
 
 const symlinkSupported = await (async (): Promise<boolean> => {
   const dir = await mkdtemp(join(tmpdir(), "vesicle-store-symlink-probe-"));
@@ -179,24 +180,18 @@ mutated body
   test("cross-process installs preserve every index entry under burst contention", async () => {
     await withEnv(async (env, scratch) => {
       const storeModule = join(import.meta.dir, "../../../src/skills/store.ts");
-      const readyRoot = join(scratch, "workers-ready");
-      const barrier = join(scratch, "workers-go");
-      await mkdir(readyRoot, { recursive: true });
+      const barrier = await startWorkerBarrier(scratch);
       const expected = Array.from({ length: 12 }, (_, index) => `process-${index}`);
       const sources = await Promise.all(expected.map((name, index) => makeSource(join(scratch, `source-${index}`), name, `body-${index}`)));
-      const workerScript = [
-        'import { lstat, writeFile } from "node:fs/promises";',
-        `import { installSnapshot } from ${JSON.stringify(storeModule)};`,
-        'await writeFile(process.env.READY_PATH!, "ready");',
-        "while (!(await lstat(process.env.BARRIER_PATH!).catch(() => undefined))) await Bun.sleep(5);",
-        "await installSnapshot({ sourceDirectory: process.env.SOURCE_PATH!, env: { ...process.env, VESICLE_CONFIG_DIR: process.env.STORE_CONFIG_DIR! } });",
-      ].join("\n");
+      const workerScript = barrier.workerScript({
+        imports: [`import { installSnapshot } from ${JSON.stringify(storeModule)};`],
+        payload: ["await installSnapshot({ sourceDirectory: process.env.SOURCE_PATH!, env: { ...process.env, VESICLE_CONFIG_DIR: process.env.STORE_CONFIG_DIR! } });"],
+      });
       const workers = sources.map((source, index) => Bun.spawn({
         cmd: [process.execPath, "-e", workerScript],
         env: {
           ...process.env,
-          BARRIER_PATH: barrier,
-          READY_PATH: join(readyRoot, `${index}.ready`),
+          ...barrier.workerEnv(index),
           SOURCE_PATH: source,
           STORE_CONFIG_DIR: env.VESICLE_CONFIG_DIR!,
         },
@@ -204,24 +199,12 @@ mutated body
         stderr: "pipe",
       }));
       try {
-        let readyCount = 0;
-        for (let attempt = 0; attempt < 1_000; attempt++) {
-          const ready = await Promise.all(expected.map((_, index) => lstat(join(readyRoot, `${index}.ready`)).then(() => true, () => false)));
-          readyCount = ready.filter(Boolean).length;
-          if (readyCount === expected.length) break;
-          await Bun.sleep(10);
-        }
-        expect(readyCount).toBe(expected.length);
-        await writeFile(barrier, "go");
-        const results = await Promise.all(workers.map(async (worker) => ({
-          exitCode: await worker.exited,
-          stderr: await new Response(worker.stderr).text(),
-        })));
+        await barrier.releaseWhenReady(expected.length);
+        const results = await barrier.collect(workers);
         expect(results).toEqual(expected.map(() => ({ exitCode: 0, stderr: "" })));
         expect((await readActiveIndex(env)).entries.map((entry) => entry.name).sort()).toEqual([...expected].sort());
       } finally {
-        for (const worker of workers) worker.kill("SIGKILL");
-        await Promise.all(workers.map((worker) => worker.exited));
+        await barrier.shutdown(workers);
       }
     });
   }, 20_000);

--- a/tests/unit/tui/workspace/tree-data.test.ts
+++ b/tests/unit/tui/workspace/tree-data.test.ts
@@ -10,7 +10,6 @@ import {
   readFilePreview,
   scanDirectory,
 } from "../../../../src/tui/workspace/tree-data";
-import { buildProjectPathIndex } from "../../../../src/core/project/path-index";
 
 let root: string;
 
@@ -78,17 +77,6 @@ describe("workspace tree flattening", () => {
 });
 
 describe("workspace file index and matching", () => {
-  test("indexes visible files and directories without following symlinks", async () => {
-    await symlink(join(root, "novels"), join(root, "linked-novels"));
-    await writeFile(join(root, "foo\\..\\bar.md"), "unsafe-name\n");
-    const index = await buildProjectPathIndex(root, { showHidden: false });
-    expect(index).toContainEqual({ path: "workspace", kind: "dir" });
-    expect(index).toContainEqual({ path: "workspace/cards/mira.md", kind: "file" });
-    expect(index.some((entry) => entry.path.startsWith("linked-novels"))).toBe(false);
-    expect(index.some((entry) => entry.path.startsWith(".hidden"))).toBe(false);
-    expect(index.some((entry) => entry.path.includes(".."))).toBe(false);
-  });
-
   test("indexes visible files recursively, skipping hidden subtrees", async () => {
     const index = await buildFileIndex(root, { showHidden: false });
     expect(index).toContain("workspace/cards/mira.md");


### PR DESCRIPTION
Grade: Quick PR

Refs #265

## Summary

- **Item 6**: the single core/project-domain case in `tests/unit/tui/workspace/tree-data.test.ts` (`buildProjectPathIndex`, symlink/unsafe-name assertions) moves to the new `tests/unit/core/project/path-index.test.ts` with a verbatim copy of the fixture; the TUI file keeps its remaining `buildFileIndex`/`matchFiles` cases, and the `symlink` import stays (still used by the quick-open test). No `symlinkCapable` guard added — the move preserves the test's existing platform semantics exactly.
- **Item 5**: the near-verbatim cross-process ready/barrier harness duplicated in `tests/unit/skills/disabled.test.ts` and `store.test.ts` is extracted into `tests/support/worker-barrier.ts` (`startWorkerBarrier(dir)`: ready-file prelude, `releaseWhenReady`, `collect`, `shutdown`). The three accidental drifts normalize to the stricter `disabled.test.ts` semantics: the worker-side barrier wait rethrows non-ENOENT `lstat` errors, shutdown kills only still-running workers (`exitCode === null`), and cleanup swallows `exited` rejections so it cannot mask the test's own failure.
- Harness readiness exhaustion now throws a harness error (`worker barrier: N/M workers ready`) instead of an `expect` equality failure, making harness vs domain failures distinguishable.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test` — 2346 pass / 0 fail / 10 skip
- [x] `bun run doctor` — Missing: none
- [x] Targeted: `bun test tests/unit/core/project tests/unit/tui/workspace tests/unit/skills` — 401 pass / 0 fail

## Notes / Follow-ups

- Out of scope per the memo: `store.test.ts`'s lock-holder-death test (different pattern; its environmental-death comments are intentional), `tests/unit/skills-runtime/host-activation.test.ts` (existsSync/stdout-based pattern), and item 1 (release-notes scripting, tracked with #268 item 10).
- No new tests: mechanical move/dedup validated by the existing suites passing unchanged.