### PR TITLE
fix(smoke): merge the installer icon assertions into one CanonicalIcon guard (#265 item 2)

### DIFF
--- a/scripts/smoke/smoke-windows-installer.ps1
+++ b/scripts/smoke/smoke-windows-installer.ps1
@@ -72,8 +72,8 @@ try {
     foreach ($required in @($Executable, $IconFile, (Join-Path $InstallDir "harness-manifest.json"), (Join-Path $InstallDir "assets"), (Join-Path $InstallDir "host-assets"), (Join-Path $InstallDir "host-assets\skills\vesicle-docs\SKILL.md"), (Join-Path $InstallDir "host-assets\skills\vesicle-docs\references\index.md"), (Join-Path $InstallDir "unins000.exe"))) {
         if (-not (Test-Path -LiteralPath $required)) { throw "Installed payload is missing: $required" }
     }
-    if ((Get-FileHash -LiteralPath $IconFile -Algorithm SHA256).Hash -ne (Get-FileHash -LiteralPath (Resolve-Path $CanonicalIcon).Path -Algorithm SHA256).Hash) { throw "Installed icon does not match the canonical ICO." }
     if ($CanonicalIcon -ne "") {
+        if ((Get-FileHash -LiteralPath $IconFile -Algorithm SHA256).Hash -ne (Get-FileHash -LiteralPath (Resolve-Path $CanonicalIcon).Path -Algorithm SHA256).Hash) { throw "Installed icon does not match the canonical ICO." }
         $Verifier = Join-Path $PSScriptRoot "..\check\check-windows-brand.ps1"
         & $Verifier -CanonicalIcon (Resolve-Path $CanonicalIcon).Path -Executable $Executable -Uninstaller (Join-Path $InstallDir "unins000.exe")
     }


### PR DESCRIPTION
Grade: Quick PR

Refs #265

## Summary

- `scripts/smoke/smoke-windows-installer.ps1`: the installed-icon SHA-256 comparison sat outside the `if ($CanonicalIcon -ne "")` guard while the brand-verifier call sat inside it. With the default empty `$CanonicalIcon`, `Resolve-Path ""` throws before the guard is reached — a latent crash on any invocation that omits the parameter. The hash comparison now lives inside the guard, ahead of the verifier call (same order as before: hash first, then verifier).
- The only behavior change is the empty-`CanonicalIcon` path (skip both brand assertions instead of crashing). The CI path is byte-identical: `release-build.yml` always passes `-CanonicalIcon "brand/windows/prism-vesicle.ico"`.

## Test Plan

- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run doctor`
- [ ] Targeted tests / smoke: **unavailable locally** — this WSL environment has no `pwsh`, and the script drives a Windows Inno installer. Execution evidence comes from the next `release-build` workflow run (the smoke runs in its windows job).

## Notes / Follow-ups

- Timing note from the memo: editing a Windows build script invalidates prior manual Windows acceptance evidence. This lands right after the 1.0.0 release, the farthest point from the next release; the next `release-build` run regenerates the evidence.
- Informational (not acted on): `release-build.yml` already invokes `check-windows-brand.ps1` separately just before the smoke, so the smoke's verifier call is partially redundant in CI.