### PR TITLE
fix(windows): isolate shell_exec child consoles

### DIFF
--- a/src/core/process/runtime.ts
+++ b/src/core/process/runtime.ts
@@ -185,7 +185,7 @@ function startProcessSpawn(
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
-    ...(platform === "win32" ? {} : { detached: true }),
+    ...(platform === "win32" ? { windowsHide: true } : { detached: true }),
   });
 
   const stdoutState = createCaptureState();
@@ -329,6 +329,7 @@ async function terminateProcessTree(pid: number, platform: NodeJS.Platform): Pro
       stdout: "ignore",
       stderr: "ignore",
       env: buildProcessEnvironment(),
+      windowsHide: true,
     });
     await taskkill.exited.catch(() => undefined);
     return;

--- a/src/core/process/runtime.ts
+++ b/src/core/process/runtime.ts
@@ -179,13 +179,14 @@ function startProcessSpawn(
   const started = performance.now();
   const baseEnv = buildProcessEnvironment(options.env);
   const env = options.additionalEnv ? { ...baseEnv, ...options.additionalEnv } : baseEnv;
+  const isWindowsCmd = platform === "win32" && command[0]?.toLowerCase().endsWith("\\cmd.exe");
   const child = Bun.spawn(command, {
     cwd: rootDir,
     env,
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
-    ...(platform === "win32" ? { windowsHide: true } : { detached: true }),
+    ...(platform === "win32" ? (isWindowsCmd ? {} : { windowsHide: true }) : { detached: true }),
   });
 
   const stdoutState = createCaptureState();

--- a/src/core/process/runtime.ts
+++ b/src/core/process/runtime.ts
@@ -179,14 +179,15 @@ function startProcessSpawn(
   const started = performance.now();
   const baseEnv = buildProcessEnvironment(options.env);
   const env = options.additionalEnv ? { ...baseEnv, ...options.additionalEnv } : baseEnv;
-  const isWindowsCmd = platform === "win32" && command[0]?.toLowerCase().endsWith("\\cmd.exe");
+  const commandName = command[0]?.toLowerCase();
+  const isCmdShell = platform === "win32" && (commandName === "cmd.exe" || commandName?.endsWith("\\cmd.exe"));
   const child = Bun.spawn(command, {
     cwd: rootDir,
     env,
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
-    ...(platform === "win32" ? (isWindowsCmd ? {} : { windowsHide: true }) : { detached: true }),
+    ...(platform === "win32" ? (isCmdShell ? {} : { windowsHide: true }) : { detached: true }),
   });
 
   const stdoutState = createCaptureState();


### PR DESCRIPTION
On Windows, shell_exec and taskkill cleanup could inherit the Vesicle console and pollute the Windows Terminal tab title. Adds windowsHide to both Windows spawn paths. Verified with Windows Bun process integration tests and manual Windows Terminal comparison against installed 1.1.1. Closes #324.