### PR TITLE
fix(release): map the compare API's nested commit payload in the close-issues bridge

### DIFF
--- a/scripts/release/close-bridged-issues.ts
+++ b/scripts/release/close-bridged-issues.ts
@@ -32,6 +32,14 @@ const SQUASH_SUBJECT_RE = /\(#(\d+)\)\s*$/;
 
 export type CommitLike = { message: string };
 
+/** The compare endpoint nests the message: entries are `{ sha, commit: { message, ... } }`. */
+export type CompareCommitLike = { commit?: { message?: string } };
+
+/** Map compare-API entries to flat commit messages; missing payloads become empty strings. */
+export function mapCompareCommitMessages(entries: CompareCommitLike[]): CommitLike[] {
+  return entries.map((entry) => ({ message: entry.commit?.message ?? "" }));
+}
+
 /** Constituent PR numbers recoverable from a commit list (native-merge and squash forms). */
 export function extractPrNumbersFromCommits(commits: CommitLike[]): number[] {
   const numbers = new Set<number>();
@@ -138,11 +146,11 @@ async function main(): Promise<number> {
   const commits: CommitLike[] = [];
   let total = 0;
   for (let page = 1; page <= 10; page += 1) {
-    const comparison = await api<{ commits?: CommitLike[]; total_commits?: number }>(
+    const comparison = await api<{ commits?: CompareCommitLike[]; total_commits?: number }>(
       `compare/${base}...${head}?per_page=250&page=${page}`,
     );
     total = comparison.total_commits ?? 0;
-    const batch = comparison.commits ?? [];
+    const batch = mapCompareCommitMessages(comparison.commits ?? []);
     commits.push(...batch);
     if (commits.length >= total || batch.length === 0) break;
   }

--- a/tests/unit/scripts/close-bridged-issues.test.ts
+++ b/tests/unit/scripts/close-bridged-issues.test.ts
@@ -3,6 +3,7 @@ import {
   collectIssueOrigins,
   extractClosingIssueNumbers,
   extractPrNumbersFromCommits,
+  mapCompareCommitMessages,
 } from "../../../scripts/release/close-bridged-issues";
 
 describe("constituent PR extraction", () => {
@@ -39,6 +40,17 @@ describe("constituent PR extraction", () => {
         { message: "docs(readme): mark the project status badge stable for 1.0.0 (#267)" },
       ]),
     ).toEqual([267]);
+  });
+
+  test("maps the compare endpoint's nested commit payload before extraction", () => {
+    // Wire-shape regression: the compare API nests messages under `.commit`,
+    // and feeding raw entries to extraction crashed the v1.1.0 bridge run.
+    const compareEntries = [
+      { sha: "abc", commit: { message: "fix(tui): wire the strict double-tilde flavor (#305)" } },
+      { sha: "def", commit: { message: "Merge pull request #307 from 3aKHP/fix/issue-298" } },
+      { sha: "ghi" },
+    ];
+    expect(extractPrNumbersFromCommits(mapCompareCommitMessages(compareEntries))).toEqual([305, 307]);
   });
 });
 


### PR DESCRIPTION
Grade: Quick

## Summary

The close-issues bridge (added in #272) has never succeeded: both its runs (2026-08-31 and the v1.1.0 release merge) crashed on `TypeError: undefined is not an object (evaluating 'commit.message.matchAll')` before closing anything.

Root cause: the compare endpoint returns commits as `{ sha, commit: { message, ... } }`, but the bridge typed entries as flat `{ message }` and read `commit.message` directly. Every entry yielded `undefined`, so the first `matchAll` threw. The extraction helpers were unit-tested; the wire shape never was — a classic integration gap.

Fix: map compare entries through `mapCompareCommitMessages` at the boundary (missing payloads → empty string), plus a wire-shape regression test feeding compare-shaped entries through the mapper into extraction.

## Out-of-band closure for v1.1.0

The bridge's intended v1.1.0 closure set (computed from constituent PR bodies): #265, #273, #278, #281, #290, #291, #294, #295, #298, #299, #302, #308, #309, #312 (#284 closed natively at merge). These will be closed manually with the bridge's comment format; this fix serves the next release.

## Verification

- `bun test tests/unit/scripts/close-bridged-issues.test.ts` — 11 pass (10 existing + 1 new regression)
- `bun run lint`, `bun run typecheck` — clean
- The fixed mapping reproduces the intended closure set when run locally against the v1.1.0 range (`ed2326e...6269042`, 56 commits, 26 constituent PRs)