### PR TITLE
fix(release): stage artifacts after checkout in the GitHub-release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,26 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Ordering invariant: checkout cleans the workspace, so it must run
+      # before any artifact staging under release/. At the v1.1.0 tag this
+      # order was inverted and checkout wiped the staged artifacts, so the
+      # published release carried no files (the body was fine).
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.metadata.outputs.sha }}
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      # The release body is composed from the paired bilingual CHANGELOG by
+      # scripts/release/compose-notes.ts. GitHub's generate_release_notes
+      # autogen is deliberately absent: its compare-base fallback dumped the
+      # full history into the first non-prerelease body (issue #268 item 10).
+      - name: Compose bilingual release notes from the paired CHANGELOG
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: bun scripts/release/compose-notes.ts --version "$VERSION" --out release-notes.md
       - uses: actions/download-artifact@v8
         with:
           digest-mismatch: error
@@ -74,22 +94,6 @@ jobs:
       - name: Write checksums
         working-directory: release
         run: sha256sum * > SHA256SUMS.txt
-      # The release body is composed from the paired bilingual CHANGELOG by
-      # scripts/release/compose-notes.ts. GitHub's generate_release_notes
-      # autogen is deliberately absent: its compare-base fallback dumped the
-      # full history into the first non-prerelease body (issue #268 item 10).
-      - uses: actions/checkout@v7
-        with:
-          ref: ${{ needs.metadata.outputs.sha }}
-          fetch-depth: 0
-          fetch-tags: true
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-      - name: Compose bilingual release notes from the paired CHANGELOG
-        env:
-          VERSION: ${{ needs.metadata.outputs.version }}
-        run: bun scripts/release/compose-notes.ts --version "$VERSION" --out release-notes.md
       - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
Grade: Quick

## Summary

`actions/checkout` cleans the workspace by default. When #306 added the checkout step to the GitHub-release job (compose-notes needs the paired CHANGELOG), it was placed **after** the `publish-*` artifact staging and the checksum write — so the v1.1.0 tag run wiped `release/` before `action-gh-release` read it, and the published release carried **no assets** (`Pattern 'release/*' does not match any files`). The composed bilingual body was unaffected, and the npm package publishes from its own job and was unaffected.

Fix: move checkout + setup-bun + compose-notes before artifact staging, and pin the ordering invariant in a comment.

Post-incident state: the v1.1.0 release assets (4 files + SHA256SUMS.txt) were reattached manually from the tag run's digest-verified `publish-*` artifacts; tag and npm were never touched.

## Verification

- Workflow-only change, one job, step reorder; no product code.
- Read-back of the v1.1.0 tag run log: staging → checksums → checkout (wipe) → `release/*` no-match, confirming the mechanism.
- Next release exercises this path end-to-end; no local runner exists for the publish job.
- No new tests per the test-value discipline (CI workflow step order is not unit-testable here).